### PR TITLE
feat: 로그인 1차 QA 대응

### DIFF
--- a/app/src/main/java/com/teamwss/websoso/data/repository/UserRepository.kt
+++ b/app/src/main/java/com/teamwss/websoso/data/repository/UserRepository.kt
@@ -62,7 +62,8 @@ class UserRepository @Inject constructor(
 
     suspend fun fetchOtherUserProfile(userId: Long): OtherUserProfileEntity {
         return userApi.getOtherUserProfile(userId).toData()
-        
+    }
+
     suspend fun saveUserProfile(
         nickname: String,
         gender: String,

--- a/app/src/main/java/com/teamwss/websoso/ui/login/LoginActivity.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/login/LoginActivity.kt
@@ -3,6 +3,8 @@ package com.teamwss.websoso.ui.login
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
+import android.os.Handler
+import android.os.Looper
 import androidx.activity.viewModels
 import com.teamwss.websoso.R
 import com.teamwss.websoso.common.ui.base.BaseActivity
@@ -16,6 +18,9 @@ import dagger.hilt.android.AndroidEntryPoint
 class LoginActivity : BaseActivity<ActivityLoginBinding>(R.layout.activity_login) {
 
     private val viewModel: LoginViewModel by viewModels()
+    private var currentPage = 0
+    private val handler = Handler(Looper.getMainLooper())
+    private lateinit var runnable: Runnable
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -23,6 +28,7 @@ class LoginActivity : BaseActivity<ActivityLoginBinding>(R.layout.activity_login
         setupObserver()
         onWithoutLoginButtonClick()
         onKakaoLoginButtonClick()
+        startAutoScroll()
     }
 
     private fun setupObserver() {
@@ -50,7 +56,30 @@ class LoginActivity : BaseActivity<ActivityLoginBinding>(R.layout.activity_login
         }
     }
 
+    private fun startAutoScroll() {
+        val pageCount = viewModel.loginImages.value?.size ?: 0
+
+        runnable = Runnable {
+            if (pageCount > 0) {
+                if (currentPage < pageCount - 1) {
+                    currentPage++
+                    binding.vpLogin.setCurrentItem(currentPage, true)
+                    handler.postDelayed(runnable, PAGE_SCROLL_DELAY)
+                } else {
+                    handler.removeCallbacks(runnable)
+                }
+            }
+        }
+        handler.postDelayed(runnable, PAGE_SCROLL_DELAY)
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        handler.removeCallbacks(runnable)
+    }
+
     companion object {
+        private const val PAGE_SCROLL_DELAY = 3500L
 
         fun getIntent(context: Context): Intent {
             return Intent(context, LoginActivity::class.java).apply {

--- a/app/src/main/java/com/teamwss/websoso/ui/login/LoginActivity.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/login/LoginActivity.kt
@@ -79,7 +79,7 @@ class LoginActivity : BaseActivity<ActivityLoginBinding>(R.layout.activity_login
     }
 
     companion object {
-        private const val PAGE_SCROLL_DELAY = 3500L
+        private const val PAGE_SCROLL_DELAY = 2000L
 
         fun getIntent(context: Context): Intent {
             return Intent(context, LoginActivity::class.java).apply {

--- a/app/src/main/res/layout/activity_login.xml
+++ b/app/src/main/res/layout/activity_login.xml
@@ -56,7 +56,7 @@
             android:layout_width="0dp"
             android:layout_height="54dp"
             android:layout_marginHorizontal="20dp"
-            android:layout_marginBottom="10dp"
+            android:layout_marginBottom="30dp"
             android:background="@drawable/bg_login_white_radius_14dp_stroke_primary100_1dp"
             android:gravity="center"
             android:padding="10dp"

--- a/app/src/main/res/layout/item_login_image.xml
+++ b/app/src/main/res/layout/item_login_image.xml
@@ -16,7 +16,7 @@
         <ImageView
             android:id="@+id/iv_login_image_item"
             android:layout_width="360dp"
-            android:layout_height="514dp"
+            android:layout_height="428dp"
             android:scaleType="centerCrop"
             app:imageResource="@{imageRes}"
             app:layout_constraintBottom_toBottomOf="parent"


### PR DESCRIPTION
## 📌𝘐𝘴𝘴𝘶𝘦𝘴
- closed #284 

## 📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯
- [x] 캐러셀 이미지 자동으로 움직이기
- [x] 캐러셀 이미지 고정사이즈 변경
- [x] UI 대체적으로 변경
회원가입 없이 둘러보기 버튼 위치 너무 내려가 있음, 이미지 비율이 좀 커진 느낌임 
→ 캐러셀 이미지 사이즈 고정, 이미지 중앙 + dotIndicator 소셜로그인이랑 버튼 하단 고정, 버튼 아래 마진

## 📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵

https://github.com/user-attachments/assets/ae2d6db2-4759-4a44-a1f0-8e88394c08ad



## 💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴