### PR TITLE
Feature/library loading

### DIFF
--- a/app/src/main/java/com/teamwss/websoso/ui/common/view/CustomSnackBar.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/common/view/CustomSnackBar.kt
@@ -1,3 +1,5 @@
+package com.teamwss.websoso.ui.common.view
+
 import android.graphics.drawable.Drawable
 import android.view.LayoutInflater
 import android.view.View

--- a/app/src/main/java/com/teamwss/websoso/ui/common/view/LoadingProgressIndicator.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/common/view/LoadingProgressIndicator.kt
@@ -1,0 +1,35 @@
+package com.teamwss.websoso.ui.common.view
+
+import android.graphics.Color
+import android.graphics.drawable.ColorDrawable
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.DialogFragment
+import com.teamwss.websoso.R
+
+class LoadingProgressIndicator : DialogFragment() {
+
+    override fun onCreateView(
+        inflater: LayoutInflater, container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        isCancelable = false
+        return inflater.inflate(R.layout.fragment_progress_dialog, container, false)
+    }
+
+    override fun onStart() {
+        super.onStart()
+        context?.let {
+            dialog?.window?.setBackgroundDrawable(ColorDrawable(Color.TRANSPARENT))
+        }
+    }
+
+    companion object {
+        const val TAG = "LoadingProgressIndicator"
+
+        @JvmStatic
+        fun newInstance() = LoadingProgressIndicator()
+    }
+}

--- a/app/src/main/java/com/teamwss/websoso/ui/main/MainActivity.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/main/MainActivity.kt
@@ -1,6 +1,6 @@
 package com.teamwss.websoso.ui.main
 
-import CustomSnackBar
+import com.teamwss.websoso.ui.common.view.CustomSnackBar
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle

--- a/app/src/main/java/com/teamwss/websoso/ui/main/home/CustomHomeItemDecoration.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/main/home/CustomHomeItemDecoration.kt
@@ -5,7 +5,7 @@ import android.graphics.Rect
 import android.view.View
 import androidx.recyclerview.widget.RecyclerView
 
-class CustomItemDecoration(private val context: Context) : RecyclerView.ItemDecoration() {
+class CustomHomeItemDecoration(private val context: Context) : RecyclerView.ItemDecoration() {
     private val marginStartEnd = dpToPx(context, 20)
 
     override fun getItemOffsets(outRect: Rect, view: View, parent: RecyclerView, state: RecyclerView.State) {

--- a/app/src/main/java/com/teamwss/websoso/ui/main/home/HomeFragment.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/main/home/HomeFragment.kt
@@ -43,7 +43,7 @@ class HomeFragment : Fragment() {
     private fun setupRecyclerView() {
         with(binding.rvHomeSosoPick) {
             adapter = homeAdapter
-            addItemDecoration(CustomItemDecoration(requireContext()))
+            addItemDecoration(CustomHomeItemDecoration(requireContext()))
         }
     }
 

--- a/app/src/main/java/com/teamwss/websoso/ui/main/library/LibraryFragment.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/main/library/LibraryFragment.kt
@@ -49,7 +49,7 @@ class LibraryFragment : Fragment() {
 
     override fun onResume() {
         super.onResume()
-        viewModel.updateUiStateResumed()
+        viewModel.getNovels()
     }
 
     private fun setupViewPager() {
@@ -102,16 +102,13 @@ class LibraryFragment : Fragment() {
     private fun observeLibraryUiState() {
         viewModel.libraryUiState.observe(viewLifecycleOwner) { libraryUiState ->
             when (libraryUiState) {
-                LibraryUiState.Uninitialized -> {
-                    viewModel.getNovels()
+                LibraryUiState.Loading -> {
+                    showLoading()
                 }
 
                 LibraryUiState.Resumed -> {
-                    viewModel.getNovels()
-                }
-
-                LibraryUiState.Loading -> {
                     showLoading()
+                    viewModel.getNovels()
                 }
 
                 LibraryUiState.Success -> {

--- a/app/src/main/java/com/teamwss/websoso/ui/main/library/LibraryFragment.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/main/library/LibraryFragment.kt
@@ -14,15 +14,17 @@ import com.teamwss.websoso.ui.main.library.adapter.LibraryViewPagerAdapter
 import com.teamwss.websoso.ui.main.library.model.ReadState
 import com.teamwss.websoso.ui.novelDetail.NovelDetailActivity
 import com.teamwss.websoso.ui.search.SearchActivity
+import com.teamwss.websoso.util.fragment.hideLoading
+import com.teamwss.websoso.util.fragment.showLoading
 
 class LibraryFragment : Fragment() {
     private var _binding: FragmentLibraryBinding? = null
     private val binding: FragmentLibraryBinding get() = requireNotNull(_binding)
-    private val viewPagerAdapter: LibraryViewPagerAdapter by lazy {
-        LibraryViewPagerAdapter(::clickNovelItem, ::navigateToSearchActivity)
-    }
     private val viewModel: LibraryViewModel by viewModels {
         LibraryViewModel.Factory
+    }
+    private val viewPagerAdapter: LibraryViewPagerAdapter by lazy {
+        LibraryViewPagerAdapter(::navigateToNovelDetail, ::navigateToSearchActivity)
     }
 
     override fun onCreateView(
@@ -41,13 +43,13 @@ class LibraryFragment : Fragment() {
         setupViewPager()
         setupTabLayoutWithViewPager()
         setupTabSelectedListener()
-        observeReadState()
-        observeCurrentNovels()
+
+        observeLibraryUiState()
     }
 
     override fun onResume() {
         super.onResume()
-        viewModel.getNovels(viewModel.readState.value ?: ReadState.ALL)
+        viewModel.setUiSateResumed()
     }
 
     private fun setupViewPager() {
@@ -86,11 +88,6 @@ class LibraryFragment : Fragment() {
         })
     }
 
-    private fun navigateToSearchActivity() {
-        val intent = SearchActivity.newIntent(requireContext())
-        startActivity(intent)
-    }
-
     private fun getReadStateFromTabPosition(position: Int): ReadState {
         return when (position) {
             0 -> ReadState.ALL
@@ -102,22 +99,45 @@ class LibraryFragment : Fragment() {
         }
     }
 
-    private fun observeReadState() {
-        viewModel.readState.observe(viewLifecycleOwner) { readState ->
-            if (viewModel.lastReadState.value != readState) {
-                viewModel.setReadState(readState)
+    private fun observeLibraryUiState() {
+        viewModel.libraryUiState.observe(viewLifecycleOwner) { libraryUiState ->
+            when (libraryUiState) {
+                LibraryUiState.Uninitialized -> {
+                    viewModel.getNovels()
+                }
+
+                LibraryUiState.Resumed -> {
+                    viewModel.getNovels()
+                }
+
+                LibraryUiState.Loading -> {
+                    showLoading()
+                }
+
+                LibraryUiState.Success -> {
+                    hideLoading()
+                    viewPagerAdapter.fetchUserNovels(
+                        viewModel.currentUserNovels.value ?: emptyList()
+                    )
+                }
+
+                LibraryUiState.Error -> {
+                    hideLoading()
+                    // TODO: Error SnackBar
+                }
+
+                else -> {}
             }
         }
     }
 
-    private fun observeCurrentNovels() {
-        viewModel.currentUserNovels.observe(viewLifecycleOwner) { currentUserNovels ->
-            viewPagerAdapter.fetchUserNovels(currentUserNovels)
-        }
+    private fun navigateToNovelDetail(novelId: Long) {
+        val intent = NovelDetailActivity.createIntent(requireContext(), novelId)
+        startActivity(intent)
     }
 
-    private fun clickNovelItem(novelId: Long) {
-        val intent = NovelDetailActivity.createIntent(requireContext(), novelId)
+    private fun navigateToSearchActivity() {
+        val intent = SearchActivity.newIntent(requireContext())
         startActivity(intent)
     }
 

--- a/app/src/main/java/com/teamwss/websoso/ui/main/library/LibraryFragment.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/main/library/LibraryFragment.kt
@@ -49,7 +49,7 @@ class LibraryFragment : Fragment() {
 
     override fun onResume() {
         super.onResume()
-        viewModel.setUiSateResumed()
+        viewModel.updateUiStateResumed()
     }
 
     private fun setupViewPager() {

--- a/app/src/main/java/com/teamwss/websoso/ui/main/library/LibraryUiState.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/main/library/LibraryUiState.kt
@@ -1,0 +1,9 @@
+package com.teamwss.websoso.ui.main.library
+
+sealed class LibraryUiState {
+    object Uninitialized : LibraryUiState()
+    object Loading : LibraryUiState()
+    object Resumed : LibraryUiState()
+    object Success : LibraryUiState()
+    object Error : LibraryUiState()
+}

--- a/app/src/main/java/com/teamwss/websoso/ui/main/library/LibraryUiState.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/main/library/LibraryUiState.kt
@@ -1,7 +1,6 @@
 package com.teamwss.websoso.ui.main.library
 
 sealed class LibraryUiState {
-    object Uninitialized : LibraryUiState()
     object Loading : LibraryUiState()
     object Resumed : LibraryUiState()
     object Success : LibraryUiState()

--- a/app/src/main/java/com/teamwss/websoso/ui/main/library/LibraryViewModel.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/main/library/LibraryViewModel.kt
@@ -55,9 +55,9 @@ class LibraryViewModel(
     }
 
     fun getNovels() {
+        _libraryUiState.value = LibraryUiState.Loading
         viewModelScope.launch {
             runCatching {
-                _libraryUiState.value = LibraryUiState.Loading
                 userNovelsRepository.getUserNovels(
                     currentReadState.value.toString(),
                     setupLastUserId(),

--- a/app/src/main/java/com/teamwss/websoso/ui/main/library/LibraryViewModel.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/main/library/LibraryViewModel.kt
@@ -36,8 +36,7 @@ class LibraryViewModel(
     val userNovelCount: LiveData<Long>
         get() = _userNovelCount
 
-    private var _libraryUiState: MutableLiveData<LibraryUiState> =
-        MutableLiveData(LibraryUiState.Uninitialized)
+    private var _libraryUiState: MutableLiveData<LibraryUiState> = MutableLiveData(LibraryUiState.Loading)
     val libraryUiState: LiveData<LibraryUiState>
         get() = _libraryUiState
 
@@ -48,14 +47,7 @@ class LibraryViewModel(
         }
     }
 
-    fun updateUiStateResumed() {
-        // 최초 시작 시에 Resumed 상태로 변경 되는 것을 방지합니다.
-        if (_libraryUiState.value != LibraryUiState.Loading)
-            _libraryUiState.value = LibraryUiState.Resumed
-    }
-
     fun getNovels() {
-        _libraryUiState.value = LibraryUiState.Loading
         viewModelScope.launch {
             runCatching {
                 userNovelsRepository.getUserNovels(

--- a/app/src/main/java/com/teamwss/websoso/ui/main/library/LibraryViewModel.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/main/library/LibraryViewModel.kt
@@ -9,7 +9,6 @@ import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
 import com.teamwss.websoso.App
-import com.teamwss.websoso.data.mapper.UserNovelMapper.toData
 import com.teamwss.websoso.data.model.LibraryUserNovelEntity
 import com.teamwss.websoso.data.repository.UserNovelsRepository
 import com.teamwss.websoso.ui.main.library.model.ReadState
@@ -20,13 +19,9 @@ class LibraryViewModel(
     private val userNovelsRepository: UserNovelsRepository
 ) : ViewModel() {
 
-    private var _readState: MutableLiveData<ReadState> = MutableLiveData(ReadState.ALL)
-    val readState: LiveData<ReadState>
-        get() = _readState
-
-    private var _lastReadState: MutableLiveData<ReadState> = MutableLiveData(ReadState.ALL)
-    val lastReadState: LiveData<ReadState>
-        get() = _lastReadState
+    private var _currentReadState: MutableLiveData<ReadState> = MutableLiveData(ReadState.ALL)
+    val currentReadState: LiveData<ReadState>
+        get() = _currentReadState
 
     private var _currentUserNovels: MutableLiveData<List<LibraryUserNovelEntity>> =
         MutableLiveData(emptyList())
@@ -41,32 +36,40 @@ class LibraryViewModel(
     val userNovelCount: LiveData<Long>
         get() = _userNovelCount
 
-    init {
-        _currentSortType.value = SortType.NEWEST
-        getNovels(ReadState.ALL)
-    }
+    private var _libraryUiState: MutableLiveData<LibraryUiState> =
+        MutableLiveData(LibraryUiState.Uninitialized)
+    val libraryUiState: LiveData<LibraryUiState>
+        get() = _libraryUiState
 
     fun setReadState(readState: ReadState) {
-        if (this.readState.value != readState) {
-            _lastReadState.value = this.readState.value
-            _readState.value = readState
-            getNovels(readState)
+        if (this.currentReadState.value != readState) {
+            _currentReadState.value = readState
+            _libraryUiState.value = LibraryUiState.Resumed
         }
     }
 
-    fun getNovels(readState: ReadState) {
+    fun setUiSateResumed() {
+        // 최초 시작 시에 Resumed 상태로 변경 되는 것을 방지합니다.
+        if (_libraryUiState.value != LibraryUiState.Loading)
+            _libraryUiState.value = LibraryUiState.Resumed
+    }
+
+    fun getNovels() {
         viewModelScope.launch {
             runCatching {
+                _libraryUiState.value = LibraryUiState.Loading
                 userNovelsRepository.getUserNovels(
-                    readState.toString(),
+                    currentReadState.value.toString(),
                     setupLastUserId(),
-                    USER_NOVEL_COUNT,
+                    NOVEL_GET_SIZE,
                     currentSortType.value.toString()
                 )
-            }.onSuccess {(userNovels, userNovelCount) ->
+            }.onSuccess { (userNovels, userNovelCount) ->
                 _currentUserNovels.value = userNovels
                 _userNovelCount.value = userNovelCount
+                _libraryUiState.value = LibraryUiState.Success
             }.onFailure {
+                _libraryUiState.value = LibraryUiState.Error
                 Log.e("LibraryViewModel", it.message ?: "error")
             }
         }
@@ -79,7 +82,7 @@ class LibraryViewModel(
     }
 
     companion object {
-        const val USER_NOVEL_COUNT = 20
+        const val NOVEL_GET_SIZE = 20
         const val NEWEST_MAXIMUM_ID = 9999L
         const val OLDEST_MINIMUM_ID = 0L
 

--- a/app/src/main/java/com/teamwss/websoso/ui/main/library/LibraryViewModel.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/main/library/LibraryViewModel.kt
@@ -48,7 +48,7 @@ class LibraryViewModel(
         }
     }
 
-    fun setUiSateResumed() {
+    fun updateUiStateResumed() {
         // 최초 시작 시에 Resumed 상태로 변경 되는 것을 방지합니다.
         if (_libraryUiState.value != LibraryUiState.Loading)
             _libraryUiState.value = LibraryUiState.Resumed

--- a/app/src/main/java/com/teamwss/websoso/ui/main/library/adapter/LibraryItemAdapter.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/main/library/adapter/LibraryItemAdapter.kt
@@ -8,14 +8,14 @@ import com.teamwss.websoso.data.model.LibraryUserNovelEntity
 import com.teamwss.websoso.databinding.ItemLibraryNovelBinding
 
 class LibraryItemAdapter(
-    private val onItemClick: (Long) -> Unit
+    private val userNovelClick: (userNovelId: Long) -> Unit
 ) :
     ListAdapter<LibraryUserNovelEntity, LibraryItemViewHolder>(FollowerDiffCallback) {
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): LibraryItemViewHolder {
         val binding =
             ItemLibraryNovelBinding.inflate(LayoutInflater.from(parent.context), parent, false)
-        return LibraryItemViewHolder(binding,onItemClick)
+        return LibraryItemViewHolder(binding,userNovelClick)
     }
 
     override fun onBindViewHolder(holder: LibraryItemViewHolder, position: Int) {

--- a/app/src/main/java/com/teamwss/websoso/ui/main/library/adapter/LibraryItemViewHolder.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/main/library/adapter/LibraryItemViewHolder.kt
@@ -7,7 +7,7 @@ import kotlin.properties.Delegates
 
 class LibraryItemViewHolder(
     private val binding: ItemLibraryNovelBinding,
-    private val onItemClick: (Long) -> Unit
+    private val userNovelClick: (userNovelId: Long) -> Unit
 ) : RecyclerView.ViewHolder(binding.root) {
 
     private var userNovelId by Delegates.notNull<Long>()
@@ -15,7 +15,7 @@ class LibraryItemViewHolder(
     init {
         binding.root.setOnClickListener {
             if (adapterPosition != RecyclerView.NO_POSITION) {
-                onItemClick(userNovelId)
+                userNovelClick(userNovelId)
             }
         }
     }

--- a/app/src/main/java/com/teamwss/websoso/ui/main/library/adapter/LibraryViewPagerAdapter.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/main/library/adapter/LibraryViewPagerAdapter.kt
@@ -7,7 +7,7 @@ import com.teamwss.websoso.data.model.LibraryUserNovelEntity
 import com.teamwss.websoso.databinding.ItemLibraryViewPagerBinding
 
 class LibraryViewPagerAdapter(
-    private val onItemClick: (Long) -> Unit,
+    private val userNovelClick: (userNovelId: Long) -> Unit,
     private val onPostClick: () -> Unit
 ) :
     RecyclerView.Adapter<LibraryViewPagerViewHolder>() {
@@ -17,7 +17,7 @@ class LibraryViewPagerAdapter(
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): LibraryViewPagerViewHolder {
         val binding =
             ItemLibraryViewPagerBinding.inflate(LayoutInflater.from(parent.context), parent, false)
-        return LibraryViewPagerViewHolder(binding, onItemClick, onPostClick)
+        return LibraryViewPagerViewHolder(binding, userNovelClick, onPostClick)
     }
 
     override fun onBindViewHolder(holder: LibraryViewPagerViewHolder, position: Int) {

--- a/app/src/main/java/com/teamwss/websoso/ui/main/library/adapter/LibraryViewPagerAdapter.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/main/library/adapter/LibraryViewPagerAdapter.kt
@@ -12,7 +12,7 @@ class LibraryViewPagerAdapter(
 ) :
     RecyclerView.Adapter<LibraryViewPagerViewHolder>() {
 
-    private var userNovels = emptyList<LibraryUserNovelEntity>()
+    private var userNovels :List<LibraryUserNovelEntity> = libraryUserNovelsInitData
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): LibraryViewPagerViewHolder {
         val binding =
@@ -30,4 +30,44 @@ class LibraryViewPagerAdapter(
     }
 
     override fun getItemCount(): Int = 5
+
+    companion object{
+        private val libraryUserNovelsInitData = listOf(
+            LibraryUserNovelEntity(
+                userNovelId = 1,
+                userNovelTitle = "",
+                userNovelCover = "",
+                userNovelAuthor = "",
+                userNovelRating = 0f
+            ),
+            LibraryUserNovelEntity(
+                userNovelId = 1,
+                userNovelTitle = "",
+                userNovelCover = "",
+                userNovelAuthor = "",
+                userNovelRating = 0f
+            ),
+            LibraryUserNovelEntity(
+                userNovelId = 1,
+                userNovelTitle = "",
+                userNovelCover = "",
+                userNovelAuthor = "",
+                userNovelRating = 0f
+            ),
+            LibraryUserNovelEntity(
+                userNovelId = 1,
+                userNovelTitle = "",
+                userNovelCover = "",
+                userNovelAuthor = "",
+                userNovelRating = 0f
+            ),
+            LibraryUserNovelEntity(
+                userNovelId = 1,
+                userNovelTitle = "",
+                userNovelCover = "",
+                userNovelAuthor = "",
+                userNovelRating = 0f
+            ),
+        )
+    }
 }

--- a/app/src/main/java/com/teamwss/websoso/ui/main/library/adapter/LibraryViewPagerViewHolder.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/main/library/adapter/LibraryViewPagerViewHolder.kt
@@ -7,10 +7,10 @@ import com.teamwss.websoso.databinding.ItemLibraryViewPagerBinding
 
 class LibraryViewPagerViewHolder(
     private val binding: ItemLibraryViewPagerBinding,
-    private val onItemClick: (Long) -> Unit,
+    private val userNovelClick: (userNovelId: Long) -> Unit,
     private val onPostClick: () -> Unit
 ) : RecyclerView.ViewHolder(binding.root) {
-    private val libraryItemAdapter = LibraryItemAdapter(onItemClick)
+    private val libraryItemAdapter = LibraryItemAdapter(userNovelClick)
 
     init {
         binding.rvLibraryViewPager.adapter = libraryItemAdapter

--- a/app/src/main/java/com/teamwss/websoso/ui/main/record/RecordFragment.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/main/record/RecordFragment.kt
@@ -14,6 +14,7 @@ import androidx.fragment.app.commit
 import androidx.fragment.app.viewModels
 import com.teamwss.websoso.R
 import com.teamwss.websoso.databinding.FragmentRecordBinding
+import com.teamwss.websoso.ui.common.view.CustomSnackBar
 import com.teamwss.websoso.ui.main.MainActivity
 import com.teamwss.websoso.ui.main.library.LibraryFragment
 import com.teamwss.websoso.ui.memoPlain.MemoPlainActivity

--- a/app/src/main/java/com/teamwss/websoso/ui/memoPlain/DialogMemoDelete.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/memoPlain/DialogMemoDelete.kt
@@ -10,9 +10,9 @@ import android.view.Window
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.activityViewModels
-import com.google.android.material.snackbar.Snackbar
 import com.teamwss.websoso.R
 import com.teamwss.websoso.databinding.DialogMemoDeleteBinding
+import com.teamwss.websoso.ui.common.view.CustomSnackBar
 
 class DialogMemoDelete(private val memoDeleteSuccess: () -> Unit) : DialogFragment() {
     private var _binding: DialogMemoDeleteBinding? = null

--- a/app/src/main/java/com/teamwss/websoso/ui/memoPlain/MemoPlainActivity.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/memoPlain/MemoPlainActivity.kt
@@ -1,6 +1,6 @@
 package com.teamwss.websoso.ui.memoPlain
 
-import CustomSnackBar
+import com.teamwss.websoso.ui.common.view.CustomSnackBar
 import android.app.Activity
 import android.content.Context
 import android.content.Intent

--- a/app/src/main/java/com/teamwss/websoso/ui/memoWrite/MemoWriteActivity.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/memoWrite/MemoWriteActivity.kt
@@ -1,16 +1,13 @@
 package com.teamwss.websoso.ui.memoWrite
 
-import CustomSnackBar
+import com.teamwss.websoso.ui.common.view.CustomSnackBar
 import android.annotation.SuppressLint
 import android.app.Activity
 import android.content.Context
 import android.content.Intent
-import android.graphics.Color
 import android.os.Bundle
 import android.util.Log
 import android.view.MotionEvent
-import android.view.WindowInsets
-import android.view.WindowInsetsController.APPEARANCE_LIGHT_STATUS_BARS
 import android.view.WindowManager
 import android.view.inputmethod.InputMethodManager
 import androidx.activity.viewModels

--- a/app/src/main/java/com/teamwss/websoso/ui/novelDetail/NovelDetailActivity.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/novelDetail/NovelDetailActivity.kt
@@ -1,6 +1,6 @@
 package com.teamwss.websoso.ui.novelDetail
 
-import CustomSnackBar
+import com.teamwss.websoso.ui.common.view.CustomSnackBar
 import android.app.Activity
 import android.content.Context
 import android.content.Intent

--- a/app/src/main/java/com/teamwss/websoso/ui/novelDetail/fragment/NovelMemoFragment.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/novelDetail/fragment/NovelMemoFragment.kt
@@ -1,6 +1,6 @@
 package com.teamwss.websoso.ui.novelDetail.fragment
 
-import CustomSnackBar
+import com.teamwss.websoso.ui.common.view.CustomSnackBar
 import android.app.Activity
 import android.content.Intent
 import android.os.Bundle
@@ -12,7 +12,6 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
-import com.google.android.material.snackbar.Snackbar
 import com.teamwss.websoso.R
 import com.teamwss.websoso.databinding.FragmentNovelMemoBinding
 import com.teamwss.websoso.ui.memoPlain.MemoPlainActivity

--- a/app/src/main/java/com/teamwss/websoso/util/activity/ActivityExt.kt
+++ b/app/src/main/java/com/teamwss/websoso/util/activity/ActivityExt.kt
@@ -1,0 +1,20 @@
+package com.teamwss.websoso.util.activity
+
+import androidx.appcompat.app.AppCompatActivity
+import androidx.fragment.app.commit
+import com.teamwss.websoso.ui.common.view.LoadingProgressIndicator
+
+
+fun AppCompatActivity.showLoading() {
+    supportFragmentManager.commit(allowStateLoss = true) {
+        add(LoadingProgressIndicator.newInstance(), LoadingProgressIndicator.TAG)
+    }
+}
+
+fun AppCompatActivity.hideLoading() {
+    supportFragmentManager.findFragmentByTag(LoadingProgressIndicator.TAG)?.let { fragment ->
+        supportFragmentManager.commit(allowStateLoss = true) {
+            remove(fragment)
+        }
+    }
+}

--- a/app/src/main/java/com/teamwss/websoso/util/fragment/FragmentExt.kt
+++ b/app/src/main/java/com/teamwss/websoso/util/fragment/FragmentExt.kt
@@ -1,0 +1,19 @@
+package com.teamwss.websoso.util.fragment
+
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.commit
+import com.teamwss.websoso.ui.common.view.LoadingProgressIndicator
+
+fun Fragment.showLoading() {
+    childFragmentManager.commit(allowStateLoss = true) {
+        add(LoadingProgressIndicator.newInstance(), LoadingProgressIndicator.TAG)
+    }
+}
+
+fun Fragment.hideLoading() {
+    childFragmentManager.findFragmentByTag(LoadingProgressIndicator.TAG)?.let { fragment ->
+        childFragmentManager.commit(allowStateLoss = true) {
+            remove(fragment)
+        }
+    }
+}

--- a/app/src/main/res/drawable/ic_sort_type_selector_arrow.xml
+++ b/app/src/main/res/drawable/ic_sort_type_selector_arrow.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="21dp"
+    android:height="21dp"
+    android:viewportWidth="21"
+    android:viewportHeight="21">
+  <path
+      android:strokeWidth="1"
+      android:pathData="M5.316,8.48L10.317,13.481L15.317,8.48"
+      android:fillColor="#00000000"
+      android:strokeColor="#52515F"
+      android:strokeLineCap="round"/>
+</vector>

--- a/app/src/main/res/layout/fragment_library.xml
+++ b/app/src/main/res/layout/fragment_library.xml
@@ -99,7 +99,8 @@
                 android:textColor="@color/gray_200_AEADB3"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent" />
+                app:layout_constraintTop_toTopOf="parent"
+                tools:text="nn개" />
 
         </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/app/src/main/res/layout/fragment_library.xml
+++ b/app/src/main/res/layout/fragment_library.xml
@@ -102,6 +102,48 @@
                 app:layout_constraintTop_toTopOf="parent"
                 tools:text="nn개" />
 
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:id="@+id/clLibrarySortType"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginEnd="20dp"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toTopOf="parent">
+
+                <TextView
+                    android:id="@+id/tvLibrarySortType"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@{viewModel.currentSortType.toString()}"
+                    android:textAppearance="@style/label1"
+                    android:textColor="@color/gray_300_52515F"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent"
+                    tools:text="최신순" />
+
+                <ImageView
+                    android:id="@+id/ivLibrarySortTypeSelectArrow"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="4dp"
+                    android:src="@drawable/ic_sort_type_selector_arrow"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toEndOf="@id/tvLibrarySortType"
+                    app:layout_constraintTop_toTopOf="parent" />
+
+            </androidx.constraintlayout.widget.ConstraintLayout>
+
+            <Spinner
+                android:id="@+id/spNovelDetail"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:visibility="invisible"
+                app:layout_constraintEnd_toEndOf="@id/clLibrarySortType"
+                app:layout_constraintTop_toBottomOf="@id/clLibrarySortType" />
+
         </androidx.constraintlayout.widget.ConstraintLayout>
 
         <androidx.viewpager2.widget.ViewPager2

--- a/app/src/main/res/layout/fragment_library.xml
+++ b/app/src/main/res/layout/fragment_library.xml
@@ -150,7 +150,6 @@
             android:id="@+id/vpLibraryNovel"
             android:layout_width="0dp"
             android:layout_height="0dp"
-            android:layout_marginBottom="18dp"
             app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"

--- a/app/src/main/res/layout/fragment_progress_dialog.xml
+++ b/app/src/main/res/layout/fragment_progress_dialog.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <com.google.android.material.progressindicator.CircularProgressIndicator
+        android:id="@+id/cpiLoading"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:indeterminate="true"
+        android:theme="@style/Widget.Material3.CircularProgressIndicator"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/item_library_novel.xml
+++ b/app/src/main/res/layout/item_library_novel.xml
@@ -5,25 +5,25 @@
 
     <data>
 
-            <variable
-                name="libraryNovel"
-                type="com.teamwss.websoso.data.model.LibraryUserNovelEntity" />
+        <variable
+            name="libraryNovel"
+            type="com.teamwss.websoso.data.model.LibraryUserNovelEntity" />
 
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:paddingTop="24dp">
+        android:paddingVertical="12dp">
 
         <com.google.android.material.imageview.ShapeableImageView
             android:id="@+id/ivLibraryNovelCover"
+            loadCoverImageRounded30="@{libraryNovel.userNovelCover}"
             android:layout_width="105dp"
             android:layout_height="155dp"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"
-            loadCoverImageRounded30="@{libraryNovel.userNovelCover}"
             tools:src="@mipmap/ic_launcher" />
 
         <TextView
@@ -36,9 +36,9 @@
             android:gravity="left"
             android:lineSpacingExtra="5sp"
             android:maxLines="2"
+            android:text="@{libraryNovel.userNovelTitle}"
             android:textAppearance="@style/body2"
             android:textColor="@color/black"
-            android:text="@{libraryNovel.userNovelTitle}"
             app:layout_constraintEnd_toEndOf="@id/ivLibraryNovelCover"
             app:layout_constraintStart_toStartOf="@id/ivLibraryNovelCover"
             app:layout_constraintTop_toBottomOf="@id/ivLibraryNovelCover"
@@ -48,9 +48,9 @@
             android:id="@+id/tvLibraryNovelAuthor"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:text="@{libraryNovel.userNovelAuthor}"
             android:textAppearance="@style/label1"
             android:textColor="@color/gray_200_AEADB3"
-            android:text="@{libraryNovel.userNovelAuthor}"
             app:layout_constraintStart_toStartOf="@+id/tvLibraryNovelTitle"
             app:layout_constraintTop_toBottomOf="@id/tvLibraryNovelTitle"
             tools:text="이보라" />
@@ -59,23 +59,23 @@
             android:id="@+id/ivLibraryStar"
             android:layout_width="11dp"
             android:layout_height="10dp"
-            app:visibleGone="@{libraryNovel.userNovelRating != 0}"
             android:layout_marginTop="6dp"
             android:src="@drawable/ic_star_full"
             app:layout_constraintStart_toStartOf="@+id/tvLibraryNovelTitle"
-            app:layout_constraintTop_toBottomOf="@id/tvLibraryNovelAuthor" />
+            app:layout_constraintTop_toBottomOf="@id/tvLibraryNovelAuthor"
+            app:visibleGone="@{libraryNovel.userNovelRating != 0}" />
 
         <TextView
             android:id="@+id/tvLibraryNovelRating"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginStart="5dp"
-            app:visibleGone="@{libraryNovel.userNovelRating != 0}"
             android:text="@{Float.toString(libraryNovel.userNovelRating)}"
             android:textAppearance="@style/label1"
             app:layout_constraintBottom_toBottomOf="@id/ivLibraryStar"
             app:layout_constraintStart_toEndOf="@id/ivLibraryStar"
             app:layout_constraintTop_toTopOf="@id/ivLibraryStar"
+            app:visibleGone="@{libraryNovel.userNovelRating != 0}"
             tools:text="4.5" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/item_library_view_pager.xml
+++ b/app/src/main/res/layout/item_library_view_pager.xml
@@ -15,10 +15,8 @@
             app:layoutManager="androidx.recyclerview.widget.GridLayoutManager"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintHorizontal_bias="0.0"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"
-            app:layout_constraintVertical_bias="0.0"
             app:spanCount="3"
             tools:listitem="@layout/item_library_novel" />
 


### PR DESCRIPTION
## 📌𝘐𝘴𝘴𝘶𝘦𝘴
- closed #104

## 📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯
- 로딩 화면을 구현하였습니다.
- 최신순,오래된순 정렬 구현을 위한 ui 작업을 조금 해두었습니다.
- 현재 NEWEST, OLDEST로 보이는 것이 맞습니다.
- 화면을 전환할 때 비어있는 화면에 등장하는 "작품 등록하기"화면을 안보이도록 initDummyData를 넣었습니다.

## 📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵

https://github.com/Team-WSS/WSS-Android/assets/52442547/9975aa97-aacc-4b11-ab48-04d0d59fefdc


## 💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴
최신순 오래된순 정렬을 할 때 서버 통신 함수 인자에 NEWEST, OLDEST  보내야하는데

그러면 최신순->NEWEST, 오래된순->OLDEST 바꿔줘야하는 상황이 생기게 됩니다.

서버에 요청해서 에초에 `최신순`처럼 한글로 보내는 것은 어떻게 생각하시나요?