### PR TITLE
feat: 성별/나이 변경 ui 구현

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -83,5 +83,9 @@
             android:name=".ui.profileDisclosure.ProfileDisclosureActivity"
             android:exported="false"
             android:screenOrientation="portrait" />
+        <activity
+            android:name=".ui.changeGenderAndAge.ChangeGenderAndAgeActivity"
+            android:exported="false"
+            android:screenOrientation="portrait" />
     </application>
 </manifest>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -75,7 +75,7 @@
             android:exported="false"
             android:screenOrientation="portrait" />
         <activity
-            android:name=".accountInfo.AccountInfoActivity"
+            android:name=".ui.accountInfo.AccountInfoActivity"
             android:exported="false"
             android:screenOrientation="portrait" />
 

--- a/app/src/main/java/com/teamwss/websoso/ui/accountInfo/AccountInfoActivity.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/accountInfo/AccountInfoActivity.kt
@@ -15,6 +15,7 @@ class AccountInfoActivity :
         super.onCreate(savedInstanceState)
 
         setupTranslucentOnStatusBar()
+        onBackButtonClick()
     }
 
     private fun setupTranslucentOnStatusBar() {
@@ -22,6 +23,12 @@ class AccountInfoActivity :
             WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS,
             WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS,
         )
+    }
+
+    private fun onBackButtonClick() {
+        binding.ivAccountInfoBackButton.setOnClickListener {
+            finish()
+        }
     }
 
     companion object {

--- a/app/src/main/java/com/teamwss/websoso/ui/accountInfo/AccountInfoActivity.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/accountInfo/AccountInfoActivity.kt
@@ -1,4 +1,4 @@
-package com.teamwss.websoso.accountInfo
+package com.teamwss.websoso.ui.accountInfo
 
 import android.content.Context
 import android.content.Intent

--- a/app/src/main/java/com/teamwss/websoso/ui/changeGenderAndAge/ChangeBirthYearBottomSheetDialog.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/changeGenderAndAge/ChangeBirthYearBottomSheetDialog.kt
@@ -1,0 +1,56 @@
+package com.teamwss.websoso.ui.changeGenderAndAge
+
+import android.os.Bundle
+import android.view.View
+import com.google.android.material.bottomsheet.BottomSheetBehavior
+import com.google.android.material.bottomsheet.BottomSheetDialog
+import com.teamwss.websoso.R
+import com.teamwss.websoso.databinding.DialogOnboardingBirthYearBinding
+import com.teamwss.websoso.ui.common.base.BindingBottomSheetDialog
+import java.time.LocalDate
+
+class ChangeBirthYearBottomSheetDialog :
+    BindingBottomSheetDialog<DialogOnboardingBirthYearBinding>(R.layout.dialog_onboarding_birth_year) {
+
+    override fun onViewCreated(
+        view: View,
+        savedInstanceState: Bundle?,
+    ) {
+        super.onViewCreated(view, savedInstanceState)
+
+        setupDialogBehavior()
+        setupNumberPicker()
+        setupListeners()
+    }
+
+    private fun setupDialogBehavior() {
+        (dialog as BottomSheetDialog).behavior.state = BottomSheetBehavior.STATE_EXPANDED
+        (dialog as BottomSheetDialog).behavior.skipCollapsed = true
+    }
+
+    private fun setupNumberPicker() {
+        val numberPicker = binding.npOnboardingSecondBottomSheetBirthYear
+        numberPicker.apply {
+            minValue = MIN_BIRTH_YEAR
+            maxValue = MAX_BIRTH_YEAR
+            value = INIT_BIRTH_YEAR
+        }
+    }
+
+    private fun setupListeners() {
+        binding.btnOnboardingSecondBottomSheetComplete.setOnClickListener {
+            val selectedYear = binding.npOnboardingSecondBottomSheetBirthYear.value
+            dismiss()
+        }
+
+        binding.ivOnboardingSecondBottomSheetCancel.setOnClickListener {
+            dismiss()
+        }
+    }
+
+    companion object {
+        private var MAX_BIRTH_YEAR: Int = LocalDate.now().year
+        private const val MIN_BIRTH_YEAR: Int = 1900
+        private const val INIT_BIRTH_YEAR: Int = 2000
+    }
+}

--- a/app/src/main/java/com/teamwss/websoso/ui/changeGenderAndAge/ChangeGenderAndAgeActivity.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/changeGenderAndAge/ChangeGenderAndAgeActivity.kt
@@ -5,6 +5,7 @@ import android.view.WindowManager
 import com.teamwss.websoso.R
 import com.teamwss.websoso.databinding.ActivityChangeGenderAndAgeBinding
 import com.teamwss.websoso.ui.common.base.BindingActivity
+import com.teamwss.websoso.ui.onboarding.OnboardingBirthYearBottomSheetDialog
 
 class ChangeGenderAndAgeActivity :
     BindingActivity<ActivityChangeGenderAndAgeBinding>(R.layout.activity_change_gender_and_age) {
@@ -13,6 +14,7 @@ class ChangeGenderAndAgeActivity :
         super.onCreate(savedInstanceState)
 
         setupTranslucentOnStatusBar()
+        onChangeBirthYearClickButton()
     }
 
     private fun setupTranslucentOnStatusBar() {
@@ -20,5 +22,26 @@ class ChangeGenderAndAgeActivity :
             WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS,
             WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS,
         )
+    }
+
+    private fun onChangeBirthYearClickButton() {
+        binding.clChangeGenderAndAgeBirthYear.setOnClickListener {
+            showBirthYearBottomSheetDialog()
+        }
+    }
+
+    private fun showBirthYearBottomSheetDialog() {
+        val existingDialog =
+            supportFragmentManager.findFragmentByTag(BIRTH_YEAR_BOTTOM_SHEET_DIALOG_TAG)
+        if (existingDialog == null) {
+            OnboardingBirthYearBottomSheetDialog().show(
+                supportFragmentManager,
+                BIRTH_YEAR_BOTTOM_SHEET_DIALOG_TAG,
+            )
+        }
+    }
+
+    companion object {
+        private const val BIRTH_YEAR_BOTTOM_SHEET_DIALOG_TAG = "BirthYearBottomSheetDialog"
     }
 }

--- a/app/src/main/java/com/teamwss/websoso/ui/changeGenderAndAge/ChangeGenderAndAgeActivity.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/changeGenderAndAge/ChangeGenderAndAgeActivity.kt
@@ -1,6 +1,7 @@
 package com.teamwss.websoso.ui.changeGenderAndAge
 
 import android.os.Bundle
+import android.view.WindowManager
 import com.teamwss.websoso.R
 import com.teamwss.websoso.databinding.ActivityChangeGenderAndAgeBinding
 import com.teamwss.websoso.ui.common.base.BindingActivity
@@ -10,5 +11,14 @@ class ChangeGenderAndAgeActivity :
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
+        setupTranslucentOnStatusBar()
+    }
+
+    private fun setupTranslucentOnStatusBar() {
+        window.setFlags(
+            WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS,
+            WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS,
+        )
     }
 }

--- a/app/src/main/java/com/teamwss/websoso/ui/changeGenderAndAge/ChangeGenderAndAgeActivity.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/changeGenderAndAge/ChangeGenderAndAgeActivity.kt
@@ -1,0 +1,14 @@
+package com.teamwss.websoso.ui.changeGenderAndAge
+
+import android.os.Bundle
+import com.teamwss.websoso.R
+import com.teamwss.websoso.databinding.ActivityChangeGenderAndAgeBinding
+import com.teamwss.websoso.ui.common.base.BindingActivity
+
+class ChangeGenderAndAgeActivity :
+    BindingActivity<ActivityChangeGenderAndAgeBinding>(R.layout.activity_change_gender_and_age) {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+    }
+}

--- a/app/src/main/java/com/teamwss/websoso/ui/myPage/MyPageFragment.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/myPage/MyPageFragment.kt
@@ -9,6 +9,7 @@ import com.teamwss.websoso.R
 import com.teamwss.websoso.databinding.FragmentMyPageBinding
 import com.teamwss.websoso.ui.common.base.BindingFragment
 import com.teamwss.websoso.ui.myPage.adapter.MyPageViewPagerAdapter
+import com.teamwss.websoso.ui.setting.SettingActivity
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
@@ -19,6 +20,7 @@ class MyPageFragment : BindingFragment<FragmentMyPageBinding>(R.layout.fragment_
         super.onViewCreated(view, savedInstanceState)
         setUpViewPager()
         setUpItemVisibilityOnToolBar()
+        onSettingButtonClick()
     }
 
     private fun setUpViewPager() {
@@ -51,6 +53,13 @@ class MyPageFragment : BindingFragment<FragmentMyPageBinding>(R.layout.fragment_
 
             tvMyPageStickyTitle.isVisible = isCollapsed
             clMyPageUserProfile.isVisible = !isCollapsed
+        }
+    }
+
+    private fun onSettingButtonClick() {
+        binding.ivMyPageStickyGoToSetting.setOnClickListener {
+            val intent = SettingActivity.getIntent(requireContext())
+            startActivity(intent)
         }
     }
 

--- a/app/src/main/java/com/teamwss/websoso/ui/onboarding/second/OnboardingSecondFragment.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/onboarding/second/OnboardingSecondFragment.kt
@@ -69,6 +69,6 @@ class OnboardingSecondFragment :
     }
 
     companion object {
-        private const val BIRTH_YEAR_BOTTOM_SHEET_DIALOG_TAG = "BrithYearBottomSheetDialog"
+        private const val BIRTH_YEAR_BOTTOM_SHEET_DIALOG_TAG = "BirthYearBottomSheetDialog"
     }
 }

--- a/app/src/main/java/com/teamwss/websoso/ui/profileDisclosure/ProfileDisclosureActivity.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/profileDisclosure/ProfileDisclosureActivity.kt
@@ -15,6 +15,7 @@ class ProfileDisclosureActivity :
         super.onCreate(savedInstanceState)
 
         setupTranslucentOnStatusBar()
+        onBackButtonClick()
     }
 
     private fun setupTranslucentOnStatusBar() {
@@ -22,6 +23,12 @@ class ProfileDisclosureActivity :
             WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS,
             WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS,
         )
+    }
+
+    private fun onBackButtonClick() {
+        binding.ivProfileDisclosureBackButton.setOnClickListener {
+            finish()
+        }
     }
 
     companion object {

--- a/app/src/main/java/com/teamwss/websoso/ui/profileDisclosure/ProfileDisclosureActivity.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/profileDisclosure/ProfileDisclosureActivity.kt
@@ -1,5 +1,7 @@
 package com.teamwss.websoso.ui.profileDisclosure
 
+import android.content.Context
+import android.content.Intent
 import android.os.Bundle
 import android.view.WindowManager
 import com.teamwss.websoso.R
@@ -20,5 +22,12 @@ class ProfileDisclosureActivity :
             WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS,
             WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS,
         )
+    }
+
+    companion object {
+
+        fun getIntent(context: Context): Intent {
+            return Intent(context, ProfileDisclosureActivity::class.java)
+        }
     }
 }

--- a/app/src/main/java/com/teamwss/websoso/ui/setting/SettingActivity.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/setting/SettingActivity.kt
@@ -1,5 +1,7 @@
 package com.teamwss.websoso.ui.setting
 
+import android.content.Context
+import android.content.Intent
 import android.os.Bundle
 import android.view.WindowManager
 import com.teamwss.websoso.R
@@ -19,5 +21,12 @@ class SettingActivity : BindingActivity<ActivitySettingBinding>(R.layout.activit
             WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS,
             WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS,
         )
+    }
+
+    companion object {
+
+        fun getIntent(context: Context): Intent {
+            return Intent(context, SettingActivity::class.java)
+        }
     }
 }

--- a/app/src/main/java/com/teamwss/websoso/ui/setting/SettingActivity.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/setting/SettingActivity.kt
@@ -6,7 +6,9 @@ import android.os.Bundle
 import android.view.WindowManager
 import com.teamwss.websoso.R
 import com.teamwss.websoso.databinding.ActivitySettingBinding
+import com.teamwss.websoso.ui.accountInfo.AccountInfoActivity
 import com.teamwss.websoso.ui.common.base.BindingActivity
+import com.teamwss.websoso.ui.profileDisclosure.ProfileDisclosureActivity
 
 class SettingActivity : BindingActivity<ActivitySettingBinding>(R.layout.activity_setting) {
 
@@ -14,6 +16,7 @@ class SettingActivity : BindingActivity<ActivitySettingBinding>(R.layout.activit
         super.onCreate(savedInstanceState)
 
         setupTranslucentOnStatusBar()
+        bindClickListener()
     }
 
     private fun setupTranslucentOnStatusBar() {
@@ -21,6 +24,40 @@ class SettingActivity : BindingActivity<ActivitySettingBinding>(R.layout.activit
             WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS,
             WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS,
         )
+    }
+
+    private fun bindClickListener() {
+        binding.onClick = onSettingClickListener()
+        binding.lifecycleOwner = this
+    }
+
+    private fun onSettingClickListener() = object : SettingClickListener {
+
+        override fun onUserAccountInfoButtonClick() {
+            val intent = AccountInfoActivity.getIntent(this@SettingActivity)
+            startActivity(intent)
+        }
+
+        override fun onProfileDisclosureButtonClick() {
+            val intent = ProfileDisclosureActivity.getIntent(this@SettingActivity)
+            startActivity(intent)
+        }
+
+        override fun onWebsosoOfficialButtonClick() {
+            // TODO 웹소소 공식 계정으로 연결
+        }
+
+        override fun onInquireAndFeedbackButtonClick() {
+            // TODO 문의하기 / 피드백으로 연결
+        }
+
+        override fun onAppRatingButtonClick() {
+            // TODO 별점 남기기로 이동
+        }
+
+        override fun onTermsOfUseButtonClick() {
+            // TODO 서비스 이용약관으로 이동
+        }
     }
 
     companion object {

--- a/app/src/main/java/com/teamwss/websoso/ui/setting/SettingActivity.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/setting/SettingActivity.kt
@@ -58,6 +58,10 @@ class SettingActivity : BindingActivity<ActivitySettingBinding>(R.layout.activit
         override fun onTermsOfUseButtonClick() {
             // TODO 서비스 이용약관으로 이동
         }
+
+        override fun onBackButtonClick() {
+            finish()
+        }
     }
 
     companion object {

--- a/app/src/main/java/com/teamwss/websoso/ui/setting/SettingClickListener.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/setting/SettingClickListener.kt
@@ -13,4 +13,6 @@ interface SettingClickListener {
     fun onAppRatingButtonClick()
 
     fun onTermsOfUseButtonClick()
+
+    fun onBackButtonClick()
 }

--- a/app/src/main/java/com/teamwss/websoso/ui/setting/SettingClickListener.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/setting/SettingClickListener.kt
@@ -1,0 +1,16 @@
+package com.teamwss.websoso.ui.setting
+
+interface SettingClickListener {
+
+    fun onUserAccountInfoButtonClick()
+
+    fun onProfileDisclosureButtonClick()
+
+    fun onWebsosoOfficialButtonClick()
+
+    fun onInquireAndFeedbackButtonClick()
+
+    fun onAppRatingButtonClick()
+
+    fun onTermsOfUseButtonClick()
+}

--- a/app/src/main/res/layout/activity_change_gender_and_age.xml
+++ b/app/src/main/res/layout/activity_change_gender_and_age.xml
@@ -1,0 +1,131 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:background="@color/white">
+
+        <ImageView
+            android:id="@+id/iv_change_gender_and_age_back_button"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="12dp"
+            android:layout_marginTop="64dp"
+            android:contentDescription="@null"
+            android:paddingHorizontal="8dp"
+            android:paddingVertical="4dp"
+            android:src="@drawable/btn_setting_back"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <TextView
+            android:id="@+id/tv_change_gender_and_age_title"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/account_info_change_gender_and_age"
+            android:textAppearance="@style/title2"
+            android:textColor="@color/black"
+            app:layout_constraintBottom_toBottomOf="@id/iv_change_gender_and_age_back_button"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="@id/iv_change_gender_and_age_back_button" />
+
+        <TextView
+            android:id="@+id/tv_change_gender_and_age_user_gender"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="20dp"
+            android:layout_marginTop="40dp"
+            android:text="@string/onboarding_second_gender"
+            android:textAppearance="@style/body2"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/tv_change_gender_and_age_title" />
+
+        <LinearLayout
+            android:id="@+id/ll_change_gender_and_age_gender_chips"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="20dp"
+            android:layout_marginTop="10dp"
+            android:orientation="horizontal"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/tv_change_gender_and_age_user_gender">
+
+            <com.google.android.material.chip.Chip
+                android:id="@+id/chip_onboarding_second_gender_man"
+                style="@style/HarryMoongChi.Chip.Choice"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:checkable="true"
+                android:text="@string/onboarding_second_man" />
+
+            <com.google.android.material.chip.Chip
+                android:id="@+id/chip_onboarding_second_gender_woman"
+                style="@style/HarryMoongChi.Chip.Choice"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="12dp"
+                android:layout_weight="1"
+                android:checkable="true"
+                android:text="@string/onboarding_second_woman" />
+        </LinearLayout>
+
+        <View
+            android:id="@+id/view_change_gender_and_age_divider"
+            android:layout_width="0dp"
+            android:layout_height="1dp"
+            android:layout_marginTop="30dp"
+            android:background="@color/gray_50_F4F5F8"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/ll_change_gender_and_age_gender_chips" />
+
+        <TextView
+            android:id="@+id/tv_change_gender_and_age_birth_year"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:text="@string/onboarding_second_birth_year"
+            android:textAppearance="@style/body2"
+            app:layout_constraintStart_toStartOf="@id/tv_change_gender_and_age_user_gender"
+            app:layout_constraintTop_toBottomOf="@id/view_change_gender_and_age_divider" />
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/cl_change_gender_and_age_birth_year"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="20dp"
+            android:layout_marginTop="6dp"
+            android:background="@drawable/bg_onboarding_second_gray_50_radius_8dp"
+            android:paddingHorizontal="20dp"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/tv_change_gender_and_age_birth_year">
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginVertical="10dp"
+                android:textAppearance="@style/body2"
+                android:textColor="@color/black"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                tools:text="2000" />
+
+            <ImageView
+                android:layout_width="wrap_content"
+                android:layout_height="0dp"
+                android:src="@drawable/ic_onboarding_dropdown"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintDimensionRatio="1"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+        </androidx.constraintlayout.widget.ConstraintLayout>
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/app/src/main/res/layout/activity_setting.xml
+++ b/app/src/main/res/layout/activity_setting.xml
@@ -2,6 +2,13 @@
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
+    <data>
+
+        <variable
+            name="onClick"
+            type="com.teamwss.websoso.ui.setting.SettingClickListener" />
+    </data>
+
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
@@ -46,6 +53,7 @@
             android:id="@+id/cl_setting_account_info"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
+            android:onClick="@{() -> onClick.onUserAccountInfoButtonClick()}"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/view_setting_title_divider">
@@ -85,6 +93,7 @@
             android:id="@+id/cl_setting_profile_disclosure"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
+            android:onClick="@{() -> onClick.onProfileDisclosureButtonClick()}"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/cl_setting_account_info">
@@ -124,6 +133,7 @@
             android:id="@+id/cl_setting_websoso_account"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
+            android:onClick="@{() -> onClick.onWebsosoOfficialButtonClick()}"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/cl_setting_profile_disclosure">
@@ -163,6 +173,7 @@
             android:id="@+id/cl_setting_inquire_and_feedback"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
+            android:onClick="@{() -> onClick.onInquireAndFeedbackButtonClick()}"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/cl_setting_websoso_account">
@@ -202,6 +213,7 @@
             android:id="@+id/cl_setting_app_rating"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
+            android:onClick="@{() -> onClick.onAppRatingButtonClick()}"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/cl_setting_inquire_and_feedback">
@@ -241,6 +253,7 @@
             android:id="@+id/cl_setting_terms_of_use"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
+            android:onClick="@{() -> onClick.onTermsOfUseButtonClick()}"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/cl_setting_app_rating">

--- a/app/src/main/res/layout/activity_setting.xml
+++ b/app/src/main/res/layout/activity_setting.xml
@@ -21,6 +21,7 @@
             android:layout_marginStart="12dp"
             android:layout_marginTop="64dp"
             android:contentDescription="@null"
+            android:onClick="@{() -> onClick.onBackButtonClick()}"
             android:paddingHorizontal="8dp"
             android:paddingVertical="4dp"
             android:src="@drawable/btn_setting_back"


### PR DESCRIPTION
## 📌𝘐𝘴𝘴𝘶𝘦𝘴
- closed #192

## 📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯
- 성별/나이 변경 ui 구현했습니다.
- 데이트 피커 바텀시트 연결했습니다. (thanks to harry)
- 마이페이지 > 환경설정 > 각 다른 뷰들로 이동하는 리스너 구현했습니다.
- 환경설정 내의 뒤로가기 버튼 리스너 구현했습니다.
- 계정정보 패키지가 ui단이 아닌 ui와 같은 계층에 패키지가 존재해서 이동했습니다. 죄송요 ㅎㅎ

## 📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵

영상 내의 싱글셀렉션은 아직 구현되지 않은 상태입니다

https://github.com/user-attachments/assets/622029d3-14e0-4021-a07d-6782be827b04


## 💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴