### PR TITLE
feat: 상세 탐색 키워드 검색 로직 구현

### DIFF
--- a/app/src/main/java/com/teamwss/websoso/ui/detailExplore/DetailExploreViewModel.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/detailExplore/DetailExploreViewModel.kt
@@ -101,11 +101,25 @@ class DetailExploreViewModel @Inject constructor(
                     categories = keywordsList.categories.map { it.toUi() },
                 )
 
-                _uiState.value = uiState.value?.copy(
-                    loading = false,
-                    categories = categoriesModel.categories,
-                )
+                when (searchWord == null) {
+                    true -> {
+                        _uiState.value = uiState.value?.copy(
+                            loading = false,
+                            categories = categoriesModel.categories,
+                        )
+                    }
 
+                    false -> {
+                        val results = categoriesModel.categories.flatMap { it.keywords }
+
+                        _uiState.value = uiState.value?.copy(
+                            loading = false,
+                            searchResultKeywords = results,
+                            isInitialSearchKeyword = false,
+                            isSearchResultKeywordsEmpty = results.isEmpty(),
+                        )
+                    }
+                }
             }.onFailure {
                 _uiState.value = uiState.value?.copy(
                     loading = false,

--- a/app/src/main/java/com/teamwss/websoso/ui/detailExplore/DetailExploreViewModel.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/detailExplore/DetailExploreViewModel.kt
@@ -52,6 +52,8 @@ class DetailExploreViewModel @Inject constructor(
         _isInfoChipSelected.addSource(_selectedRating) {
             _isInfoChipSelected.value = isInfoChipSelectedEnabled()
         }
+
+        updateKeyword(null)
     }
 
     private fun isInfoChipSelectedEnabled(): Boolean {

--- a/app/src/main/java/com/teamwss/websoso/ui/detailExplore/DetailExploreViewModel.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/detailExplore/DetailExploreViewModel.kt
@@ -42,12 +42,6 @@ class DetailExploreViewModel @Inject constructor(
         MutableLiveData(DetailExploreKeywordUiState())
     val uiState: LiveData<DetailExploreKeywordUiState> get() = _uiState
 
-    private val _searchWord: MutableLiveData<String> = MutableLiveData()
-    val searchWord: MutableLiveData<String> get() = _searchWord
-
-    private val _isSearchCancelButtonVisible: MutableLiveData<Boolean> = MutableLiveData(false)
-    val isSearchCancelButtonVisible: LiveData<Boolean> get() = _isSearchCancelButtonVisible
-
     init {
         _isInfoChipSelected.addSource(_selectedGenres) {
             _isInfoChipSelected.value = isInfoChipSelectedEnabled()
@@ -98,10 +92,10 @@ class DetailExploreViewModel @Inject constructor(
         _selectedRating.value = rating
     }
 
-    fun updateKeyword() {
+    fun updateKeyword(searchWord: String?) {
         viewModelScope.launch {
             runCatching {
-                keywordRepository.fetchKeywords(searchWord.value)
+                keywordRepository.fetchKeywords(searchWord)
             }.onSuccess { keywordsList ->
                 val categoriesModel = CategoriesModel(
                     categories = keywordsList.categories.map { it.toUi() },
@@ -135,14 +129,6 @@ class DetailExploreViewModel @Inject constructor(
         _isKeywordChipSelected.value = false
     }
 
-    fun updateSearchCancelButtonVisibility() {
-        _isSearchCancelButtonVisible.value = _searchWord.value.isNullOrEmpty().not()
-    }
-
-    fun updateSearchWordEmpty() {
-        _searchWord.value = ""
-    }
-
     fun updateClickedChipState(keywordId: Int) {
         val currentUiState = _uiState.value ?: return
 
@@ -162,5 +148,24 @@ class DetailExploreViewModel @Inject constructor(
 
         _isKeywordChipSelected.value = isAnyKeywordSelected
         _uiState.value = currentUiState.copy(categories = updatedCategories)
+    }
+
+    fun updateIsSearchKeywordProceeding(isProceeding: Boolean) {
+        uiState.value?.let { uiState ->
+            _uiState.value = uiState.copy(
+                isSearchKeywordProceeding = isProceeding,
+            )
+        }
+    }
+
+    fun initSearchKeyword() {
+        uiState.value?.let { uiState ->
+            _uiState.value = uiState.copy(
+                searchResultKeywords = emptyList(),
+                isSearchKeywordProceeding = false,
+                isInitialSearchKeyword = true,
+                isSearchResultKeywordsEmpty = false,
+            )
+        }
     }
 }

--- a/app/src/main/java/com/teamwss/websoso/ui/detailExplore/keyword/DetailExploreClickListener.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/detailExplore/keyword/DetailExploreClickListener.kt
@@ -2,10 +2,6 @@ package com.teamwss.websoso.ui.detailExplore.keyword
 
 interface DetailExploreClickListener {
 
-    fun onSearchButtonClick()
-
-    fun onSearchCancelButtonClick()
-
     fun onNovelInquireButtonClick()
 
     fun onDetailSearchNovelButtonClick()

--- a/app/src/main/java/com/teamwss/websoso/ui/detailExplore/keyword/DetailExploreKeywordFragment.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/detailExplore/keyword/DetailExploreKeywordFragment.kt
@@ -3,6 +3,7 @@ package com.teamwss.websoso.ui.detailExplore.keyword
 import android.os.Bundle
 import android.view.View
 import androidx.core.view.children
+import androidx.core.view.forEach
 import androidx.fragment.app.activityViewModels
 import com.teamwss.websoso.R
 import com.teamwss.websoso.common.ui.base.BaseFragment
@@ -14,6 +15,7 @@ import com.teamwss.websoso.common.util.toFloatScaledByPx
 import com.teamwss.websoso.databinding.FragmentDetailExploreKeywordBinding
 import com.teamwss.websoso.ui.detailExplore.DetailExploreViewModel
 import com.teamwss.websoso.ui.detailExplore.keyword.adapter.DetailExploreKeywordAdapter
+import com.teamwss.websoso.ui.detailExplore.keyword.model.DetailExploreKeywordUiState
 import com.teamwss.websoso.ui.detailExploreResult.DetailExploreResultActivity
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -28,17 +30,18 @@ class DetailExploreKeywordFragment :
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        detailExploreViewModel.updateKeyword("")
+        detailExploreViewModel.updateKeyword(null)
         bindViewModel()
         setupAdapter()
-        setupSearchKeyword()
         setupObserver()
+        setupSearchKeyword()
+        setupWebsosoSearchEditListener()
     }
 
     private fun bindViewModel() {
         binding.detailExploreViewModel = detailExploreViewModel
         binding.onClick = onDetailExploreKeywordButtonClick()
-        binding.lifecycleOwner = this
+        binding.lifecycleOwner = viewLifecycleOwner
     }
 
     private fun onDetailExploreKeywordButtonClick() = object : DetailExploreClickListener {
@@ -61,13 +64,9 @@ class DetailExploreKeywordFragment :
         val isCompleted = detailExploreViewModel.selectedStatus.value?.isCompleted
         val novelRating = detailExploreViewModel.selectedRating.value
 
-        val keywordIds = detailExploreViewModel.uiState.value?.categories
-            ?.asSequence()
-            ?.flatMap { it.keywords.asSequence() }
-            ?.filter { it.isSelected }
-            ?.map { it.keywordId }
-            ?.toList()
-            ?: emptyList()
+        val keywordIds = detailExploreViewModel.uiState.value?.categories?.asSequence()
+            ?.flatMap { it.keywords.asSequence() }?.filter { it.isSelected }?.map { it.keywordId }
+            ?.toList() ?: emptyList()
 
         val intent = DetailExploreResultActivity.getIntent(
             context = requireContext(),
@@ -87,61 +86,21 @@ class DetailExploreKeywordFragment :
         }
     }
 
-    private fun setupSearchKeyword() {
-        binding.wsetDetailExploreKeywordSearch.apply {
-            setWebsosoSearchHint(getString(R.string.detail_explore_search_hint))
-
-        }
-        setupWebsosoSearchEditListener()
-
-    }
-
-    private fun setupWebsosoSearchEditListener() {
-        binding.wsetDetailExploreKeywordSearch.setOnWebsosoSearchActionListener { _, _, _ ->
-            performSearch()
-            true
-        }
-
-        binding.wsetDetailExploreKeywordSearch.setOnWebsosoSearchFocusChangeListener { _, isFocused ->
-            if (isFocused) detailExploreViewModel.updateIsSearchKeywordProceeding(true)
-        }
-
-        binding.wsetDetailExploreKeywordSearch.setOnWebsosoSearchClearClickListener {
-            initSearchKeyword()
-        }
-    }
-
-    private fun performSearch() {
-        val input = binding.wsetDetailExploreKeywordSearch.getWebsosoSearchText()
-        if (input.isEmpty()) {
-            initSearchKeyword()
-            return
-        }
-        detailExploreViewModel.updateKeyword(input)
-    }
-
-    private fun initSearchKeyword() {
-        binding.wsetDetailExploreKeywordSearch.clearWebsosoSearchFocus()
-        detailExploreViewModel.initSearchKeyword()
-    }
-
     private fun setupObserver() {
-        detailExploreViewModel.uiState.observe(viewLifecycleOwner) {
-            detailExploreKeywordAdapter.submitList(it.categories)
-            setupSelectedChips(it.categories)
+        detailExploreViewModel.uiState.observe(viewLifecycleOwner) { uiState ->
+            detailExploreKeywordAdapter.submitList(uiState.categories)
+            setupSelectedChips(uiState.categories)
+            updateSearchKeywordResult(uiState)
         }
     }
 
     private fun setupSelectedChips(categories: List<CategoryModel>) {
         val currentChipKeywords =
-            binding.wcgDetailExploreKeywordSelectedKeyword.children
-                .filterIsInstance<WebsosoChip>()
+            binding.wcgDetailExploreKeywordSelectedKeyword.children.filterIsInstance<WebsosoChip>()
                 .map { it.text.toString() }.toList()
 
         val selectedKeywords =
-            categories.asSequence()
-                .flatMap { it.keywords.asSequence() }
-                .filter { it.isSelected }
+            categories.asSequence().flatMap { it.keywords.asSequence() }.filter { it.isSelected }
                 .map { it.keywordName }.toList()
 
         val chipsToRemove = currentChipKeywords - selectedKeywords.toSet()
@@ -176,7 +135,7 @@ class DetailExploreKeywordFragment :
             setWebsosoChipStrokeColor(R.color.primary_100_6A5DFD)
             setWebsosoChipBackgroundColor(R.color.white)
             setWebsosoChipPaddingVertical(12f.toFloatScaledByPx())
-            setWebsosoChipPaddingHorizontal(6f.toFloatScaledByPx())
+            setWebsosoChipPaddingHorizontal(4f.toFloatScaledByPx())
             setWebsosoChipRadius(20f.toFloatScaledByPx())
             setOnCloseIconClickListener {
                 detailExploreViewModel.updateClickedChipState(
@@ -191,5 +150,96 @@ class DetailExploreKeywordFragment :
         }.also { websosoChip ->
             binding.wcgDetailExploreKeywordSelectedKeyword.addChip(websosoChip)
         }
+    }
+
+    private fun updateSearchKeywordResult(uiState: DetailExploreKeywordUiState) {
+        val previousSearchResultKeywords =
+            binding.wcgDetailExploreKeywordResult.children.toList().map { it as WebsosoChip }
+        if (!uiState.isSearchKeywordProceeding) return
+        if (uiState.isSearchResultKeywordsEmpty) return
+        if (uiState.searchResultKeywords.map { it.keywordName } == previousSearchResultKeywords.map { it.text.toString() }) {
+            updateSearchKeywordResultIsSelected(uiState)
+            return
+        }
+        binding.wcgDetailExploreKeywordResult.removeAllViews()
+        updateSearchKeywordResultWebsosoChips(uiState)
+    }
+
+    private fun updateSearchKeywordResultIsSelected(uiState: DetailExploreKeywordUiState) {
+        binding.wcgDetailExploreKeywordResult.forEach { view ->
+            val chip = view as? WebsosoChip ?: return@forEach
+
+            val isSelected = uiState.categories
+                .asSequence()
+                .flatMap { it.keywords }
+                .filter { it.isSelected }
+                .any { it.keywordName == chip.text.toString() }
+
+            chip.isSelected = isSelected
+        }
+    }
+
+    private fun updateSearchKeywordResultWebsosoChips(uiState: DetailExploreKeywordUiState) {
+        uiState.searchResultKeywords.forEach { keyword ->
+            val isSelected = uiState.categories.asSequence().flatMap { it.keywords }
+                .any { it.keywordId == keyword.keywordId && it.isSelected }
+
+            WebsosoChip(binding.root.context).apply {
+                setWebsosoChipText(keyword.keywordName)
+                setWebsosoChipTextAppearance(R.style.body2)
+                setWebsosoChipTextColor(R.color.bg_novel_rating_chip_text_selector)
+                setWebsosoChipStrokeColor(R.color.bg_novel_rating_chip_stroke_selector)
+                setWebsosoChipBackgroundColor(R.color.bg_novel_rating_chip_background_selector)
+                setWebsosoChipPaddingVertical(12f.toFloatScaledByPx())
+                setWebsosoChipPaddingHorizontal(6f.toFloatScaledByPx())
+                setWebsosoChipRadius(20f.toFloatScaledByPx())
+                setOnWebsosoChipClick {
+                    detailExploreViewModel.updateClickedChipState(keyword.keywordId)
+                }
+                this.isSelected = isSelected
+            }.also { websosoChip ->
+                binding.wcgDetailExploreKeywordResult.addChip(websosoChip)
+            }
+        }
+    }
+
+    private fun setupSearchKeyword() {
+        binding.wsetDetailExploreKeywordSearch.apply {
+            setWebsosoSearchHint(getString(R.string.detail_explore_search_hint))
+        }
+    }
+
+    private fun setupWebsosoSearchEditListener() {
+        binding.wsetDetailExploreKeywordSearch.setOnWebsosoSearchActionListener { _, _, _ ->
+            performSearch()
+            true
+        }
+
+        binding.wsetDetailExploreKeywordSearch.setOnWebsosoSearchFocusChangeListener { _, isFocused ->
+            if (isFocused) detailExploreViewModel.updateIsSearchKeywordProceeding(true)
+        }
+
+        binding.wsetDetailExploreKeywordSearch.setOnWebsosoSearchClearClickListener {
+            initSearchKeyword()
+        }
+    }
+
+    private fun performSearch() {
+        val input = binding.wsetDetailExploreKeywordSearch.getWebsosoSearchText()
+        if (input.isEmpty()) {
+            initSearchKeyword()
+            return
+        }
+        detailExploreViewModel.updateKeyword(input)
+    }
+
+    private fun initSearchKeyword() {
+        binding.wsetDetailExploreKeywordSearch.clearWebsosoSearchFocus()
+        detailExploreViewModel.initSearchKeyword()
+    }
+
+    override fun onDestroyView() {
+        initSearchKeyword()
+        super.onDestroyView()
     }
 }

--- a/app/src/main/java/com/teamwss/websoso/ui/detailExplore/keyword/DetailExploreKeywordFragment.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/detailExplore/keyword/DetailExploreKeywordFragment.kt
@@ -2,6 +2,7 @@ package com.teamwss.websoso.ui.detailExplore.keyword
 
 import android.os.Bundle
 import android.view.View
+import androidx.activity.OnBackPressedCallback
 import androidx.core.view.children
 import androidx.core.view.forEach
 import androidx.fragment.app.activityViewModels
@@ -30,12 +31,12 @@ class DetailExploreKeywordFragment :
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        detailExploreViewModel.updateKeyword(null)
         bindViewModel()
         setupAdapter()
         setupObserver()
         setupSearchKeyword()
         setupWebsosoSearchEditListener()
+        setupBackButtonListener()
     }
 
     private fun bindViewModel() {
@@ -236,6 +237,20 @@ class DetailExploreKeywordFragment :
     private fun initSearchKeyword() {
         binding.wsetDetailExploreKeywordSearch.clearWebsosoSearchFocus()
         detailExploreViewModel.initSearchKeyword()
+    }
+
+    private fun setupBackButtonListener() {
+        requireActivity().onBackPressedDispatcher.addCallback(
+            viewLifecycleOwner,
+            object : OnBackPressedCallback(true) {
+                override fun handleOnBackPressed() {
+                    if (binding.wsetDetailExploreKeywordSearch.hasFocus()) {
+                        initSearchKeyword()
+                    } else {
+                        requireActivity().onBackPressedDispatcher.onBackPressed()
+                    }
+                }
+            })
     }
 
     override fun onDestroyView() {

--- a/app/src/main/java/com/teamwss/websoso/ui/detailExplore/keyword/DetailExploreKeywordFragment.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/detailExplore/keyword/DetailExploreKeywordFragment.kt
@@ -66,7 +66,9 @@ class DetailExploreKeywordFragment :
         val novelRating = detailExploreViewModel.selectedRating.value
 
         val keywordIds = detailExploreViewModel.uiState.value?.categories?.asSequence()
-            ?.flatMap { it.keywords.asSequence() }?.filter { it.isSelected }?.map { it.keywordId }
+            ?.flatMap { it.keywords.asSequence() }
+            ?.filter { it.isSelected }
+            ?.map { it.keywordId }
             ?.toList() ?: emptyList()
 
         val intent = DetailExploreResultActivity.getIntent(
@@ -97,11 +99,15 @@ class DetailExploreKeywordFragment :
 
     private fun setupSelectedChips(categories: List<CategoryModel>) {
         val currentChipKeywords =
-            binding.wcgDetailExploreKeywordSelectedKeyword.children.filterIsInstance<WebsosoChip>()
+            binding.wcgDetailExploreKeywordSelectedKeyword.children
+                .filterIsInstance<WebsosoChip>()
                 .map { it.text.toString() }.toList()
 
         val selectedKeywords =
-            categories.asSequence().flatMap { it.keywords.asSequence() }.filter { it.isSelected }
+            categories
+                .asSequence()
+                .flatMap { it.keywords.asSequence() }
+                .filter { it.isSelected }
                 .map { it.keywordName }.toList()
 
         val chipsToRemove = currentChipKeywords - selectedKeywords.toSet()

--- a/app/src/main/java/com/teamwss/websoso/ui/detailExplore/keyword/DetailExploreKeywordFragment.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/detailExplore/keyword/DetailExploreKeywordFragment.kt
@@ -28,9 +28,10 @@ class DetailExploreKeywordFragment :
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        detailExploreViewModel.updateKeyword()
+        detailExploreViewModel.updateKeyword("")
         bindViewModel()
         setupAdapter()
+        setupSearchKeyword()
         setupObserver()
     }
 
@@ -41,14 +42,6 @@ class DetailExploreKeywordFragment :
     }
 
     private fun onDetailExploreKeywordButtonClick() = object : DetailExploreClickListener {
-
-        override fun onSearchButtonClick() {
-            // TODO 검색하는 버튼
-        }
-
-        override fun onSearchCancelButtonClick() {
-            detailExploreViewModel.updateSearchWordEmpty()
-        }
 
         override fun onNovelInquireButtonClick() {
             // TODO 문의하기로 이동
@@ -94,11 +87,45 @@ class DetailExploreKeywordFragment :
         }
     }
 
-    private fun setupObserver() {
-        detailExploreViewModel.searchWord.observe(viewLifecycleOwner) {
-            detailExploreViewModel.updateSearchCancelButtonVisibility()
+    private fun setupSearchKeyword() {
+        binding.wsetDetailExploreKeywordSearch.apply {
+            setWebsosoSearchHint(getString(R.string.detail_explore_search_hint))
+
+        }
+        setupWebsosoSearchEditListener()
+
+    }
+
+    private fun setupWebsosoSearchEditListener() {
+        binding.wsetDetailExploreKeywordSearch.setOnWebsosoSearchActionListener { _, _, _ ->
+            performSearch()
+            true
         }
 
+        binding.wsetDetailExploreKeywordSearch.setOnWebsosoSearchFocusChangeListener { _, isFocused ->
+            if (isFocused) detailExploreViewModel.updateIsSearchKeywordProceeding(true)
+        }
+
+        binding.wsetDetailExploreKeywordSearch.setOnWebsosoSearchClearClickListener {
+            initSearchKeyword()
+        }
+    }
+
+    private fun performSearch() {
+        val input = binding.wsetDetailExploreKeywordSearch.getWebsosoSearchText()
+        if (input.isEmpty()) {
+            initSearchKeyword()
+            return
+        }
+        detailExploreViewModel.updateKeyword(input)
+    }
+
+    private fun initSearchKeyword() {
+        binding.wsetDetailExploreKeywordSearch.clearWebsosoSearchFocus()
+        detailExploreViewModel.initSearchKeyword()
+    }
+
+    private fun setupObserver() {
         detailExploreViewModel.uiState.observe(viewLifecycleOwner) {
             detailExploreKeywordAdapter.submitList(it.categories)
             setupSelectedChips(it.categories)

--- a/app/src/main/java/com/teamwss/websoso/ui/detailExplore/keyword/DetailExploreKeywordFragment.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/detailExplore/keyword/DetailExploreKeywordFragment.kt
@@ -5,6 +5,7 @@ import android.view.View
 import androidx.activity.OnBackPressedCallback
 import androidx.core.view.children
 import androidx.core.view.forEach
+import androidx.core.view.isVisible
 import androidx.fragment.app.activityViewModels
 import com.teamwss.websoso.R
 import com.teamwss.websoso.common.ui.base.BaseFragment
@@ -92,9 +93,18 @@ class DetailExploreKeywordFragment :
     private fun setupObserver() {
         detailExploreViewModel.uiState.observe(viewLifecycleOwner) { uiState ->
             detailExploreKeywordAdapter.submitList(uiState.categories)
+            setupSelectedScrollViewVisibility(uiState.categories)
             setupSelectedChips(uiState.categories)
             updateSearchKeywordResult(uiState)
         }
+    }
+
+    private fun setupSelectedScrollViewVisibility(categories: List<CategoryModel>) {
+        val hasSelectedKeywords = categories
+            .flatMap { it.keywords }
+            .any { it.isSelected }
+
+        binding.hsvRatingKeywordSelectedKeyword.isVisible = hasSelectedKeywords
     }
 
     private fun setupSelectedChips(categories: List<CategoryModel>) {

--- a/app/src/main/java/com/teamwss/websoso/ui/detailExplore/keyword/DetailExploreKeywordFragment.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/detailExplore/keyword/DetailExploreKeywordFragment.kt
@@ -170,17 +170,27 @@ class DetailExploreKeywordFragment :
     }
 
     private fun updateSearchKeywordResult(uiState: DetailExploreKeywordUiState) {
-        val previousSearchResultKeywords =
-            binding.wcgDetailExploreKeywordResult.children.toList().map { it as WebsosoChip }
-        if (!uiState.isSearchKeywordProceeding) return
-        if (uiState.isSearchResultKeywordsEmpty) return
-        if (uiState.searchResultKeywords.map { it.keywordName } == previousSearchResultKeywords.map { it.text.toString() }) {
-            updateSearchKeywordResultIsSelected(uiState)
-            return
+        val previousSearchResultKeywords = binding.wcgDetailExploreKeywordResult.children
+            .toList()
+            .map { it as WebsosoChip }
+
+        when {
+            !uiState.isSearchKeywordProceeding -> return
+
+            uiState.isSearchResultKeywordsEmpty -> return
+
+            uiState.searchResultKeywords.map { it.keywordName } == previousSearchResultKeywords.map { it.text.toString() } -> {
+                updateSearchKeywordResultIsSelected(uiState)
+                return
+            }
+
+            else -> {
+                binding.wcgDetailExploreKeywordResult.removeAllViews()
+                updateSearchKeywordResultWebsosoChips(uiState)
+            }
         }
-        binding.wcgDetailExploreKeywordResult.removeAllViews()
-        updateSearchKeywordResultWebsosoChips(uiState)
     }
+
 
     private fun updateSearchKeywordResultIsSelected(uiState: DetailExploreKeywordUiState) {
         binding.wcgDetailExploreKeywordResult.forEach { view ->

--- a/app/src/main/java/com/teamwss/websoso/ui/detailExplore/keyword/adapter/DetailExploreKeywordViewHolder.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/detailExplore/keyword/adapter/DetailExploreKeywordViewHolder.kt
@@ -55,8 +55,8 @@ class DetailExploreKeywordViewHolder(
                 setWebsosoChipTextColor(R.color.bg_novel_rating_chip_text_selector)
                 setWebsosoChipStrokeColor(R.color.bg_novel_rating_chip_stroke_selector)
                 setWebsosoChipBackgroundColor(R.color.bg_novel_rating_chip_background_selector)
-                setWebsosoChipPaddingVertical(12f.toFloatScaledByPx())
-                setWebsosoChipPaddingHorizontal(6f.toFloatScaledByPx())
+                setWebsosoChipPaddingVertical(10f.toFloatScaledByPx())
+                setWebsosoChipPaddingHorizontal(4f.toFloatScaledByPx())
                 setWebsosoChipRadius(20f.toFloatScaledByPx())
                 setOnWebsosoChipClick {
                     onKeywordClick(keyword.keywordId)

--- a/app/src/main/java/com/teamwss/websoso/ui/detailExplore/keyword/model/DetailExploreKeywordUiState.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/detailExplore/keyword/model/DetailExploreKeywordUiState.kt
@@ -1,9 +1,14 @@
 package com.teamwss.websoso.ui.detailExplore.keyword.model
 
 import com.teamwss.websoso.common.ui.model.CategoriesModel.CategoryModel
+import com.teamwss.websoso.common.ui.model.CategoriesModel.CategoryModel.KeywordModel
 
 data class DetailExploreKeywordUiState(
     val categories: List<CategoryModel> = emptyList(),
     val loading: Boolean = true,
     val error: Boolean = false,
+    val searchResultKeywords: List<KeywordModel> = emptyList(),
+    val isSearchKeywordProceeding: Boolean = false,
+    val isInitialSearchKeyword: Boolean = true,
+    val isSearchResultKeywordsEmpty: Boolean = false,
 )

--- a/app/src/main/res/layout/fragment_detail_explore_keyword.xml
+++ b/app/src/main/res/layout/fragment_detail_explore_keyword.xml
@@ -28,53 +28,13 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent">
 
-            <EditText
-                android:id="@+id/et_detail_explore_keyword_search_content"
+            <com.teamwss.websoso.common.ui.custom.WebsosoSearchEditText
+                android:id="@+id/wset_detail_explore_keyword_search"
                 android:layout_width="0dp"
                 android:layout_height="44dp"
                 android:layout_marginHorizontal="20dp"
-                android:autofillHints="@null"
-                android:background="@drawable/bg_common_search_selector"
-                android:cursorVisible="true"
-                android:hint="@string/detail_explore_search_hint"
-                android:imeOptions="actionSearch"
-                android:inputType="text"
-                android:maxLines="1"
-                android:paddingStart="16dp"
-                android:scrollHorizontally="true"
-                android:text="@={detailExploreViewModel.searchWord}"
-                android:textAppearance="@style/label1"
-                android:textColor="@color/black"
-                android:textColorHint="@color/gray_200_AEADB3"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent"
-                tools:ignore="RtlSymmetry" />
-
-            <ImageView
-                android:id="@+id/iv_detail_explore_keyword_search_button"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginEnd="8dp"
-                android:contentDescription="@null"
-                android:onClick="@{() -> onClick.onSearchButtonClick()}"
-                android:padding="4dp"
-                android:src="@drawable/btn_explore_search"
-                app:layout_constraintBottom_toBottomOf="@id/et_detail_explore_keyword_search_content"
-                app:layout_constraintEnd_toEndOf="@id/et_detail_explore_keyword_search_content"
-                app:layout_constraintTop_toTopOf="@id/et_detail_explore_keyword_search_content" />
-
-            <ImageView
-                android:id="@+id/iv_detail_explore_keyword_cancel_button"
-                isVisible="@{detailExploreViewModel.isSearchCancelButtonVisible}"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:contentDescription="@null"
-                android:onClick="@{() -> onClick.onSearchCancelButtonClick()}"
-                android:padding="8dp"
-                android:src="@drawable/btn_explore_cancel"
-                app:layout_constraintBottom_toBottomOf="@id/et_detail_explore_keyword_search_content"
-                app:layout_constraintEnd_toStartOf="@+id/iv_detail_explore_keyword_search_button"
                 app:layout_constraintTop_toTopOf="parent" />
         </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/app/src/main/res/layout/fragment_detail_explore_keyword.xml
+++ b/app/src/main/res/layout/fragment_detail_explore_keyword.xml
@@ -96,6 +96,8 @@
                 android:layout_marginTop="8dp"
                 android:orientation="vertical"
                 android:overScrollMode="never"
+                app:isInvisibleMode="@{true}"
+                app:isVisible="@{!detailExploreViewModel.uiState.searchKeywordProceeding}"
                 app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
                 app:layout_constrainedHeight="true"
                 app:layout_constraintBottom_toBottomOf="parent"
@@ -107,15 +109,16 @@
         <androidx.constraintlayout.widget.ConstraintLayout
             android:id="@+id/cl_detail_explore_keyword_result"
             android:layout_width="0dp"
-            android:layout_height="500dp"
+            android:layout_height="402dp"
             android:background="@color/white"
             android:paddingHorizontal="20dp"
-            android:visibility="gone"
+            app:isVisible="@{detailExploreViewModel.uiState.searchKeywordProceeding}"
             app:layout_constraintBottom_toTopOf="@id/cl_detail_explore_keyword_reset_button"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintHeight_min="384dp"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/view_detail_explore_divider">
+            app:layout_constraintTop_toBottomOf="@id/view_detail_explore_divider"
+            tools:visibility="gone">
 
             <TextView
                 android:id="@+id/tv_detail_explore_keyword_result_title"
@@ -125,6 +128,7 @@
                 android:text="@string/detail_explore_keyword_search_result"
                 android:textAppearance="@style/title3"
                 android:textColor="@color/gray_300_52515F"
+                app:isVisible="@{!detailExploreViewModel.uiState.initialSearchKeyword}"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toTopOf="parent" />
 
@@ -145,6 +149,7 @@
             android:layout_height="wrap_content"
             android:background="@color/white"
             android:visibility="gone"
+            app:isVisible="@{detailExploreViewModel.uiState.searchKeywordProceeding ? detailExploreViewModel.uiState.isSearchResultKeywordsEmpty : false}"
             app:layout_constraintBottom_toTopOf="@id/cl_detail_explore_keyword_reset_button"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintHeight_min="384dp"

--- a/app/src/main/res/layout/fragment_detail_explore_keyword.xml
+++ b/app/src/main/res/layout/fragment_detail_explore_keyword.xml
@@ -93,7 +93,7 @@
                 android:id="@+id/rv_detail_explore_keyword_list"
                 android:layout_width="0dp"
                 android:layout_height="402dp"
-                android:layout_marginTop="8dp"
+                android:layout_marginTop="2dp"
                 android:orientation="vertical"
                 android:overScrollMode="never"
                 app:isInvisibleMode="@{true}"

--- a/app/src/main/res/layout/layout_search.xml
+++ b/app/src/main/res/layout/layout_search.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-        android:layout_width="match_parent"
+    android:layout_width="match_parent"
     android:layout_height="match_parent">
 
     <EditText
@@ -26,7 +26,6 @@
         android:id="@+id/iv_common_search_clear"
         android:layout_width="36dp"
         android:layout_height="36dp"
-        android:padding="8dp"
         android:src="@drawable/ic_common_search_clear"
         android:visibility="gone"
         app:layout_constraintBottom_toBottomOf="parent"


### PR DESCRIPTION
## 📌𝘐𝘴𝘴𝘶𝘦𝘴
- closed #108

## 📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯
- 상세 탐색 키워드 검색 로직 구현했습니다.
- 검색바에 포커스를 가질 시 키워드 전체 뷰가 사라지고, 검색을 할 수 있으며 x 버튼을 누르면 포커스가 해제되고 다시 키워드 전체 뷰가 나타납니다.
- 검색 로직은 대부분 " "의 코드를 가져왔습니다. 정말 감사함다 ㅎㅎ


## 📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵


https://github.com/user-attachments/assets/9b012f31-3281-4915-affd-775b8c6a09e2

[검색 시]
<img width="324" alt="스크린샷 2024-08-29 오후 10 33 00" src="https://github.com/user-attachments/assets/4d3c142d-5b23-4096-8b60-bd103f206649">

[기존 키워드 전체 보기 뷰]
<img width="322" alt="스크린샷 2024-08-29 오후 10 33 26" src="https://github.com/user-attachments/assets/82419d95-8a2c-447a-970f-708533d60b80">

## 💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴