### PR TITLE
feat: 일반 검색 1차 QA 대응

### DIFF
--- a/app/src/main/java/com/teamwss/websoso/ui/normalExplore/NormalExploreActivity.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/normalExplore/NormalExploreActivity.kt
@@ -98,8 +98,7 @@ class NormalExploreActivity :
         }
 
         override fun onNovelInquireButtonClick() {
-            val url = "http://pf.kakao.com/_kHxlWG"
-            val intent = Intent(Intent.ACTION_VIEW, Uri.parse(url))
+            val intent = Intent(Intent.ACTION_VIEW, Uri.parse(KAKAO_INQUIRE_URL))
             startActivity(intent)
         }
     }
@@ -158,6 +157,7 @@ class NormalExploreActivity :
     }
 
     companion object {
+        private const val KAKAO_INQUIRE_URL = "http://pf.kakao.com/_kHxlWG"
 
         fun getIntent(context: Context): Intent = Intent(context, NormalExploreActivity::class.java)
     }

--- a/app/src/main/java/com/teamwss/websoso/ui/normalExplore/NormalExploreActivity.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/normalExplore/NormalExploreActivity.kt
@@ -2,6 +2,7 @@ package com.teamwss.websoso.ui.normalExplore
 
 import android.content.Context
 import android.content.Intent
+import android.net.Uri
 import android.os.Bundle
 import android.view.inputmethod.EditorInfo
 import android.view.inputmethod.InputMethodManager
@@ -97,7 +98,9 @@ class NormalExploreActivity :
         }
 
         override fun onNovelInquireButtonClick() {
-            // TODO 카카오톡 채널로 연결
+            val url = "http://pf.kakao.com/_kHxlWG"
+            val intent = Intent(Intent.ACTION_VIEW, Uri.parse(url))
+            startActivity(intent)
         }
     }
 

--- a/app/src/main/res/layout/activity_blocked_users.xml
+++ b/app/src/main/res/layout/activity_blocked_users.xml
@@ -67,8 +67,8 @@
 
             <ImageView
                 android:id="@+id/iv_blocked_users_empty"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
+                android:layout_width="166dp"
+                android:layout_height="160dp"
                 android:src="@drawable/img_my_library_empty_cat"
                 app:layout_constraintBottom_toTopOf="@id/tv_blocked_users_empty"
                 app:layout_constraintEnd_toEndOf="parent"

--- a/app/src/main/res/layout/activity_normal_explore.xml
+++ b/app/src/main/res/layout/activity_normal_explore.xml
@@ -146,7 +146,7 @@
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/cdl_normal_explore">
+            app:layout_constraintTop_toTopOf="parent">
 
             <ImageView
                 android:id="@+id/iv_normal_explore_not_exist_result"

--- a/app/src/main/res/layout/fragment_explore.xml
+++ b/app/src/main/res/layout/fragment_explore.xml
@@ -218,7 +218,7 @@
                 android:orientation="horizontal"
                 android:overScrollMode="never"
                 android:paddingStart="20dp"
-                android:paddingEnd="34dp"
+                android:paddingEnd="14dp"
                 android:paddingBottom="40dp"
                 app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
                 app:layout_constraintEnd_toEndOf="parent"

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -4,6 +4,7 @@
         <item name="colorPrimary">@color/white</item>
         <item name="android:statusBarColor">@color/white</item>
         <item name="android:windowLightStatusBar">true</item>
+        <item name="android:textCursorDrawable">@color/black</item>
         <item name="android:includeFontPadding">false</item>
         <item name="android:windowSplashScreenAnimatedIcon" tools:targetApi="s">@android:color/transparent</item>
         <item name="android:windowSplashScreenAnimationDuration" tools:targetApi="s">0</item>


### PR DESCRIPTION
## 📌𝘐𝘴𝘴𝘶𝘦𝘴
- closed #281

## 📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯
- [x] 소소픽 오른쪽 마진 값 수정하기
- [x] (일반검색) - 결과 없을 때 카카오톡 채널로 이동
- [x] (일반검색) - 결과 비어있을 때 뷰 위치 수정 
- [x] 전체적으로 사용하는 `EditText` 커서 색상 검은색으로 변경
- [x] 디자이너 선생님의 직접적인 QA로 인한 차단유저 목록 비어있을 때 소소냥 이미지 크기 조절했습니다.

## 📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵

https://github.com/user-attachments/assets/05a5b543-6d7b-4be2-8737-e8f2e4d2e9d1


## 💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴