### PR TITLE
feat: 다른 유저 서재 ui 구현 및 api 연결

### DIFF
--- a/app/src/main/java/com/teamwss/websoso/ui/main/myPage/myLibrary/MyLibraryViewModel.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/main/myPage/myLibrary/MyLibraryViewModel.kt
@@ -16,8 +16,8 @@ import javax.inject.Inject
 @HiltViewModel
 class MyLibraryViewModel @Inject constructor(
     private val userRepository: UserRepository,
-) :
-    ViewModel() {
+) : ViewModel() {
+
     private val _genres = MutableLiveData<List<GenrePreferenceEntity>>()
     val genres: LiveData<List<GenrePreferenceEntity>> get()= _genres
 

--- a/app/src/main/java/com/teamwss/websoso/ui/otherUserPage/otherUserLibrary/OtherUserLibraryFragment.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/otherUserPage/otherUserLibrary/OtherUserLibraryFragment.kt
@@ -16,14 +16,15 @@ import com.teamwss.websoso.common.ui.custom.WebsosoChip
 import com.teamwss.websoso.common.util.setListViewHeightBasedOnChildren
 import com.teamwss.websoso.data.model.NovelPreferenceEntity
 import com.teamwss.websoso.databinding.FragmentOtherUserLibraryBinding
+import com.teamwss.websoso.ui.otherUserPage.otherUserLibrary.adapter.RestGenrePreferenceAdapter
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
 class OtherUserLibraryFragment :
     BaseFragment<FragmentOtherUserLibraryBinding>(R.layout.fragment_other_user_library) {
     private val otherUserLibraryViewModel: OtherUserLibraryViewModel by viewModels()
-    private val restGenrePreferenceAdapter: com.teamwss.websoso.ui.otherUserPage.otherUserLibrary.adapter.RestGenrePreferenceAdapter by lazy {
-        com.teamwss.websoso.ui.otherUserPage.otherUserLibrary.adapter.RestGenrePreferenceAdapter()
+    private val restGenrePreferenceAdapter: RestGenrePreferenceAdapter by lazy {
+       RestGenrePreferenceAdapter()
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -31,11 +32,11 @@ class OtherUserLibraryFragment :
         binding.lifecycleOwner = viewLifecycleOwner
         binding.otherUserLibraryViewModel = otherUserLibraryViewModel
 
-        setupRestGenrePreferenceAdapter()
+        setUpRestGenrePreferenceAdapter()
         setUpObserve()
     }
 
-    private fun setupRestGenrePreferenceAdapter() {
+    private fun setUpRestGenrePreferenceAdapter() {
         binding.lvOtherUserLibraryRestGenre.adapter = restGenrePreferenceAdapter
     }
 
@@ -123,7 +124,6 @@ class OtherUserLibraryFragment :
     private fun createKeywordChip(data: NovelPreferenceEntity.KeywordEntity): Chip {
         return WebsosoChip(requireContext()).apply {
             text = "${data.keywordName} ${data.keywordCount}"
-            isCheckable = true
             isChecked = false
 
             setChipBackgroundColorResource(R.color.primary_50_F1EFFF)

--- a/app/src/main/java/com/teamwss/websoso/ui/otherUserPage/otherUserLibrary/OtherUserLibraryFragment.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/otherUserPage/otherUserLibrary/OtherUserLibraryFragment.kt
@@ -1,10 +1,134 @@
 package com.teamwss.websoso.ui.otherUserPage.otherUserLibrary
 
+import android.os.Bundle
+import android.text.SpannableString
+import android.text.SpannableStringBuilder
+import android.text.Spanned
+import android.text.style.ForegroundColorSpan
+import android.view.View
+import androidx.core.content.ContextCompat
+import androidx.core.view.isVisible
+import androidx.fragment.app.viewModels
+import com.google.android.material.chip.Chip
 import com.teamwss.websoso.R
 import com.teamwss.websoso.common.ui.base.BaseFragment
+import com.teamwss.websoso.common.ui.custom.WebsosoChip
+import com.teamwss.websoso.common.util.setListViewHeightBasedOnChildren
+import com.teamwss.websoso.data.model.NovelPreferenceEntity
 import com.teamwss.websoso.databinding.FragmentOtherUserLibraryBinding
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
 class OtherUserLibraryFragment :
-    BaseFragment<FragmentOtherUserLibraryBinding>(R.layout.fragment_other_user_library)
+    BaseFragment<FragmentOtherUserLibraryBinding>(R.layout.fragment_other_user_library) {
+    private val otherUserLibraryViewModel: OtherUserLibraryViewModel by viewModels()
+    private val restGenrePreferenceAdapter: com.teamwss.websoso.ui.otherUserPage.otherUserLibrary.adapter.RestGenrePreferenceAdapter by lazy {
+        com.teamwss.websoso.ui.otherUserPage.otherUserLibrary.adapter.RestGenrePreferenceAdapter()
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        binding.lifecycleOwner = viewLifecycleOwner
+        binding.otherUserLibraryViewModel = otherUserLibraryViewModel
+
+        setupRestGenrePreferenceAdapter()
+        setUpObserve()
+    }
+
+    private fun setupRestGenrePreferenceAdapter() {
+        binding.lvOtherUserLibraryRestGenre.adapter = restGenrePreferenceAdapter
+    }
+
+    private fun setUpObserve() {
+        otherUserLibraryViewModel.restGenres.observe(viewLifecycleOwner) { genres ->
+            restGenrePreferenceAdapter.updateRestGenrePreferenceData(genres)
+        }
+
+        otherUserLibraryViewModel.isGenreListVisible.observe(viewLifecycleOwner) { isVisible ->
+            updateRestGenrePreferenceVisibility(isVisible)
+        }
+
+        otherUserLibraryViewModel.translatedAttractivePoints.observe(viewLifecycleOwner) { translatedPoints ->
+            val combinedText =
+                translatedPoints.joinToString(", ") + getString(R.string.my_library_attractive_point_fixed_text)
+            applyTextColors(combinedText)
+        }
+
+        otherUserLibraryViewModel.novelPreferences.observe(viewLifecycleOwner) { novelPreferences ->
+            updateNovelPreferencesKeywords(novelPreferences)
+        }
+    }
+
+    private fun updateRestGenrePreferenceVisibility(isVisible: Boolean) {
+        binding.lvOtherUserLibraryRestGenre.isVisible = isVisible
+        if (isVisible) {
+            binding.lvOtherUserLibraryRestGenre.setListViewHeightBasedOnChildren()
+        }
+    }
+
+    private fun applyTextColors(combinedText: String) {
+        val primary100 = requireContext().getColor(R.color.primary_100_6A5DFD)
+        val gray300 = requireContext().getColor(R.color.gray_300_52515F)
+
+        val spannableStringBuilder = SpannableStringBuilder()
+
+        val fixedText = getString(R.string.my_library_attractive_point_fixed_text)
+
+        val splitText = combinedText.split(fixedText)
+
+        if (splitText.isNotEmpty()) {
+            val attractivePoints =
+                SpannableString(splitText[0]).apply {
+                    setSpan(
+                        ForegroundColorSpan(primary100),
+                        0,
+                        length,
+                        Spanned.SPAN_EXCLUSIVE_EXCLUSIVE
+                    )
+                }
+            spannableStringBuilder.append(attractivePoints)
+
+            val fixedSpannable =
+                SpannableString(fixedText).apply {
+                    setSpan(
+                        ForegroundColorSpan(gray300),
+                        0,
+                        length,
+                        Spanned.SPAN_EXCLUSIVE_EXCLUSIVE
+                    )
+                }
+            spannableStringBuilder.append(fixedSpannable)
+        } else {
+            val spannable = SpannableString(combinedText).apply {
+                setSpan(
+                    ForegroundColorSpan(primary100),
+                    0,
+                    length,
+                    Spanned.SPAN_EXCLUSIVE_EXCLUSIVE,
+                )
+            }
+            spannableStringBuilder.append(spannable)
+        }
+
+        binding.tvOtherUserLibraryAttractivePoints.text = spannableStringBuilder
+    }
+
+    private fun updateNovelPreferencesKeywords(novelPreferences: NovelPreferenceEntity) {
+        novelPreferences.keywords.forEach { keyword ->
+            val chip = createKeywordChip(keyword)
+            binding.wcgOtherUserLibraryAttractivePoints.addView(chip)
+        }
+    }
+
+    private fun createKeywordChip(data: NovelPreferenceEntity.KeywordEntity): Chip {
+        return WebsosoChip(requireContext()).apply {
+            text = "${data.keywordName} ${data.keywordCount}"
+            isCheckable = true
+            isChecked = false
+
+            setChipBackgroundColorResource(R.color.primary_50_F1EFFF)
+            setTextColor(ContextCompat.getColor(requireContext(), R.color.primary_100_6A5DFD))
+            setTextAppearance(R.style.body2)
+        }
+    }
+}

--- a/app/src/main/java/com/teamwss/websoso/ui/otherUserPage/otherUserLibrary/OtherUserLibraryViewModel.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/otherUserPage/otherUserLibrary/OtherUserLibraryViewModel.kt
@@ -1,0 +1,104 @@
+package com.teamwss.websoso.ui.otherUserPage.otherUserLibrary
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.teamwss.websoso.data.model.GenrePreferenceEntity
+import com.teamwss.websoso.data.model.NovelPreferenceEntity
+import com.teamwss.websoso.data.model.UserNovelStatsEntity
+import com.teamwss.websoso.data.repository.UserRepository
+import com.teamwss.websoso.ui.main.myPage.myLibrary.model.AttractivePoints
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class OtherUserLibraryViewModel @Inject constructor(
+    private val userRepository: UserRepository,
+) :
+    ViewModel() {
+    private val _genres = MutableLiveData<List<GenrePreferenceEntity>>()
+    val genres: LiveData<List<GenrePreferenceEntity>> get() = _genres
+
+    private val _dominantGenres = MutableLiveData<List<GenrePreferenceEntity>>()
+    val topGenres: LiveData<List<GenrePreferenceEntity>> get() = _dominantGenres
+
+    private val _restGenres = MutableLiveData<List<GenrePreferenceEntity>>()
+    val restGenres: LiveData<List<GenrePreferenceEntity>> get() = _restGenres
+
+    private val _isGenreListVisible = MutableLiveData<Boolean>(false)
+    val isGenreListVisible: LiveData<Boolean> get() = _isGenreListVisible
+
+    private val _novelPreferences = MutableLiveData<NovelPreferenceEntity>()
+    val novelPreferences: LiveData<NovelPreferenceEntity> get() = _novelPreferences
+
+    private val _attractivePointsText = MutableLiveData<String>()
+    val attractivePointsText: LiveData<String> get() = _attractivePointsText
+
+    private val _translatedAttractivePoints = MutableLiveData<List<String>>()
+    val translatedAttractivePoints: LiveData<List<String>> get() = _translatedAttractivePoints
+
+    private val _novelStats = MutableLiveData<UserNovelStatsEntity>()
+    val novelStats: LiveData<UserNovelStatsEntity> get() = _novelStats
+
+    private val userId: Long = getUserId()
+
+    init {
+        updateNovelStats()
+        updateGenrePreference(userId)
+        updateNovelPreferences(userId)
+    }
+
+    private fun updateNovelStats() {
+        viewModelScope.launch {
+            runCatching {
+                userRepository.fetchUserNovelStats()
+            }.onSuccess { novelStats ->
+                _novelStats.value = novelStats
+            }.onFailure { exception ->
+            }
+        }
+    }
+
+    private fun updateGenrePreference(userId: Long) {
+        viewModelScope.launch {
+            runCatching {
+                userRepository.fetchGenrePreference(userId)
+            }.onSuccess { genres ->
+                val sortedGenres = genres.sortedByDescending { it.genreCount }
+
+                _dominantGenres.value = sortedGenres.take(3)
+                _restGenres.value = sortedGenres.drop(3)
+            }.onFailure { exception ->
+            }
+        }
+    }
+
+    private fun getUserId(): Long {
+        return 1L
+    }
+
+    fun updateToggleGenresVisibility() {
+        _isGenreListVisible.value = _isGenreListVisible.value?.not() ?: false
+    }
+
+    private fun updateNovelPreferences(userId: Long) {
+        viewModelScope.launch {
+            runCatching {
+                userRepository.fetchNovelPreferences(userId)
+            }.onSuccess { novelPreferences ->
+                _novelPreferences.value = novelPreferences
+                _translatedAttractivePoints.value =
+                    translateAttractivePoints(novelPreferences.attractivePoints)
+            }.onFailure { exception ->
+            }
+        }
+    }
+
+    private fun translateAttractivePoints(attractivePoints: List<String>): List<String> {
+        return attractivePoints.mapNotNull { point ->
+            AttractivePoints.fromString(point)?.korean
+        }
+    }
+}

--- a/app/src/main/java/com/teamwss/websoso/ui/otherUserPage/otherUserLibrary/OtherUserLibraryViewModel.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/otherUserPage/otherUserLibrary/OtherUserLibraryViewModel.kt
@@ -16,8 +16,8 @@ import javax.inject.Inject
 @HiltViewModel
 class OtherUserLibraryViewModel @Inject constructor(
     private val userRepository: UserRepository,
-) :
-    ViewModel() {
+) : ViewModel() {
+
     private val _genres = MutableLiveData<List<GenrePreferenceEntity>>()
     val genres: LiveData<List<GenrePreferenceEntity>> get() = _genres
 

--- a/app/src/main/java/com/teamwss/websoso/ui/otherUserPage/otherUserLibrary/adapter/RestGenrePreferenceAdapter.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/otherUserPage/otherUserLibrary/adapter/RestGenrePreferenceAdapter.kt
@@ -1,0 +1,46 @@
+package com.teamwss.websoso.ui.otherUserPage.otherUserLibrary.adapter
+
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.BaseAdapter
+import com.teamwss.websoso.data.model.GenrePreferenceEntity
+import com.teamwss.websoso.databinding.ItemRestGenreBinding
+
+class RestGenrePreferenceAdapter(
+    items: List<GenrePreferenceEntity> = emptyList(),
+) : BaseAdapter() {
+
+    private var items: List<GenrePreferenceEntity> = items
+
+    override fun getView(position: Int, convertView: View?, parent: ViewGroup): View {
+        val binding: ItemRestGenreBinding = if (convertView == null) {
+            ItemRestGenreBinding.inflate(LayoutInflater.from(parent.context), parent, false).also {
+                it.root.tag = it
+            }
+        } else {
+            convertView.tag as ItemRestGenreBinding
+        }
+
+        binding.genrePreference = getItem(position)
+        binding.executePendingBindings()
+        return binding.root
+    }
+
+    override fun getCount(): Int {
+        return items.size
+    }
+
+    override fun getItem(position: Int): GenrePreferenceEntity {
+        return items[position]
+    }
+
+    override fun getItemId(position: Int): Long {
+        return position.toLong()
+    }
+
+    fun updateRestGenrePreferenceData(newItems: List<GenrePreferenceEntity>) {
+        items = newItems
+        notifyDataSetChanged()
+    }
+}

--- a/app/src/main/res/layout/fragment_my_library.xml
+++ b/app/src/main/res/layout/fragment_my_library.xml
@@ -46,7 +46,7 @@
                 app:layout_constraintEnd_toEndOf="parent"/>
 
             <LinearLayout
-                android:id="@+id/linear_my_library_storage"
+                android:id="@+id/ll_my_library_storage"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:orientation="horizontal"
@@ -58,7 +58,7 @@
                 app:layout_constraintTop_toBottomOf="@id/tv_my_library_storage_title">
 
                 <LinearLayout
-                    android:id="@+id/linear_my_library_storage_interesting"
+                    android:id="@+id/ll_my_library_storage_interesting"
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_weight="1"
@@ -93,7 +93,7 @@
                     android:background="@color/gray_70_DFDFE3"/>
 
                 <LinearLayout
-                    android:id="@+id/linear_my_library_storage_watching"
+                    android:id="@+id/ll_my_library_storage_watching"
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_weight="1"
@@ -123,7 +123,7 @@
                 </LinearLayout>
 
                 <LinearLayout
-                    android:id="@+id/linear_my_library_storage_watched"
+                    android:id="@+id/ll_my_library_storage_watched"
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_weight="1"
@@ -153,7 +153,7 @@
                 </LinearLayout>
 
                 <LinearLayout
-                    android:id="@+id/linear_my_library_storage_quit"
+                    android:id="@+id/ll_my_library_storage_quit"
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_weight="1"
@@ -261,7 +261,7 @@
                     app:layout_constraintTop_toTopOf="parent" />
 
                 <LinearLayout
-                    android:id="@+id/linear_my_library_dominant_genre"
+                    android:id="@+id/ll_my_library_dominant_genre"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_marginHorizontal="20dp"
@@ -271,7 +271,7 @@
                     app:layout_constraintTop_toBottomOf="@id/tv_my_library_genre_preference_title">
 
                     <LinearLayout
-                        android:id="@+id/linear_my_library_dominant_genre_first"
+                        android:id="@+id/ll_my_library_dominant_genre_first"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:layout_weight="1"
@@ -308,7 +308,7 @@
                     </LinearLayout>
 
                     <LinearLayout
-                        android:id="@+id/linear_my_library_dominant_genre_second"
+                        android:id="@+id/ll_my_library_dominant_genre_second"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:layout_weight="1"
@@ -345,7 +345,7 @@
                     </LinearLayout>
 
                     <LinearLayout
-                        android:id="@+id/linear_my_library_dominant_genre_third"
+                        android:id="@+id/ll_my_library_dominant_genre_third"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:layout_weight="1"
@@ -390,7 +390,7 @@
                     android:layout_marginHorizontal="40dp"
                     android:layout_marginTop="32dp"
                     android:divider="@null"
-                    app:layout_constraintTop_toBottomOf="@id/linear_my_library_dominant_genre"
+                    app:layout_constraintTop_toBottomOf="@id/ll_my_library_dominant_genre"
                     tools:layout_editor_absoluteX="40dp" />
 
                 <ImageView

--- a/app/src/main/res/layout/fragment_other_user_library.xml
+++ b/app/src/main/res/layout/fragment_other_user_library.xml
@@ -46,7 +46,7 @@
                 app:layout_constraintTop_toTopOf="@id/tv_other_user_library_storage_title" />
 
             <LinearLayout
-                android:id="@+id/linear_other_user_library_storage"
+                android:id="@+id/ll_other_user_library_storage"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginHorizontal="20dp"
@@ -58,7 +58,7 @@
                 app:layout_constraintTop_toBottomOf="@id/tv_other_user_library_storage_title">
 
                 <LinearLayout
-                    android:id="@+id/linear_other_user_library_storage_interesting"
+                    android:id="@+id/ll_other_user_library_storage_interesting"
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_weight="1"
@@ -93,7 +93,7 @@
                     android:background="@color/gray_70_DFDFE3" />
 
                 <LinearLayout
-                    android:id="@+id/linear_other_user_library_storage_watching"
+                    android:id="@+id/ll_other_user_library_storage_watching"
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_weight="1"
@@ -123,7 +123,7 @@
                 </LinearLayout>
 
                 <LinearLayout
-                    android:id="@+id/linear_other_user_library_storage_watched"
+                    android:id="@+id/ll_other_user_library_storage_watched"
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_weight="1"
@@ -153,7 +153,7 @@
                 </LinearLayout>
 
                 <LinearLayout
-                    android:id="@+id/linear_other_user_library_storage_quit"
+                    android:id="@+id/ll_other_user_library_storage_quit"
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_weight="1"
@@ -218,7 +218,7 @@
                     app:layout_constraintTop_toTopOf="parent" />
 
                 <LinearLayout
-                    android:id="@+id/linear_other_user_library_dominant_genre"
+                    android:id="@+id/ll_other_user_library_dominant_genre"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_marginHorizontal="20dp"
@@ -228,7 +228,7 @@
                     app:layout_constraintTop_toBottomOf="@id/tv_other_user_library_genre_preference_title">
 
                     <LinearLayout
-                        android:id="@+id/linear_other_user_library_dominant_genre_first"
+                        android:id="@+id/ll_other_user_library_dominant_genre_first"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:layout_weight="1"
@@ -265,7 +265,7 @@
                     </LinearLayout>
 
                     <LinearLayout
-                        android:id="@+id/linear_other_user_library_dominant_genre_second"
+                        android:id="@+id/ll_other_user_library_dominant_genre_second"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:layout_weight="1"
@@ -302,7 +302,7 @@
                     </LinearLayout>
 
                     <LinearLayout
-                        android:id="@+id/linear_other_user_library_dominant_genre_third"
+                        android:id="@+id/ll_other_user_library_dominant_genre_third"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:layout_weight="1"
@@ -347,7 +347,7 @@
                     android:layout_marginHorizontal="40dp"
                     android:layout_marginTop="32dp"
                     android:divider="@null"
-                    app:layout_constraintTop_toBottomOf="@id/linear_other_user_library_dominant_genre"
+                    app:layout_constraintTop_toBottomOf="@id/ll_other_user_library_dominant_genre"
                     tools:layout_editor_absoluteX="40dp" />
 
                 <ImageView

--- a/app/src/main/res/layout/fragment_other_user_library.xml
+++ b/app/src/main/res/layout/fragment_other_user_library.xml
@@ -1,9 +1,423 @@
 <?xml version="1.0" encoding="utf-8"?>
-<layout xmlns:android="http://schemas.android.com/apk/res/android">
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <data>
+
+        <variable
+            name="otherUserLibraryViewModel"
+            type="com.teamwss.websoso.ui.otherUserPage.otherUserLibrary.OtherUserLibraryViewModel" />
+    </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/cl_other_user_library_mine"
         android:layout_width="match_parent"
         android:layout_height="wrap_content">
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/cl_other_user_library_storage"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:paddingBottom="30dp"
+            app:layout_constraintTop_toTopOf="parent">
+
+            <TextView
+                android:id="@+id/tv_other_user_library_storage_title"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="20dp"
+                android:layout_marginTop="24dp"
+                android:text="@string/other_user_library_storage"
+                android:textAppearance="@style/title1"
+                android:textColor="@color/black"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <ImageView
+                android:id="@+id/iv_other_user_library_go_to_storage"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginEnd="20dp"
+                android:padding="10dp"
+                android:src="@drawable/ic_my_library_navigate_right"
+                app:layout_constraintBottom_toBottomOf="@id/tv_other_user_library_storage_title"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toTopOf="@id/tv_other_user_library_storage_title" />
+
+            <LinearLayout
+                android:id="@+id/linear_other_user_library_storage"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginHorizontal="20dp"
+                android:layout_marginTop="10dp"
+                android:background="@drawable/bg_my_library_gray50_radius_14dp"
+                android:gravity="center"
+                android:orientation="horizontal"
+                android:paddingVertical="16dp"
+                app:layout_constraintTop_toBottomOf="@id/tv_other_user_library_storage_title">
+
+                <LinearLayout
+                    android:id="@+id/linear_other_user_library_storage_interesting"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:gravity="center"
+                    android:orientation="vertical">
+
+                    <TextView
+                        android:id="@+id/tv_other_user_linear_storage_interesting_count"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text='@{String.valueOf(otherUserLibraryViewModel.novelStats.interestNovelCount)}'
+                        android:textAppearance="@style/title2"
+                        android:textColor="@color/black"
+                        tools:text="12" />
+
+                    <TextView
+                        android:id="@+id/tv_other_user_linear_storage_interesting_title"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="2dp"
+                        android:layout_weight="1"
+                        android:text="@string/other_user_library_interesting"
+                        android:textAppearance="@style/body5"
+                        android:textColor="@color/black" />
+
+                </LinearLayout>
+
+                <View
+                    android:layout_width="1dp"
+                    android:layout_height="38dp"
+                    android:background="@color/gray_70_DFDFE3" />
+
+                <LinearLayout
+                    android:id="@+id/linear_other_user_library_storage_watching"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:gravity="center"
+                    android:orientation="vertical">
+
+                    <TextView
+                        android:id="@+id/tv_other_user_linear_storage_watching_count"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text='@{String.valueOf(otherUserLibraryViewModel.novelStats.watchingNovelCount)}'
+                        android:textAppearance="@style/title2"
+                        android:textColor="@color/black"
+                        tools:text="12" />
+
+                    <TextView
+                        android:id="@+id/tv_other_user_linear_storage_watching_title"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="2dp"
+                        android:layout_weight="1"
+                        android:text="@string/other_user_library_watching"
+                        android:textAppearance="@style/body5"
+                        android:textColor="@color/black" />
+
+                </LinearLayout>
+
+                <LinearLayout
+                    android:id="@+id/linear_other_user_library_storage_watched"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:gravity="center"
+                    android:orientation="vertical">
+
+                    <TextView
+                        android:id="@+id/tv_other_user_linear_storage_watched_count"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text='@{String.valueOf(otherUserLibraryViewModel.novelStats.watchedNovelCount)}'
+                        android:textAppearance="@style/title2"
+                        android:textColor="@color/black"
+                        tools:text="12" />
+
+                    <TextView
+                        android:id="@+id/tv_other_user_linear_storage_watched_title"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="2dp"
+                        android:layout_weight="1"
+                        android:text="@string/other_user_library_watched"
+                        android:textAppearance="@style/body5"
+                        android:textColor="@color/black" />
+
+                </LinearLayout>
+
+                <LinearLayout
+                    android:id="@+id/linear_other_user_library_storage_quit"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:gravity="center"
+                    android:orientation="vertical">
+
+                    <TextView
+                        android:id="@+id/tv_other_user_linear_storage_quit_count"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text="@{String.valueOf(otherUserLibraryViewModel.novelStats.quitNovelCount)}"
+                        android:textAppearance="@style/title2"
+                        android:textColor="@color/black"
+                        tools:text="12" />
+
+                    <TextView
+                        android:id="@+id/tv_other_user_linear_storage_quit_title"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="2dp"
+                        android:layout_weight="1"
+                        android:text="@string/other_user_library_quite"
+                        android:textAppearance="@style/body5"
+                        android:textColor="@color/black" />
+
+                </LinearLayout>
+
+            </LinearLayout>
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+        <View
+            android:layout_width="match_parent"
+            android:layout_height="3dp"
+            android:background="@color/gray_50_F4F5F8"
+            app:layout_constraintTop_toBottomOf="@id/cl_other_user_library_storage" />
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/cl_other_user_library_known_preference"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:layout_constraintTop_toBottomOf="@id/cl_other_user_library_storage">
+
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:id="@+id/cl_other_user_library_genre_preference"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:layout_constraintTop_toTopOf="parent"
+                tools:layout_editor_absoluteX="0dp">
+
+                <TextView
+                    android:id="@+id/tv_other_user_library_genre_preference_title"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="20dp"
+                    android:layout_marginTop="24dp"
+                    android:text="@string/other_user_library_genre_preference"
+                    android:textAppearance="@style/title1"
+                    android:textColor="@color/black"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent" />
+
+                <LinearLayout
+                    android:id="@+id/linear_other_user_library_dominant_genre"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginHorizontal="20dp"
+                    android:layout_marginTop="16dp"
+                    android:gravity="center"
+                    android:orientation="horizontal"
+                    app:layout_constraintTop_toBottomOf="@id/tv_other_user_library_genre_preference_title">
+
+                    <LinearLayout
+                        android:id="@+id/linear_other_user_library_dominant_genre_first"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:gravity="center"
+                        android:orientation="vertical">
+
+                        <ImageView
+                            android:id="@+id/iv_other_user_library_dominant_genre_first_logo"
+                            android:layout_width="30dp"
+                            android:layout_height="37dp"
+                            app:loadImageUrl="@{otherUserLibraryViewModel.topGenres[0].genreImage}"
+                            tools:src="@drawable/ic_novel_detail_genre_test" />
+
+                        <TextView
+                            android:id="@+id/tv_other_user_library_dominant_genre_first_title"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_marginTop="12dp"
+                            android:text="@{otherUserLibraryViewModel.topGenres[0].genreName}"
+                            android:textAppearance="@style/title3"
+                            android:textColor="@color/black"
+                            tools:text="로판" />
+
+                        <TextView
+                            android:id="@+id/tv_other_user_library_dominant_genre_first_count"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_marginTop="2dp"
+                            android:text='@{String.format(@string/other_user_library_genre_count, otherUserLibraryViewModel.topGenres[0].genreCount)}'
+                            android:textAppearance="@style/body5"
+                            android:textColor="@color/gray_200_AEADB3"
+                            tools:text="12편" />
+
+                    </LinearLayout>
+
+                    <LinearLayout
+                        android:id="@+id/linear_other_user_library_dominant_genre_second"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:gravity="center"
+                        android:orientation="vertical">
+
+                        <ImageView
+                            android:id="@+id/iv_other_user_library_dominant_genre_second_logo"
+                            android:layout_width="30dp"
+                            android:layout_height="37dp"
+                            app:loadImageUrl="@{otherUserLibraryViewModel.topGenres[1].genreImage}"
+                            tools:src="@drawable/ic_novel_detail_genre_test" />
+
+                        <TextView
+                            android:id="@+id/tv_other_user_library_dominant_genre_second_title"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_marginTop="12dp"
+                            android:text="@{otherUserLibraryViewModel.topGenres[1].genreName}"
+                            android:textAppearance="@style/title3"
+                            android:textColor="@color/black"
+                            tools:text="로판" />
+
+                        <TextView
+                            android:id="@+id/tv_other_user_library_dominant_genre_second_count"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_marginTop="2dp"
+                            android:text='@{String.format(@string/other_user_library_genre_count, otherUserLibraryViewModel.topGenres[1].genreCount)}'
+                            android:textAppearance="@style/body5"
+                            android:textColor="@color/gray_200_AEADB3"
+                            tools:text="12편" />
+
+                    </LinearLayout>
+
+                    <LinearLayout
+                        android:id="@+id/linear_other_user_library_dominant_genre_third"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:gravity="center"
+                        android:orientation="vertical">
+
+                        <ImageView
+                            android:id="@+id/iv_other_user_library_dominant_genre_third_logo"
+                            android:layout_width="30dp"
+                            android:layout_height="37dp"
+                            app:loadImageUrl="@{otherUserLibraryViewModel.topGenres[2].genreImage}"
+                            tools:src="@drawable/ic_novel_detail_genre_test" />
+
+                        <TextView
+                            android:id="@+id/tv_other_user_library_dominant_genre_third_title"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_marginTop="12dp"
+                            android:text="@{otherUserLibraryViewModel.topGenres[2].genreName}"
+                            android:textAppearance="@style/title3"
+                            android:textColor="@color/black"
+                            tools:text="로판" />
+
+                        <TextView
+                            android:id="@+id/tv_other_user_library_dominant_genre_third_count"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_marginTop="2dp"
+                            android:text='@{String.format(@string/other_user_library_genre_count, otherUserLibraryViewModel.topGenres[2].genreCount)}'
+                            android:textAppearance="@style/body5"
+                            android:textColor="@color/gray_200_AEADB3"
+                            tools:text="12편" />
+
+                    </LinearLayout>
+
+                </LinearLayout>
+
+                <ListView
+                    android:id="@+id/lv_other_user_library_rest_genre"
+                    android:layout_width="match_parent"
+                    android:layout_height="0dp"
+                    android:layout_marginHorizontal="40dp"
+                    android:layout_marginTop="32dp"
+                    android:divider="@null"
+                    app:layout_constraintTop_toBottomOf="@id/linear_other_user_library_dominant_genre"
+                    tools:layout_editor_absoluteX="40dp" />
+
+                <ImageView
+                    android:id="@+id/iv_other_user_library_genre_preference_path"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="20dp"
+                    android:onClick="@{() -> otherUserLibraryViewModel.updateToggleGenresVisibility()}"
+                    android:padding="8dp"
+                    android:src="@{otherUserLibraryViewModel.isGenreListVisible ? @drawable/ic_my_library_upper_path : @drawable/ic_my_library_lower_path}"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/lv_other_user_library_rest_genre" />
+
+            </androidx.constraintlayout.widget.ConstraintLayout>
+
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:id="@+id/cl_other_user_library_novel_preference"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginHorizontal="20dp"
+                app:layout_constraintTop_toBottomOf="@id/cl_other_user_library_genre_preference">
+
+                <TextView
+                    android:id="@+id/tv_other_user_library_novel_preference_title"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="30dp"
+                    android:text="@string/other_user_library_novel_preference"
+                    android:textAppearance="@style/title1"
+                    android:textColor="@color/black"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent" />
+
+                <androidx.constraintlayout.widget.ConstraintLayout
+                    android:id="@+id/cl_other_user_library_attractive_points"
+                    android:layout_width="match_parent"
+                    android:layout_height="0dp"
+                    android:layout_marginTop="12dp"
+                    android:background="@drawable/bg_my_library_gray50_radius_12dp"
+                    android:paddingVertical="20dp"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/tv_other_user_library_novel_preference_title">
+
+                    <TextView
+                        android:id="@+id/tv_other_user_library_attractive_points"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="@{otherUserLibraryViewModel.attractivePointsText}"
+                        android:textAppearance="@style/title2"
+                        android:textColor="@color/gray_300_52515F"
+                        app:layout_constraintBottom_toBottomOf="parent"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintTop_toTopOf="parent"
+                        tools:text="현캐릭터,소재가 매력적인 작품" />
+
+                </androidx.constraintlayout.widget.ConstraintLayout>
+
+                <com.teamwss.websoso.common.ui.custom.WebsosoChipGroup
+                    android:id="@+id/wcg_other_user_library_attractive_points"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="16dp"
+                    app:layout_constraintTop_toBottomOf="@id/cl_other_user_library_attractive_points" />
+
+            </androidx.constraintlayout.widget.ConstraintLayout>
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -307,5 +307,18 @@
     <!-- 다른 유저 페이지 뷰 -->
     <string name="other_user_page_library">서재</string>
     <string name="other_user_page_activity">활동</string>
+
+    <!-- 다른 유저 서재 뷰 -->
+    <string name="other_user_library_storage">보관함</string>
+    <string name="other_user_library_preference_analysis">취향 분석</string>
+    <string name="other_user_library_interesting">관심</string>
+    <string name="other_user_library_watching">보는중</string>
+    <string name="other_user_library_watched">봤어요</string>
+    <string name="other_user_library_quite">하차</string>
+    <string name="other_user_library_unknown_preference">작품 취향을 파악할 수 없어요</string>
+    <string name="other_user_library_genre_preference">장르 취향</string>
+    <string name="other_user_library_genre_count">%d편</string>
+    <string name="other_user_library_novel_preference">작품 취향</string>
+    <string name="other_user_library_attractive_point_fixed_text">가 매력적인 작품</string>
   
 </resources>


### PR DESCRIPTION
## 📌𝘐𝘴𝘴𝘶𝘦𝘴
- closed #238 

## 📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯
- 보관함, 장르취향, 작품 취향 ui
- 데이터 바인딩 적용
- 보관함 카운트, 장르취향, 작품취향 api 연결

## 📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵

https://github.com/user-attachments/assets/ff80cae0-96e3-4d88-accd-d3aa1ed0af90



## 💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴
제가 재사용을 하고 싶었는데욤.. 바인딩 문제로 계속 작업이 진행이 안되서.. 이렇게 하게 되었습니다..(꾸벅)
이렇게 하면 안될까요..ㅜㅜ

그래서 일단 코드는 **마이페이지 서재와 변수명만 다르고 완전히 똑같습니다..!**


