### PR TITLE
fix: search view 아이템이 겹치게 검색되는 오류 수정

### DIFF
--- a/app/src/main/java/com/teamwss/websoso/ui/postNovel/PostNovelActivity.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/postNovel/PostNovelActivity.kt
@@ -124,16 +124,20 @@ class PostNovelActivity : AppCompatActivity() {
     }
 
     private fun navigateToNovelDetailFromSuccessDialog() {
-        val newUserNovelId = postNovelViewModel.newUserNovelId.value ?: 0
-        val intent = NovelDetailActivity.createIntent(this, newUserNovelId)
         navigateToHome()
-        startActivity(intent)
+        navigateToNovelDetail()
         finishAffinity()
     }
 
     private fun navigateToHomeFromSuccessDialog() {
         navigateToHome()
         finishAffinity()
+    }
+
+    private fun navigateToNovelDetail(){
+        val newUserNovelId = postNovelViewModel.newUserNovelId.value ?: 0
+        val intent = NovelDetailActivity.createIntent(this, newUserNovelId)
+        startActivity(intent)
     }
 
     private fun navigateToHome() {

--- a/app/src/main/java/com/teamwss/websoso/ui/postNovel/PostNovelViewModel.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/postNovel/PostNovelViewModel.kt
@@ -104,6 +104,7 @@ class PostNovelViewModel : ViewModel() {
             kotlin.runCatching {
                 ServicePool.userNovelService.patchPostNovelInfo(novelId, request)
             }.onSuccess {
+                _newUserNovelId.value = _novelInfo.value?.id
                 _isSaveError.value = false
             }.onFailure {
                 _isSaveError.value = true

--- a/app/src/main/java/com/teamwss/websoso/ui/search/SearchActivity.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/search/SearchActivity.kt
@@ -20,7 +20,7 @@ import com.teamwss.websoso.databinding.ActivitySearchBinding
 import com.teamwss.websoso.ui.postNovel.PostNovelActivity
 import com.teamwss.websoso.ui.search.searchViewModel.SearchViewModel
 import com.teamwss.websoso.ui.search.searchViewModel.SearchViewModel.Companion.EXTRA_PAGE_SIZE
-import com.teamwss.websoso.ui.search.searchViewModel.SearchViewModel.Companion.LAST_NOVEL_ID
+import com.teamwss.websoso.ui.search.searchViewModel.SearchViewModel.Companion.DEFAULT_LAST_NOVEL_ID
 import com.teamwss.websoso.ui.search.searchViewModel.SearchViewModel.Companion.PAGE_SIZE
 import com.teamwss.websoso.ui.search.searchViewModel.SearchViewModel.Companion.SEARCH_DELAY
 import kotlinx.coroutines.Job
@@ -103,7 +103,7 @@ class SearchActivity : AppCompatActivity() {
             viewModel.removeSearchResult()
             binding.clSearchResultNoExist.visibility = View.GONE
         }
-        viewModel.searchNovels(LAST_NOVEL_ID, PAGE_SIZE, text.toString())
+        viewModel.searchNovels(DEFAULT_LAST_NOVEL_ID, PAGE_SIZE, text.toString())
     }
 
     private fun setupTextRemover() {
@@ -145,11 +145,14 @@ class SearchActivity : AppCompatActivity() {
 
                 val lastVisibleItemPosition =
                     (recyclerView.layoutManager as LinearLayoutManager).findLastCompletelyVisibleItemPosition()
-                val itemTotalCount = recyclerView.adapter!!.itemCount - EXTRA_PAGE_SIZE
+                val itemTotalCount = searchAdapter.itemCount - EXTRA_PAGE_SIZE
 
                 if (lastVisibleItemPosition == itemTotalCount && viewModel.isLoading.value != true) {
+                    val lastItemNovelId =
+                        searchAdapter.getNovelIdAtPosition(lastVisibleItemPosition)
+
                     viewModel.searchNovels(
-                        LAST_NOVEL_ID, PAGE_SIZE, viewModel.searchWord.value.toString()
+                        lastItemNovelId, PAGE_SIZE, viewModel.searchWord.value.toString()
                     )
                 }
             }

--- a/app/src/main/java/com/teamwss/websoso/ui/search/SearchActivity.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/search/SearchActivity.kt
@@ -148,8 +148,7 @@ class SearchActivity : AppCompatActivity() {
                 val itemTotalCount = searchAdapter.itemCount - EXTRA_PAGE_SIZE
 
                 if (lastVisibleItemPosition == itemTotalCount && viewModel.isLoading.value != true) {
-                    val lastItemNovelId =
-                        searchAdapter.getNovelIdAtPosition(lastVisibleItemPosition)
+                    val lastItemNovelId = searchAdapter.getNovelIdAtPosition(searchAdapter.itemCount - 1)
 
                     viewModel.searchNovels(
                         lastItemNovelId, PAGE_SIZE, viewModel.searchWord.value.toString()

--- a/app/src/main/java/com/teamwss/websoso/ui/search/SearchActivity.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/search/SearchActivity.kt
@@ -145,9 +145,9 @@ class SearchActivity : AppCompatActivity() {
 
                 val lastVisibleItemPosition =
                     (recyclerView.layoutManager as LinearLayoutManager).findLastCompletelyVisibleItemPosition()
-                val itemTotalCount = searchAdapter.itemCount - EXTRA_PAGE_SIZE
+                val searchCountPoint = searchAdapter.itemCount - EXTRA_PAGE_SIZE
 
-                if (lastVisibleItemPosition == itemTotalCount && viewModel.isLoading.value != true) {
+                if (lastVisibleItemPosition == searchCountPoint && viewModel.isLoading.value != true) {
                     val lastItemNovelId = searchAdapter.getNovelIdAtPosition(searchAdapter.itemCount - 1)
 
                     viewModel.searchNovels(

--- a/app/src/main/java/com/teamwss/websoso/ui/search/SearchAdapter.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/search/SearchAdapter.kt
@@ -22,4 +22,8 @@ class SearchAdapter(private val onItemClick: (Long) -> Unit) :
         this.novelItems = novelList.toList()
         notifyDataSetChanged()
     }
+
+    fun getNovelIdAtPosition(position: Int): Long {
+        return novelItems[position].novelId
+    }
 }

--- a/app/src/main/java/com/teamwss/websoso/ui/search/searchViewModel/SearchViewModel.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/search/searchViewModel/SearchViewModel.kt
@@ -43,7 +43,7 @@ class SearchViewModel : ViewModel() {
     }
 
     companion object {
-        const val LAST_NOVEL_ID = 99999999L
+        const val DEFAULT_LAST_NOVEL_ID = 99999999L
         const val PAGE_SIZE = 40
         const val EXTRA_PAGE_SIZE = 20
         const val SEARCH_DELAY = 1000L


### PR DESCRIPTION
## 📌𝘐𝘴𝘴𝘶𝘦𝘴
- closed #70

## 📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯
- 서버에서 정해준 API의 이해를 통해 검색 방식을 수정하였습니다.
- lastNovelId, size, word를 받게 되어있는데 1회차 검색은 lastNovelId를 무조건 큰 숫자로 적고, 이후 검색은 리사이클러뷰의 마지막 아이템에 있는 novelId를 불러옵니다. 이러한 방식을 사용하면 2회차 검색부터 서버는 지정한 lastNovelId 미만의 novelId를 가진 소설 목록만 불러오는 방식으로 작동합니다.

## 📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵

https://github.com/Team-WSS/WSS-Android/assets/127238018/2f979d0a-f605-4a07-8d93-b12d395e51d6


## 💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴
