### PR TITLE
refactor: 좋아요 기능 리팩터링

### DIFF
--- a/app/src/main/java/com/teamwss/websoso/data/remote/api/FeedApi.kt
+++ b/app/src/main/java/com/teamwss/websoso/data/remote/api/FeedApi.kt
@@ -2,8 +2,12 @@ package com.teamwss.websoso.data.remote.api
 
 import com.teamwss.websoso.data.remote.request.FeedsRequestDto
 import com.teamwss.websoso.data.remote.response.FeedsResponseDto
+import retrofit2.Response
 import retrofit2.http.Body
+import retrofit2.http.DELETE
 import retrofit2.http.GET
+import retrofit2.http.POST
+import retrofit2.http.Path
 import retrofit2.http.Query
 
 interface FeedApi {
@@ -18,4 +22,14 @@ interface FeedApi {
         @Query("category") category: String,
         @Body feedsRequestDto: FeedsRequestDto,
     ): FeedsResponseDto
+
+    @POST("feeds/{feedId}/likes")
+    suspend fun postLikes(
+        @Path("feedId") feedId: Long,
+    ): Response<Unit>
+
+    @DELETE("feeds/{feedId}/likes")
+    suspend fun deleteLikes(
+        @Path("feedId") feedId: Long,
+    ): Response<Unit>
 }

--- a/app/src/main/java/com/teamwss/websoso/data/repository/DefaultFeedRepository.kt
+++ b/app/src/main/java/com/teamwss/websoso/data/repository/DefaultFeedRepository.kt
@@ -4,12 +4,17 @@ import com.teamwss.websoso.data.FakeApi
 import com.teamwss.websoso.data.mapper.toData
 import com.teamwss.websoso.data.model.FeedEntity
 import com.teamwss.websoso.data.model.FeedsEntity
+import com.teamwss.websoso.data.remote.api.FeedApi
 import com.teamwss.websoso.data.remote.request.FeedsRequestDto
+import retrofit2.Response
 import javax.inject.Inject
 
 class DefaultFeedRepository @Inject constructor() {
     private val _cachedFeeds: MutableList<FeedEntity> = mutableListOf()
     val cachedFeeds: List<FeedEntity> get() = _cachedFeeds.toList()
+
+    @Inject
+    private lateinit var feedApi: FeedApi
 
     suspend fun fetchFeeds(category: String, lastFeedId: Long, size: Int): FeedsEntity {
         val requestBody = FeedsRequestDto(lastFeedId = lastFeedId, size = size)
@@ -23,6 +28,13 @@ class DefaultFeedRepository @Inject constructor() {
                 _cachedFeeds.addAll(it.feeds)
             }
             .copy(feeds = cachedFeeds)
+    }
+
+    suspend fun saveLike(isLikedOfLikedFeed: Boolean, selectedFeedId: Long): Response<Unit> {
+        return when (isLikedOfLikedFeed) {
+            true -> feedApi.deleteLikes(selectedFeedId)
+            false -> feedApi.postLikes(selectedFeedId)
+        }
     }
 
     fun clearCachedFeeds() {

--- a/app/src/main/java/com/teamwss/websoso/ui/feed/FeedFragment.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/feed/FeedFragment.kt
@@ -7,6 +7,7 @@ import android.view.View
 import android.view.ViewGroup
 import android.view.WindowManager
 import android.widget.PopupWindow
+import android.widget.TextView
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
 import com.teamwss.websoso.R
@@ -59,7 +60,14 @@ class FeedFragment : BindingFragment<FragmentFeedBinding>(R.layout.fragment_feed
             // navigateToNovelDetail(id)
         }
 
+        @SuppressLint("CutPasteId")
         override fun onLikeButtonClick(view: View, id: Long) {
+            val likeCount: String = view.findViewById<TextView>(R.id.tv_feed_thumb_up_count).text.toString()
+            view.findViewById<TextView>(R.id.tv_feed_thumb_up_count).text =
+                when (view.isSelected) {
+                    true ->  (likeCount.toInt() - 1).toString()
+                    false -> (likeCount.toInt() + 1).toString()
+                }
             view.isSelected = !view.isSelected
 
             singleEventHandler.debounce(coroutineScope = lifecycleScope) {
@@ -160,11 +168,6 @@ class FeedFragment : BindingFragment<FragmentFeedBinding>(R.layout.fragment_feed
             true -> feedAdapter.submitList(feeds + Loading)
             false -> feedAdapter.submitList(feeds)
         }
-    }
-
-    override fun onStop() {
-        super.onStop()
-        feedViewModel.saveLikeCount()
     }
 
     override fun onDestroyView() {

--- a/app/src/main/java/com/teamwss/websoso/ui/feed/FeedFragment.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/feed/FeedFragment.kt
@@ -71,7 +71,7 @@ class FeedFragment : BindingFragment<FragmentFeedBinding>(R.layout.fragment_feed
             view.isSelected = !view.isSelected
 
             singleEventHandler.debounce(coroutineScope = lifecycleScope) {
-                feedViewModel.updateLikeCount(view.isSelected, id)
+                feedViewModel.updateLike(view.isSelected, id)
             }
         }
 

--- a/app/src/main/java/com/teamwss/websoso/ui/feed/FeedFragment.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/feed/FeedFragment.kt
@@ -60,18 +60,20 @@ class FeedFragment : BindingFragment<FragmentFeedBinding>(R.layout.fragment_feed
             // navigateToNovelDetail(id)
         }
 
-        @SuppressLint("CutPasteId")
         override fun onLikeButtonClick(view: View, id: Long) {
-            val likeCount: String = view.findViewById<TextView>(R.id.tv_feed_thumb_up_count).text.toString()
+            val likeCount: String =
+                view.findViewById<TextView>(R.id.tv_feed_thumb_up_count).text.toString()
+            val updatedLikeCount: Int = when (view.isSelected) {
+                true -> (likeCount.toInt() - 1)
+                false -> (likeCount.toInt() + 1)
+            }
+
             view.findViewById<TextView>(R.id.tv_feed_thumb_up_count).text =
-                when (view.isSelected) {
-                    true ->  (likeCount.toInt() - 1).toString()
-                    false -> (likeCount.toInt() + 1).toString()
-                }
+                updatedLikeCount.toString()
             view.isSelected = !view.isSelected
 
             singleEventHandler.debounce(coroutineScope = lifecycleScope) {
-                feedViewModel.updateLike(view.isSelected, id)
+                feedViewModel.updateLike(id, view.isSelected, updatedLikeCount)
             }
         }
 
@@ -133,6 +135,7 @@ class FeedFragment : BindingFragment<FragmentFeedBinding>(R.layout.fragment_feed
     private fun setupAdapter() {
         binding.rvFeed.apply {
             adapter = feedAdapter
+            itemAnimator = null
             addOnScrollListener(
                 FeedScrollListener.of(
                     singleEventHandler = singleEventHandler,

--- a/app/src/main/java/com/teamwss/websoso/ui/feed/FeedFragment.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/feed/FeedFragment.kt
@@ -61,11 +61,11 @@ class FeedFragment : BindingFragment<FragmentFeedBinding>(R.layout.fragment_feed
         }
 
         override fun onLikeButtonClick(view: View, id: Long) {
-            val likeCount: String =
-                view.findViewById<TextView>(R.id.tv_feed_thumb_up_count).text.toString()
+            val likeCount: Int =
+                view.findViewById<TextView>(R.id.tv_feed_thumb_up_count).text.toString().toInt()
             val updatedLikeCount: Int = when (view.isSelected) {
-                true -> (likeCount.toInt() - 1)
-                false -> (likeCount.toInt() + 1)
+                true -> if (likeCount > 0) likeCount - 1 else 0
+                false -> likeCount + 1
             }
 
             view.findViewById<TextView>(R.id.tv_feed_thumb_up_count).text =

--- a/app/src/main/java/com/teamwss/websoso/ui/feed/FeedScrollListener.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/feed/FeedScrollListener.kt
@@ -7,9 +7,9 @@ import com.teamwss.websoso.ui.feed.adapter.FeedType
 import com.teamwss.websoso.util.SingleEventHandler
 
 class FeedScrollListener private constructor(
+    private val singleEventHandler: SingleEventHandler,
     private val loadAdditionalFeeds: () -> Unit,
 ) : RecyclerView.OnScrollListener() {
-    private val singleEventHandler: SingleEventHandler by lazy { SingleEventHandler.from() }
 
     override fun onScrollStateChanged(recyclerView: RecyclerView, newState: Int) {
         if ((recyclerView.adapter as FeedAdapter).currentList.last() !is FeedType.Loading) return
@@ -20,11 +20,14 @@ class FeedScrollListener private constructor(
             (recyclerView.layoutManager as LinearLayoutManager).findLastCompletelyVisibleItemPosition()
 
         if (visibleLastItemPosition in totalItemCount - 2..totalItemCount)
-            singleEventHandler.handle(event = loadAdditionalFeeds)
+            singleEventHandler.throttleFirst { loadAdditionalFeeds() }
     }
 
     companion object {
 
-        fun from(event: () -> Unit): FeedScrollListener = FeedScrollListener(event)
+        fun of(
+            singleEventHandler: SingleEventHandler,
+            event: () -> Unit,
+        ): FeedScrollListener = FeedScrollListener(singleEventHandler, event)
     }
 }

--- a/app/src/main/java/com/teamwss/websoso/ui/feed/FeedViewModel.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/feed/FeedViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.teamwss.websoso.data.repository.DefaultFeedRepository
 import com.teamwss.websoso.data.repository.FakeUserRepository
 import com.teamwss.websoso.domain.usecase.GetFeedsUseCase
 import com.teamwss.websoso.ui.feed.model.Category
@@ -17,6 +18,7 @@ import javax.inject.Inject
 @HiltViewModel
 class FeedViewModel @Inject constructor(
     private val getFeedsUseCase: GetFeedsUseCase,
+    private val feedRepository: DefaultFeedRepository,
     fakeUserRepository: FakeUserRepository,
 ) : ViewModel() {
     private val _categories: MutableList<CategoryModel> = mutableListOf()
@@ -54,45 +56,60 @@ class FeedViewModel @Inject constructor(
     }
 
     fun updateFeeds() {
-        viewModelScope.launch {
-            val selectedCategory: Category =
-                categories.find { it.isSelected }?.category ?: throw IllegalStateException()
+        feedUiState.value?.let { feedUiState ->
+            viewModelScope.launch {
+                val selectedCategory: Category =
+                    categories.find { it.isSelected }?.category ?: throw IllegalStateException()
 
-            runCatching {
-                getFeedsUseCase(selectedCategory.titleEn)
-            }.onSuccess { feeds ->
-                if (feeds.category != selectedCategory.titleEn) throw IllegalStateException()
-                // Return result state of error in domain layer later
-                feedUiState.value?.let { uiState ->
-                    _feedUiState.value = uiState.copy(
+                runCatching {
+                    getFeedsUseCase(selectedCategory.titleEn)
+                }.onSuccess { feeds ->
+                    if (feeds.category != selectedCategory.titleEn) throw IllegalStateException()
+                    // Return result state of error in domain layer later
+
+                    _feedUiState.value = feedUiState.copy(
                         loading = false,
                         isLoadable = feeds.isLoadable,
                         feeds = feeds.feeds.map { it.toPresentation() },
                     )
+                }.onFailure {
+                    _feedUiState.value = feedUiState.copy(
+                        loading = false,
+                        error = true,
+                    )
                 }
-            }.onFailure {
-                _feedUiState.value = feedUiState.value?.copy(
-                    loading = false,
-                    error = true,
-                )
             }
         }
     }
 
-    fun updateLikeCount(isSelected: Boolean, selectedFeedId: Long) {
-        val uiState = feedUiState.value ?: throw IllegalArgumentException()
-        val count = if (isSelected) -1 else 1
-        val updatedFeeds = uiState.feeds.map { feed ->
-            feed.takeIf { feed.id == selectedFeedId }?.copy(
-                likeCount = feed.likeCount + count,
-                isLiked = !isSelected
-            ) ?: feed
-        }
-        _feedUiState.value = uiState.copy(feeds = updatedFeeds)
-    }
+    fun updateLike(isLiked: Boolean, selectedFeedId: Long) {
+        feedUiState.value?.let { feedUiState ->
+            val selectedFeed = feedUiState.feeds.find { feedModel ->
+                feedModel.id == selectedFeedId
+            } ?: throw IllegalArgumentException()
 
-    fun saveLikeCount() {
-        // 좋아요 API
+            if (selectedFeed.isLiked == isLiked) return
+
+            viewModelScope.launch {
+                runCatching {
+                    feedRepository.saveLike(selectedFeed.isLiked, selectedFeedId)
+                }.onSuccess {
+                    _feedUiState.value = feedUiState.copy(
+                        feeds = feedUiState.feeds.map { feedModel ->
+                            when (feedModel.id == selectedFeedId) {
+                                true -> feedModel.copy(isLiked = isLiked)
+                                false -> feedModel
+                            }
+                        }
+                    )
+                }.onFailure {
+                    _feedUiState.value = feedUiState.copy(
+                        loading = false,
+                        error = true,
+                    )
+                }
+            }
+        }
     }
 
     fun saveBlockedUser(userId: Long) {

--- a/app/src/main/java/com/teamwss/websoso/ui/feed/FeedViewModel.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/feed/FeedViewModel.kt
@@ -82,7 +82,7 @@ class FeedViewModel @Inject constructor(
         }
     }
 
-    fun updateLike(isLiked: Boolean, selectedFeedId: Long) {
+    fun updateLike(selectedFeedId: Long, isLiked: Boolean, updatedLikeCount: Int) {
         feedUiState.value?.let { feedUiState ->
             val selectedFeed = feedUiState.feeds.find { feedModel ->
                 feedModel.id == selectedFeedId
@@ -97,7 +97,11 @@ class FeedViewModel @Inject constructor(
                     _feedUiState.value = feedUiState.copy(
                         feeds = feedUiState.feeds.map { feedModel ->
                             when (feedModel.id == selectedFeedId) {
-                                true -> feedModel.copy(isLiked = isLiked)
+                                true -> feedModel.copy(
+                                    isLiked = isLiked,
+                                    likeCount = updatedLikeCount,
+                                )
+
                                 false -> feedModel
                             }
                         }

--- a/app/src/main/java/com/teamwss/websoso/util/SingleEventHandler.kt
+++ b/app/src/main/java/com/teamwss/websoso/util/SingleEventHandler.kt
@@ -1,25 +1,42 @@
 package com.teamwss.websoso.util
 
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.TimeMark
 import kotlin.time.TimeSource
 
 class SingleEventHandler private constructor() {
-    private val currentTime: TimeMark get() = TimeSource.Monotonic.markNow()
     private lateinit var lastEventTime: TimeMark
+    private lateinit var debounceJob: Job
 
-    fun handle(
-        timeMillis: Long = 500L,
+    fun throttleFirst(
+        timeMillis: Long = DEFAULT_TIME_MILLIS,
         event: () -> Unit,
     ) {
         if (::lastEventTime.isInitialized.not() ||
             (lastEventTime + timeMillis.milliseconds).hasPassedNow()
         ) event()
 
-        lastEventTime = currentTime
+        lastEventTime = TimeSource.Monotonic.markNow()
+    }
+
+    fun debounce(
+        timeMillis: Long = DEFAULT_TIME_MILLIS,
+        coroutineScope: CoroutineScope,
+        event: () -> Unit,
+    ) {
+        if (::debounceJob.isInitialized) debounceJob.cancel()
+        debounceJob = coroutineScope.launch {
+            delay(timeMillis)
+            event()
+        }
     }
 
     companion object {
+        private const val DEFAULT_TIME_MILLIS = 500L
 
         fun from(): SingleEventHandler = SingleEventHandler()
     }


### PR DESCRIPTION
## 📌𝘐𝘴𝘴𝘶𝘦𝘴
- closed #35  

## 📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯
- 피드에서의 좋아요 기능 구현했읍니다 

## 📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵
[Screen_recording_20240714_040211.webm](https://github.com/user-attachments/assets/51d483ff-0fe0-43f1-b4b2-7836991f020f)

## 💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴
낙관적UI를 구현하기 위해 클릭리스너에서 즉각 뷰를 업데이트 하도록 해주었습니다.

(원래라면 뷰모델의 상태 업데이트 -> 옵저빙 -> 뷰홀더 업데이트) 과정을 반복해야하는데,
 짧은 시간내에 여러번 클릭할 경우 state를 계속 생성-업데이트 하는게 비효율적이라고 생각했습니다.
(그렇다고 뷰모델에 SingleEventHandler를 적용하는 것도 이상...)

따라서 조금 코드가..더럽지만 즉각적으로 UI를 업데이트 시켜주며, 구현된 Debounce를 통해 마지막 이벤트를 기점으로 0.5초간 이벤트 재발생이 없다면 좋아요API를 호출합니다.
(디바운스와 쓰로틀 차이는 무한스크롤 PR 참고바랍니다.)