### PR TITLE
feat: 상세 탐색 정보 웹소소 칩 구현

### DIFF
--- a/app/src/main/java/com/teamwss/websoso/ui/detailExplore/DetailExploreDialog.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/detailExplore/DetailExploreDialog.kt
@@ -8,7 +8,9 @@ import com.teamwss.websoso.R
 import com.teamwss.websoso.databinding.DialogDetailExploreBinding
 import com.teamwss.websoso.ui.common.base.BindingBottomSheetDialog
 import com.teamwss.websoso.ui.detailExplore.info.DetailExploreInfoFragment
+import dagger.hilt.android.AndroidEntryPoint
 
+@AndroidEntryPoint
 class DetailExploreDialog :
     BindingBottomSheetDialog<DialogDetailExploreBinding>(R.layout.dialog_detail_explore) {
 

--- a/app/src/main/java/com/teamwss/websoso/ui/detailExplore/DetailExploreDialog.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/detailExplore/DetailExploreDialog.kt
@@ -2,6 +2,8 @@ package com.teamwss.websoso.ui.detailExplore
 
 import android.os.Bundle
 import android.view.View
+import com.google.android.material.bottomsheet.BottomSheetBehavior
+import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.teamwss.websoso.R
 import com.teamwss.websoso.databinding.DialogDetailExploreBinding
 import com.teamwss.websoso.ui.common.base.BindingBottomSheetDialog
@@ -13,7 +15,16 @@ class DetailExploreDialog :
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
+        setupBottomSheet()
         setupFragmentContainer()
+        onBottomSheetExitButtonClick()
+    }
+
+    private fun setupBottomSheet() {
+        (dialog as BottomSheetDialog).behavior.state = BottomSheetBehavior.STATE_EXPANDED
+        (dialog as BottomSheetDialog).behavior.isDraggable = false
+        (dialog as BottomSheetDialog).behavior.isHideable = false
+        (dialog as BottomSheetDialog).setCancelable(false)
     }
 
     private fun setupFragmentContainer() {
@@ -21,5 +32,11 @@ class DetailExploreDialog :
         childFragmentManager.beginTransaction()
             .replace(R.id.fcv_detail_explore, DetailExploreInfoFragment())
             .commit()
+    }
+
+    private fun onBottomSheetExitButtonClick() {
+        binding.ivDetailExploreExitButton.setOnClickListener {
+            dismiss()
+        }
     }
 }

--- a/app/src/main/java/com/teamwss/websoso/ui/detailExplore/DetailExploreDialog.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/detailExplore/DetailExploreDialog.kt
@@ -5,6 +5,7 @@ import android.view.View
 import com.teamwss.websoso.R
 import com.teamwss.websoso.databinding.DialogDetailExploreBinding
 import com.teamwss.websoso.ui.common.base.BindingBottomSheetDialog
+import com.teamwss.websoso.ui.detailExplore.info.DetailExploreInfoFragment
 
 class DetailExploreDialog :
     BindingBottomSheetDialog<DialogDetailExploreBinding>(R.layout.dialog_detail_explore) {
@@ -12,6 +13,13 @@ class DetailExploreDialog :
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
+        setupFragmentContainer()
+    }
 
+    private fun setupFragmentContainer() {
+        // TODO 정보/키워드 탭에 따른 fragment 수정
+        childFragmentManager.beginTransaction()
+            .replace(R.id.fcv_detail_explore, DetailExploreInfoFragment())
+            .commit()
     }
 }

--- a/app/src/main/java/com/teamwss/websoso/ui/detailExplore/DetailExploreDialog.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/detailExplore/DetailExploreDialog.kt
@@ -21,10 +21,12 @@ class DetailExploreDialog :
     }
 
     private fun setupBottomSheet() {
-        (dialog as BottomSheetDialog).behavior.state = BottomSheetBehavior.STATE_EXPANDED
-        (dialog as BottomSheetDialog).behavior.isDraggable = false
-        (dialog as BottomSheetDialog).behavior.isHideable = false
-        (dialog as BottomSheetDialog).setCancelable(false)
+        (dialog as BottomSheetDialog).apply {
+            behavior.state = BottomSheetBehavior.STATE_EXPANDED
+            behavior.isDraggable = false
+            behavior.isHideable = false
+            setCancelable(false)
+        }
     }
 
     private fun setupFragmentContainer() {

--- a/app/src/main/java/com/teamwss/websoso/ui/detailExplore/DetailExploreDialog.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/detailExplore/DetailExploreDialog.kt
@@ -16,7 +16,7 @@ class DetailExploreDialog :
         super.onViewCreated(view, savedInstanceState)
 
         setupBottomSheet()
-        setupFragmentContainer()
+        replaceDetailExploreFragment()
         onBottomSheetExitButtonClick()
     }
 
@@ -29,7 +29,7 @@ class DetailExploreDialog :
         }
     }
 
-    private fun setupFragmentContainer() {
+    private fun replaceDetailExploreFragment() {
         // TODO 정보/키워드 탭에 따른 fragment 수정
         childFragmentManager.beginTransaction()
             .replace(R.id.fcv_detail_explore, DetailExploreInfoFragment())
@@ -39,6 +39,13 @@ class DetailExploreDialog :
     private fun onBottomSheetExitButtonClick() {
         binding.ivDetailExploreExitButton.setOnClickListener {
             dismiss()
+        }
+    }
+
+    companion object {
+
+        fun newInstance(): DetailExploreDialog {
+            return DetailExploreDialog()
         }
     }
 }

--- a/app/src/main/java/com/teamwss/websoso/ui/detailExplore/info/DetailExploreInfoFragment.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/detailExplore/info/DetailExploreInfoFragment.kt
@@ -15,6 +15,7 @@ class DetailExploreInfoFragment :
         super.onViewCreated(view, savedInstanceState)
 
         setupGenreChips()
+        setupRatingChipsText()
         setupStatusChipsSingleSelection()
         setupRatingChipsSingleSelection()
     }
@@ -36,6 +37,21 @@ class DetailExploreInfoFragment :
         }
     }
 
+    private fun setupRatingChipsText() {
+        val ratings = listOf(3.5f, 4.0f, 4.5f, 4.8f)
+
+        with(binding) {
+            chipDetailExploreInfoRatingLowest.text =
+                requireContext().getString(R.string.detail_explore_info_rating_lowest, ratings[0])
+            chipDetailExploreInfoRatingLower.text =
+                requireContext().getString(R.string.detail_explore_info_rating_lower, ratings[1])
+            chipDetailExploreInfoRatingHigher.text =
+                requireContext().getString(R.string.detail_explore_info_rating_higher, ratings[2])
+            chipDetailExploreInfoRatingHighest.text =
+                requireContext().getString(R.string.detail_explore_info_rating_highest, ratings[3])
+        }
+    }
+
     private fun setupStatusChipsSingleSelection() {
         val statusChips = listOf(
             binding.chipDetailExploreInfoStatusInSeries,
@@ -53,10 +69,10 @@ class DetailExploreInfoFragment :
 
     private fun setupRatingChipsSingleSelection() {
         val ratingChips = listOf(
-            binding.chipDetailExploreInfoRating35,
-            binding.chipDetailExploreInfoRating40,
-            binding.chipDetailExploreInfoRating45,
-            binding.chipDetailExploreInfoRating48,
+            binding.chipDetailExploreInfoRatingLowest,
+            binding.chipDetailExploreInfoRatingLower,
+            binding.chipDetailExploreInfoRatingHigher,
+            binding.chipDetailExploreInfoRatingHighest,
         )
 
         ratingChips.forEach { chip ->

--- a/app/src/main/java/com/teamwss/websoso/ui/detailExplore/info/DetailExploreInfoFragment.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/detailExplore/info/DetailExploreInfoFragment.kt
@@ -38,8 +38,8 @@ class DetailExploreInfoFragment :
 
     private fun setupStatusChipsSingleSelection() {
         val statusChips = listOf(
-            binding.chipDetailExploreInfoStatusIng,
-            binding.chipDetailExploreInfoStatusFinish,
+            binding.chipDetailExploreInfoStatusInSeries,
+            binding.chipDetailExploreInfoStatusComplete,
         )
 
         statusChips.forEach { chip ->

--- a/app/src/main/java/com/teamwss/websoso/ui/detailExplore/info/DetailExploreInfoFragment.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/detailExplore/info/DetailExploreInfoFragment.kt
@@ -5,6 +5,8 @@ import android.view.View
 import com.teamwss.websoso.R
 import com.teamwss.websoso.databinding.FragmentDetailExploreInfoBinding
 import com.teamwss.websoso.ui.common.base.BindingFragment
+import com.teamwss.websoso.ui.common.customView.WebsosoChip
+import com.teamwss.websoso.ui.detailExplore.info.model.Genre
 
 class DetailExploreInfoFragment :
     BindingFragment<FragmentDetailExploreInfoBinding>(R.layout.fragment_detail_explore_info) {
@@ -12,10 +14,23 @@ class DetailExploreInfoFragment :
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        setupUI()
+        setupGenreChips()
     }
 
-    private fun setupUI() {
-        
+    private fun setupGenreChips() {
+        val genres = Genre.values().toList()
+        genres.forEach { genre ->
+            WebsosoChip(requireContext()).apply {
+                setWebsosoChipText(genre.title)
+                setWebsosoChipTextAppearance(R.style.body2)
+                setWebsosoChipTextColor(R.color.bg_detail_explore_chip_text_selector)
+                setWebsosoChipStrokeColor(R.color.bg_detail_explore_chip_stroke_selector)
+                setWebsosoChipBackgroundColor(R.color.bg_detail_explore_chip_background_selector)
+                setWebsosoChipPaddingVertical(30f)
+                setWebsosoChipPaddingHorizontal(12f)
+                setWebsosoChipRadius(45f)
+                setOnWebsosoChipClick { } // TODO 추후 추가 예정
+            }.also { websosoChip -> binding.wcgDetailExploreInfoGenre.addChip(websosoChip) }
+        }
     }
 }

--- a/app/src/main/java/com/teamwss/websoso/ui/detailExplore/info/DetailExploreInfoFragment.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/detailExplore/info/DetailExploreInfoFragment.kt
@@ -1,0 +1,21 @@
+package com.teamwss.websoso.ui.detailExplore.info
+
+import android.os.Bundle
+import android.view.View
+import com.teamwss.websoso.R
+import com.teamwss.websoso.databinding.FragmentDetailExploreInfoBinding
+import com.teamwss.websoso.ui.common.base.BindingFragment
+
+class DetailExploreInfoFragment :
+    BindingFragment<FragmentDetailExploreInfoBinding>(R.layout.fragment_detail_explore_info) {
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        setupUI()
+    }
+
+    private fun setupUI() {
+        
+    }
+}

--- a/app/src/main/java/com/teamwss/websoso/ui/detailExplore/info/DetailExploreInfoFragment.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/detailExplore/info/DetailExploreInfoFragment.kt
@@ -2,22 +2,31 @@ package com.teamwss.websoso.ui.detailExplore.info
 
 import android.os.Bundle
 import android.view.View
+import androidx.fragment.app.viewModels
 import com.teamwss.websoso.R
 import com.teamwss.websoso.databinding.FragmentDetailExploreInfoBinding
 import com.teamwss.websoso.ui.common.base.BindingFragment
 import com.teamwss.websoso.ui.common.customView.WebsosoChip
 import com.teamwss.websoso.ui.detailExplore.info.model.Genre
+import dagger.hilt.android.AndroidEntryPoint
 
+@AndroidEntryPoint
 class DetailExploreInfoFragment :
     BindingFragment<FragmentDetailExploreInfoBinding>(R.layout.fragment_detail_explore_info) {
+    private val detailExploreInfoViewModel: DetailExploreInfoViewModel by viewModels()
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
+        bindViewModel()
         setupGenreChips()
-        setupRatingChipsText()
         setupStatusChipsSingleSelection()
         setupRatingChipsSingleSelection()
+    }
+
+    private fun bindViewModel() {
+        binding.detailExploreInfoviewModel = detailExploreInfoViewModel
+        binding.lifecycleOwner = this
     }
 
     private fun setupGenreChips() {
@@ -34,21 +43,6 @@ class DetailExploreInfoFragment :
                 setWebsosoChipRadius(45f)
                 setOnWebsosoChipClick { } // TODO 추후 추가 예정
             }.also { websosoChip -> binding.wcgDetailExploreInfoGenre.addChip(websosoChip) }
-        }
-    }
-
-    private fun setupRatingChipsText() {
-        val ratings = listOf(3.5f, 4.0f, 4.5f, 4.8f)
-
-        with(binding) {
-            chipDetailExploreInfoRatingLowest.text =
-                requireContext().getString(R.string.detail_explore_info_rating_lowest, ratings[0])
-            chipDetailExploreInfoRatingLower.text =
-                requireContext().getString(R.string.detail_explore_info_rating_lower, ratings[1])
-            chipDetailExploreInfoRatingHigher.text =
-                requireContext().getString(R.string.detail_explore_info_rating_higher, ratings[2])
-            chipDetailExploreInfoRatingHighest.text =
-                requireContext().getString(R.string.detail_explore_info_rating_highest, ratings[3])
         }
     }
 

--- a/app/src/main/java/com/teamwss/websoso/ui/detailExplore/info/DetailExploreInfoFragment.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/detailExplore/info/DetailExploreInfoFragment.kt
@@ -21,7 +21,7 @@ class DetailExploreInfoFragment :
     }
 
     private fun setupGenreChips() {
-        val genres = Genre.values().toList()
+        val genres = Genre.entries
         genres.forEach { genre ->
             WebsosoChip(requireContext()).apply {
                 setWebsosoChipText(genre.title)

--- a/app/src/main/java/com/teamwss/websoso/ui/detailExplore/info/DetailExploreInfoFragment.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/detailExplore/info/DetailExploreInfoFragment.kt
@@ -15,6 +15,8 @@ class DetailExploreInfoFragment :
         super.onViewCreated(view, savedInstanceState)
 
         setupGenreChips()
+        setupStatusChipsSingleSelection()
+        setupRatingChipsSingleSelection()
     }
 
     private fun setupGenreChips() {
@@ -31,6 +33,38 @@ class DetailExploreInfoFragment :
                 setWebsosoChipRadius(45f)
                 setOnWebsosoChipClick { } // TODO 추후 추가 예정
             }.also { websosoChip -> binding.wcgDetailExploreInfoGenre.addChip(websosoChip) }
+        }
+    }
+
+    private fun setupStatusChipsSingleSelection() {
+        val statusChips = listOf(
+            binding.chipDetailExploreInfoStatusIng,
+            binding.chipDetailExploreInfoStatusFinish,
+        )
+
+        statusChips.forEach { chip ->
+            chip.setOnCheckedChangeListener { _, isChecked ->
+                if (isChecked) {
+                    statusChips.filter { it != chip }.forEach { it.isChecked = false }
+                }
+            }
+        }
+    }
+
+    private fun setupRatingChipsSingleSelection() {
+        val ratingChips = listOf(
+            binding.chipDetailExploreInfoRating35,
+            binding.chipDetailExploreInfoRating40,
+            binding.chipDetailExploreInfoRating45,
+            binding.chipDetailExploreInfoRating48,
+        )
+
+        ratingChips.forEach { chip ->
+            chip.setOnCheckedChangeListener { _, isChecked ->
+                if (isChecked) {
+                    ratingChips.filter { it != chip }.forEach { it.isChecked = false }
+                }
+            }
         }
     }
 }

--- a/app/src/main/java/com/teamwss/websoso/ui/detailExplore/info/DetailExploreInfoViewModel.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/detailExplore/info/DetailExploreInfoViewModel.kt
@@ -1,0 +1,10 @@
+package com.teamwss.websoso.ui.detailExplore.info
+
+import androidx.lifecycle.ViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+@HiltViewModel
+class DetailExploreInfoViewModel @Inject constructor() : ViewModel() {
+    val ratings: List<Float> = listOf(3.5f, 4.0f, 4.5f, 4.8f)
+}

--- a/app/src/main/java/com/teamwss/websoso/ui/detailExplore/info/model/Genre.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/detailExplore/info/model/Genre.kt
@@ -1,0 +1,15 @@
+package com.teamwss.websoso.ui.detailExplore.info.model
+
+enum class Genre(
+    val title: String,
+) {
+    ROMANCE("로맨스"),
+    ROMANCE_FANTASY("로판"),
+    FANTASY("판타지"),
+    MODERN_FANTASY("현판"),
+    WUXIA("무협"),
+    MYSTERY("미스터리"),
+    DRAMA("드라마"),
+    LIGHT_NOVEL("라노벨"),
+    BOYS_LOVE("BL"),
+}

--- a/app/src/main/java/com/teamwss/websoso/ui/main/explore/ExploreFragment.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/main/explore/ExploreFragment.kt
@@ -6,6 +6,7 @@ import androidx.fragment.app.viewModels
 import com.teamwss.websoso.R
 import com.teamwss.websoso.databinding.FragmentExploreBinding
 import com.teamwss.websoso.ui.common.base.BindingFragment
+import com.teamwss.websoso.ui.detailExplore.DetailExploreDialog
 import com.teamwss.websoso.ui.main.explore.adapter.SosoPickAdapter
 import com.teamwss.websoso.ui.normalExplore.NormalExploreActivity
 import dagger.hilt.android.AndroidEntryPoint
@@ -19,7 +20,8 @@ class ExploreFragment : BindingFragment<FragmentExploreBinding>(R.layout.fragmen
         super.onViewCreated(view, savedInstanceState)
 
         initSosoPickAdapter()
-        onClickNovelSearchButton()
+        onNormalSearchButtonClick()
+        onDetailExploreButtonClick()
         setupObserveUiState()
     }
 
@@ -32,10 +34,17 @@ class ExploreFragment : BindingFragment<FragmentExploreBinding>(R.layout.fragmen
         // TODO 작품 정보 뷰로 이동
     }
 
-    private fun onClickNovelSearchButton() {
+    private fun onNormalSearchButtonClick() {
         binding.clExploreNormalSearch.setOnClickListener {
             val intent = NormalExploreActivity.from(requireContext())
             startActivity(intent)
+        }
+    }
+
+    private fun onDetailExploreButtonClick() {
+        binding.clExploreDetailSearch.setOnClickListener {
+            val detailExploreBottomSheet = DetailExploreDialog()
+            detailExploreBottomSheet.show(this@ExploreFragment.childFragmentManager, tag)
         }
     }
 

--- a/app/src/main/java/com/teamwss/websoso/ui/main/explore/ExploreFragment.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/main/explore/ExploreFragment.kt
@@ -43,7 +43,7 @@ class ExploreFragment : BindingFragment<FragmentExploreBinding>(R.layout.fragmen
 
     private fun onDetailExploreButtonClick() {
         binding.clExploreDetailSearch.setOnClickListener {
-            val detailExploreBottomSheet = DetailExploreDialog()
+            val detailExploreBottomSheet = DetailExploreDialog.newInstance()
             detailExploreBottomSheet.show(this@ExploreFragment.childFragmentManager, tag)
         }
     }

--- a/app/src/main/res/color/bg_detail_explore_chip_background_selector.xml
+++ b/app/src/main/res/color/bg_detail_explore_chip_background_selector.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:color="@color/primary_50_F1EFFF" android:state_selected="true" />
+    <item android:color="@color/gray_50_F4F5F8" android:state_selected="false" />
+</selector>

--- a/app/src/main/res/color/bg_detail_explore_chip_stroke_selector.xml
+++ b/app/src/main/res/color/bg_detail_explore_chip_stroke_selector.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:color="@color/primary_100_6A5DFD" android:state_selected="true" />
+    <item android:color="@color/transparent" android:state_selected="false" />
+</selector>

--- a/app/src/main/res/color/bg_detail_explore_chip_text_selector.xml
+++ b/app/src/main/res/color/bg_detail_explore_chip_text_selector.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:color="@color/primary_100_6A5DFD" android:state_selected="true" />
+    <item android:color="@color/gray_300_52515F" android:state_selected="false" />
+</selector>

--- a/app/src/main/res/layout/dialog_detail_explore.xml
+++ b/app/src/main/res/layout/dialog_detail_explore.xml
@@ -57,6 +57,7 @@
             android:layout_height="wrap_content"
             android:layout_marginTop="28dp"
             android:minHeight="540dp"
+            app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/view_detail_explore_selected_info" />

--- a/app/src/main/res/layout/fragment_detail_explore_info.xml
+++ b/app/src/main/res/layout/fragment_detail_explore_info.xml
@@ -55,14 +55,18 @@
 
             <com.google.android.material.chip.Chip
                 android:id="@+id/chip_detail_explore_info_status_in_series"
-                style="@style/DetailExploreInfo.Chip.Choice"
+                style="@style/HarryMoongChi.Chip.Choice"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
                 android:layout_weight="1"
                 android:checkable="true"
                 android:text="@string/detail_explore_info_status_in_series" />
 
             <com.google.android.material.chip.Chip
                 android:id="@+id/chip_detail_explore_info_status_complete"
-                style="@style/DetailExploreInfo.Chip.Choice"
+                style="@style/HarryMoongChi.Chip.Choice"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
                 android:layout_marginStart="12dp"
                 android:layout_weight="1"
                 android:checkable="true"
@@ -100,13 +104,17 @@
 
                 <com.google.android.material.chip.Chip
                     android:id="@+id/chip_detail_explore_info_rating_3_5"
-                    style="@style/DetailExploreInfo.Chip.Choice"
+                    style="@style/HarryMoongChi.Chip.Choice"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
                     android:layout_weight="1"
                     android:text="@string/detail_explore_info_rating_3_5" />
 
                 <com.google.android.material.chip.Chip
                     android:id="@+id/chip_detail_explore_info_rating_4_0"
-                    style="@style/DetailExploreInfo.Chip.Choice"
+                    style="@style/HarryMoongChi.Chip.Choice"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
                     android:layout_marginStart="12dp"
                     android:layout_weight="1"
                     android:text="@string/detail_explore_info_rating_4_0" />
@@ -119,13 +127,17 @@
 
                 <com.google.android.material.chip.Chip
                     android:id="@+id/chip_detail_explore_info_rating_4_5"
-                    style="@style/DetailExploreInfo.Chip.Choice"
+                    style="@style/HarryMoongChi.Chip.Choice"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
                     android:layout_weight="1"
                     android:text="@string/detail_explore_info_rating_4_5" />
 
                 <com.google.android.material.chip.Chip
                     android:id="@+id/chip_detail_explore_info_rating_4_8"
-                    style="@style/DetailExploreInfo.Chip.Choice"
+                    style="@style/HarryMoongChi.Chip.Choice"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
                     android:layout_marginStart="12dp"
                     android:layout_weight="1"
                     android:text="@string/detail_explore_info_rating_4_8" />

--- a/app/src/main/res/layout/fragment_detail_explore_info.xml
+++ b/app/src/main/res/layout/fragment_detail_explore_info.xml
@@ -2,6 +2,13 @@
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
+    <data>
+
+        <variable
+            name="detailExploreInfoviewModel"
+            type="com.teamwss.websoso.ui.detailExplore.info.DetailExploreInfoViewModel" />
+    </data>
+
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
@@ -108,7 +115,7 @@
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_weight="1"
-                    android:text="@string/detail_explore_info_rating_lowest" />
+                    android:text="@{String.format(@string/detail_explore_info_rating_lowest, detailExploreInfoviewModel.ratings[0])}" />
 
                 <com.google.android.material.chip.Chip
                     android:id="@+id/chip_detail_explore_info_rating_lower"
@@ -117,7 +124,7 @@
                     android:layout_height="wrap_content"
                     android:layout_marginStart="12dp"
                     android:layout_weight="1"
-                    android:text="@string/detail_explore_info_rating_lower" />
+                    android:text="@{String.format(@string/detail_explore_info_rating_lower, detailExploreInfoviewModel.ratings[1])}" />
             </LinearLayout>
 
             <LinearLayout
@@ -131,7 +138,7 @@
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_weight="1"
-                    android:text="@string/detail_explore_info_rating_higher" />
+                    android:text="@{String.format(@string/detail_explore_info_rating_higher, detailExploreInfoviewModel.ratings[2])}" />
 
                 <com.google.android.material.chip.Chip
                     android:id="@+id/chip_detail_explore_info_rating_highest"
@@ -140,7 +147,7 @@
                     android:layout_height="wrap_content"
                     android:layout_marginStart="12dp"
                     android:layout_weight="1"
-                    android:text="@string/detail_explore_info_rating_highest" />
+                    android:text="@{String.format(@string/detail_explore_info_rating_highest, detailExploreInfoviewModel.ratings[3])}" />
             </LinearLayout>
         </LinearLayout>
 

--- a/app/src/main/res/layout/fragment_detail_explore_info.xml
+++ b/app/src/main/res/layout/fragment_detail_explore_info.xml
@@ -54,19 +54,19 @@
             app:layout_constraintTop_toBottomOf="@id/tv_detail_explore_info_status">
 
             <com.google.android.material.chip.Chip
-                android:id="@+id/chip_detail_explore_info_status_ing"
+                android:id="@+id/chip_detail_explore_info_status_in_series"
                 style="@style/DetailExploreInfo.Chip.Choice"
                 android:layout_weight="1"
                 android:checkable="true"
-                android:text="@string/detail_explore_info_status_ing" />
+                android:text="@string/detail_explore_info_status_in_series" />
 
             <com.google.android.material.chip.Chip
-                android:id="@+id/chip_detail_explore_info_status_finish"
+                android:id="@+id/chip_detail_explore_info_status_complete"
                 style="@style/DetailExploreInfo.Chip.Choice"
                 android:layout_marginStart="12dp"
                 android:layout_weight="1"
                 android:checkable="true"
-                android:text="@string/detail_explore_info_status_finish" />
+                android:text="@string/detail_explore_info_status_complete" />
         </LinearLayout>
 
         <TextView

--- a/app/src/main/res/layout/fragment_detail_explore_info.xml
+++ b/app/src/main/res/layout/fragment_detail_explore_info.xml
@@ -42,16 +42,32 @@
             app:layout_constraintStart_toStartOf="@id/tv_detail_explore_info_genre"
             app:layout_constraintTop_toBottomOf="@id/wcg_detail_explore_info_genre" />
 
-        <com.teamwss.websoso.ui.common.customView.WebsosoChipGroup
-            android:id="@+id/wcg_detail_explore_info_status"
-            android:layout_width="0dp"
+        <LinearLayout
+            android:id="@+id/ll_detail_explore_info_status"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginHorizontal="20dp"
             android:layout_marginTop="8dp"
+            android:orientation="horizontal"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/tv_detail_explore_info_status"
-            app:singleSelection="true" />
+            app:layout_constraintTop_toBottomOf="@id/tv_detail_explore_info_status">
+
+            <com.google.android.material.chip.Chip
+                android:id="@+id/chip_detail_explore_info_status_ing"
+                style="@style/DetailExploreInfo.Chip.Choice"
+                android:layout_weight="1"
+                android:checkable="true"
+                android:text="@string/detail_explore_info_status_ing" />
+
+            <com.google.android.material.chip.Chip
+                android:id="@+id/chip_detail_explore_info_status_finish"
+                style="@style/DetailExploreInfo.Chip.Choice"
+                android:layout_marginStart="12dp"
+                android:layout_weight="1"
+                android:checkable="true"
+                android:text="@string/detail_explore_info_status_finish" />
+        </LinearLayout>
 
         <TextView
             android:id="@+id/tv_detail_explore_info_rating"
@@ -63,18 +79,58 @@
             android:textAppearance="@style/title2"
             android:textColor="@color/black"
             app:layout_constraintStart_toStartOf="@id/tv_detail_explore_info_genre"
-            app:layout_constraintTop_toBottomOf="@id/wcg_detail_explore_info_status" />
+            app:layout_constraintTop_toBottomOf="@id/ll_detail_explore_info_status" />
 
-        <com.teamwss.websoso.ui.common.customView.WebsosoChipGroup
-            android:id="@+id/wcg_detail_explore_info_rating"
-            android:layout_width="0dp"
+        <LinearLayout
+            android:id="@+id/ll_detail_explore_info_rating"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginHorizontal="20dp"
             android:layout_marginTop="8dp"
+            android:orientation="vertical"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/tv_detail_explore_info_rating"
-            app:singleSelection="true" />
+            app:layout_constraintTop_toBottomOf="@id/tv_detail_explore_info_rating">
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal"
+                android:paddingBottom="12dp">
+
+                <com.google.android.material.chip.Chip
+                    android:id="@+id/chip_detail_explore_info_rating_3_5"
+                    style="@style/DetailExploreInfo.Chip.Choice"
+                    android:layout_weight="1"
+                    android:text="@string/detail_explore_info_rating_3_5" />
+
+                <com.google.android.material.chip.Chip
+                    android:id="@+id/chip_detail_explore_info_rating_4_0"
+                    style="@style/DetailExploreInfo.Chip.Choice"
+                    android:layout_marginStart="12dp"
+                    android:layout_weight="1"
+                    android:text="@string/detail_explore_info_rating_4_0" />
+            </LinearLayout>
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal">
+
+                <com.google.android.material.chip.Chip
+                    android:id="@+id/chip_detail_explore_info_rating_4_5"
+                    style="@style/DetailExploreInfo.Chip.Choice"
+                    android:layout_weight="1"
+                    android:text="@string/detail_explore_info_rating_4_5" />
+
+                <com.google.android.material.chip.Chip
+                    android:id="@+id/chip_detail_explore_info_rating_4_8"
+                    style="@style/DetailExploreInfo.Chip.Choice"
+                    android:layout_marginStart="12dp"
+                    android:layout_weight="1"
+                    android:text="@string/detail_explore_info_rating_4_8" />
+            </LinearLayout>
+        </LinearLayout>
 
         <androidx.constraintlayout.widget.ConstraintLayout
             android:id="@+id/cl_detail_explore_info_reset_button"
@@ -85,7 +141,7 @@
             android:paddingVertical="20dp"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/wcg_detail_explore_info_rating">
+            app:layout_constraintTop_toBottomOf="@id/ll_detail_explore_info_rating">
 
             <ImageView
                 android:id="@+id/iv_detail_explore_info_reset"

--- a/app/src/main/res/layout/fragment_detail_explore_info.xml
+++ b/app/src/main/res/layout/fragment_detail_explore_info.xml
@@ -103,21 +103,21 @@
                 android:paddingBottom="12dp">
 
                 <com.google.android.material.chip.Chip
-                    android:id="@+id/chip_detail_explore_info_rating_3_5"
+                    android:id="@+id/chip_detail_explore_info_rating_lowest"
                     style="@style/HarryMoongChi.Chip.Choice"
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_weight="1"
-                    android:text="@string/detail_explore_info_rating_3_5" />
+                    android:text="@string/detail_explore_info_rating_lowest" />
 
                 <com.google.android.material.chip.Chip
-                    android:id="@+id/chip_detail_explore_info_rating_4_0"
+                    android:id="@+id/chip_detail_explore_info_rating_lower"
                     style="@style/HarryMoongChi.Chip.Choice"
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_marginStart="12dp"
                     android:layout_weight="1"
-                    android:text="@string/detail_explore_info_rating_4_0" />
+                    android:text="@string/detail_explore_info_rating_lower" />
             </LinearLayout>
 
             <LinearLayout
@@ -126,21 +126,21 @@
                 android:orientation="horizontal">
 
                 <com.google.android.material.chip.Chip
-                    android:id="@+id/chip_detail_explore_info_rating_4_5"
+                    android:id="@+id/chip_detail_explore_info_rating_higher"
                     style="@style/HarryMoongChi.Chip.Choice"
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_weight="1"
-                    android:text="@string/detail_explore_info_rating_4_5" />
+                    android:text="@string/detail_explore_info_rating_higher" />
 
                 <com.google.android.material.chip.Chip
-                    android:id="@+id/chip_detail_explore_info_rating_4_8"
+                    android:id="@+id/chip_detail_explore_info_rating_highest"
                     style="@style/HarryMoongChi.Chip.Choice"
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_marginStart="12dp"
                     android:layout_weight="1"
-                    android:text="@string/detail_explore_info_rating_4_8" />
+                    android:text="@string/detail_explore_info_rating_highest" />
             </LinearLayout>
         </LinearLayout>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -35,8 +35,8 @@
     <string name="detail_explore_info_genre">장르</string>
     <string name="detail_explore_info_status">연재상태</string>
     <string name="detail_explore_info_rating">별점</string>
-    <string name="detail_explore_info_status_ing">연재중</string>
-    <string name="detail_explore_info_status_finish">완결</string>
+    <string name="detail_explore_info_status_in_series">연재중</string>
+    <string name="detail_explore_info_status_complete">완결</string>
     <string name="detail_explore_info_rating_3_5">3.5이상</string>
     <string name="detail_explore_info_rating_4_0">4.0이상</string>
     <string name="detail_explore_info_rating_4_5">4.5이상</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -28,11 +28,19 @@
     <!-- 상세 탐색 뷰 -->
     <string name="detail_explore_info">정보</string>
     <string name="detail_explore_keyword">키워드</string>
+    <string name="detail_explore_reset">초기화</string>
+    <string name="detail_explore_search_novel">작품 찾기</string>
+
+    <!-- 상세 탐색 뷰(정보) -->
     <string name="detail_explore_info_genre">장르</string>
     <string name="detail_explore_info_status">연재상태</string>
     <string name="detail_explore_info_rating">별점</string>
-    <string name="detail_explore_reset">초기화</string>
-    <string name="detail_explore_search_novel">작품 찾기</string>
+    <string name="detail_explore_info_status_ing">연재중</string>
+    <string name="detail_explore_info_status_finish">완결</string>
+    <string name="detail_explore_info_rating_3_5">3.5이상</string>
+    <string name="detail_explore_info_rating_4_0">4.0이상</string>
+    <string name="detail_explore_info_rating_4_5">4.5이상</string>
+    <string name="detail_explore_info_rating_4_8">4.8이상</string>
 
     <!-- 작품 상세 -->
     <string name="novel_detail_review">리뷰 남기기</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -37,10 +37,10 @@
     <string name="detail_explore_info_rating">별점</string>
     <string name="detail_explore_info_status_in_series">연재중</string>
     <string name="detail_explore_info_status_complete">완결</string>
-    <string name="detail_explore_info_rating_3_5">3.5이상</string>
-    <string name="detail_explore_info_rating_4_0">4.0이상</string>
-    <string name="detail_explore_info_rating_4_5">4.5이상</string>
-    <string name="detail_explore_info_rating_4_8">4.8이상</string>
+    <string name="detail_explore_info_rating_lowest">%.1f이상</string>
+    <string name="detail_explore_info_rating_lower">%.1f이상</string>
+    <string name="detail_explore_info_rating_higher">%.1f이상</string>
+    <string name="detail_explore_info_rating_highest">%.1f이상</string>
 
     <!-- 작품 상세 -->
     <string name="novel_detail_review">리뷰 남기기</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -37,10 +37,10 @@
     <string name="detail_explore_info_rating">별점</string>
     <string name="detail_explore_info_status_in_series">연재중</string>
     <string name="detail_explore_info_status_complete">완결</string>
-    <string name="detail_explore_info_rating_lowest">%.1f이상</string>
-    <string name="detail_explore_info_rating_lower">%.1f이상</string>
-    <string name="detail_explore_info_rating_higher">%.1f이상</string>
-    <string name="detail_explore_info_rating_highest">%.1f이상</string>
+    <string name="detail_explore_info_rating_lowest">%1$.1f이상</string>
+    <string name="detail_explore_info_rating_lower">%1$.1f이상</string>
+    <string name="detail_explore_info_rating_higher">%1$.1f이상</string>
+    <string name="detail_explore_info_rating_highest">%1$.1f이상</string>
 
     <!-- 작품 상세 -->
     <string name="novel_detail_review">리뷰 남기기</string>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -1,11 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
-    <style name="DetailExploreInfo.Chip.Choice" parent="Widget.MaterialComponents.Chip.Choice">
+    <!-- custom view로 구현 예정으로, 추후 삭제 예정 스타일 -->
+    <style name="HarryMoongChi.Chip.Choice" parent="Widget.MaterialComponents.Chip.Choice">
         <item name="android:checkable">true</item>
         <item name="android:checked">false</item>
-        <item name="android:layout_width">0dp</item>
-        <item name="android:layout_height">wrap_content</item>
         <item name="android:paddingVertical">12dp</item>
         <item name="android:textAppearance">@style/body2</item>
         <item name="chipBackgroundColor">@color/bg_detail_explore_chip_background_selector</item>
@@ -15,6 +14,6 @@
         <item name="rippleColor">@null</item>
         <item name="chipMinTouchTargetSize">0dp</item>
         <item name="android:textColor">@color/bg_detail_explore_chip_text_selector</item>
-        <item name="chipCornerRadius">10dp</item>
+        <item name="chipCornerRadius">8dp</item>
     </style>
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <style name="DetailExploreInfo.Chip.Choice" parent="Widget.MaterialComponents.Chip.Choice">
+        <item name="android:checkable">true</item>
+        <item name="android:checked">false</item>
+        <item name="android:layout_width">0dp</item>
+        <item name="android:layout_height">wrap_content</item>
+        <item name="android:paddingVertical">12dp</item>
+        <item name="android:textAppearance">@style/body2</item>
+        <item name="chipBackgroundColor">@color/bg_detail_explore_chip_background_selector</item>
+        <item name="chipStrokeColor">@color/bg_detail_explore_chip_stroke_selector</item>
+        <item name="chipStrokeWidth">1dp</item>
+        <item name="android:textAlignment">center</item>
+        <item name="rippleColor">@null</item>
+        <item name="chipMinTouchTargetSize">0dp</item>
+        <item name="android:textColor">@color/bg_detail_explore_chip_text_selector</item>
+        <item name="chipCornerRadius">10dp</item>
+    </style>
+</resources>


### PR DESCRIPTION
## 📌𝘐𝘴𝘴𝘶𝘦𝘴
- closed #65 

## 📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯
- 상세 탐색 정보 칩 구현했습니다.
- 장르에서는 웹소소칩을, 그 외 연재상태 및 별점은 `Material Chip`을 사용했습니다. 
> 그 이유로는 장르는 변할 가능성이 있고, 웹소소칩을 사용하기 최적화 된 ui 였지만, 연재상태 및 별점 같은 경우엔 부모 너비를 기준으로 너비가 반반이 되어야 하는 이슈를 가져서 xml에서 구현하는 것이 더 맞겠다고 판단하여 `MaterialChip` 을 사용했습니다.
- 근데 왜 `ChipGroup` SingleSelection 사용하지 않고, 로직을 구현했나요? 라고 물으신다면 위에서도 말했듯이 너비를 반반 무많이로 가져가는 게 레이아웃에 포함시키지 않고는 구현을 할 수가 없었습니다.
 GhipGroup 
    - layout
       - chip
       - chip
이 될 경우에는 chipGroup의 `singleSelection` 로직이 먹지 않아서 따로 구현했습니다.
- `TextView`를 쓸 생각도 있었는데 `chip` 사용해서 선택했을 때 ui 구현하는 게 style 사용해서 더 깔끔하고, 재사용할 수 있겠다는 생각이 들어서 `chip` 사용했습니다.
- 여러 고민이 있었는데 더 나은 생각이 떠오르신다면 저에게 알려주시와요
## 📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵

https://github.com/Team-WSS/WSS-Android/assets/114990782/9275f729-9dc4-47c1-b6cc-1243019a261e

## 💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴
- 추후 구현할 예정인 것들에 대해서 // TODO 주석 달아놨습니다.
- 다음 작업으로 바로 진행 예정입니다.

> 
<img width="177" alt="스크린샷 2024-06-28 오후 11 13 44" src="https://github.com/Team-WSS/WSS-Android/assets/114990782/ce5e9a01-ec59-4645-ade0-bb223b279f32">

이렇게 radius가 8dp이고, 선택됐을 때 저렇게 뜨는 칩들은 제가 PR에 구현해놓은 style을 사용할 수 있습니다!
xml에서 따로 chip 속성을 부여해주어야 하는 것은 width, height, text값이면 되는데 ^.^ 커스텀뷰 칩 만드는 거 이슈 파서 나중에 할게욥 ^^ ㅎㅎ