### PR TITLE
feat: 탐색 및 설정 뷰에 있는 svg > png 로 수정

### DIFF
--- a/app/src/main/java/com/teamwss/websoso/ui/blockedUsers/adapter/BlockedUsersViewHolder.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/blockedUsers/adapter/BlockedUsersViewHolder.kt
@@ -3,6 +3,7 @@ package com.teamwss.websoso.ui.blockedUsers.adapter
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
+import com.teamwss.websoso.common.util.getS3ImageUrl
 import com.teamwss.websoso.data.model.BlockedUsersEntity.BlockedUserEntity
 import com.teamwss.websoso.databinding.ItemBlockedUserBinding
 
@@ -16,7 +17,13 @@ class BlockedUsersViewHolder(
     }
 
     fun bind(blockedUser: BlockedUserEntity) {
-        binding.blockedUser = blockedUser
+        val imageUrl: String = itemView.getS3ImageUrl(blockedUser.avatarImage)
+
+        val updatedCategory = blockedUser.copy(
+            avatarImage = imageUrl,
+        )
+
+        binding.blockedUser = updatedCategory
     }
 
     companion object {

--- a/app/src/main/java/com/teamwss/websoso/ui/detailExplore/keyword/adapter/DetailExploreKeywordViewHolder.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/detailExplore/keyword/adapter/DetailExploreKeywordViewHolder.kt
@@ -5,6 +5,7 @@ import androidx.recyclerview.widget.RecyclerView
 import com.teamwss.websoso.R
 import com.teamwss.websoso.common.ui.custom.WebsosoChip
 import com.teamwss.websoso.common.ui.model.CategoriesModel.CategoryModel
+import com.teamwss.websoso.common.util.getS3ImageUrl
 import com.teamwss.websoso.common.util.toFloatPxFromDp
 import com.teamwss.websoso.common.util.toIntPxFromDp
 import com.teamwss.websoso.databinding.ItemCommonKeywordBinding
@@ -38,9 +39,15 @@ class DetailExploreKeywordViewHolder(
     }
 
     fun initKeywordView(category: CategoryModel) {
+        val imageUrl: String = itemView.getS3ImageUrl(category.categoryImage)
+
+        val updatedCategory = category.copy(
+            categoryImage = imageUrl,
+        )
+
         binding.apply {
-            tvRatingKeyword.text = category.categoryName
-            categoryImageUrl = category.categoryImage
+            tvRatingKeyword.text = updatedCategory.categoryName
+            categoryImageUrl = updatedCategory.categoryImage
             setupWebsosoChips(category)
         }
         isChipSetting = true

--- a/app/src/main/java/com/teamwss/websoso/ui/novelRating/adapter/NovelRatingKeywordViewHolder.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/novelRating/adapter/NovelRatingKeywordViewHolder.kt
@@ -5,6 +5,7 @@ import androidx.recyclerview.widget.RecyclerView
 import com.teamwss.websoso.R
 import com.teamwss.websoso.common.ui.custom.WebsosoChip
 import com.teamwss.websoso.common.ui.model.CategoriesModel.CategoryModel
+import com.teamwss.websoso.common.util.getS3ImageUrl
 import com.teamwss.websoso.common.util.toFloatPxFromDp
 import com.teamwss.websoso.common.util.toIntPxFromDp
 import com.teamwss.websoso.databinding.ItemCommonKeywordBinding
@@ -36,9 +37,15 @@ class NovelRatingKeywordViewHolder(
     }
 
     fun initKeywordView(category: CategoryModel) {
+        val imageUrl: String = itemView.getS3ImageUrl(category.categoryImage)
+
+        val updatedCategory = category.copy(
+            categoryImage = imageUrl,
+        )
+
         binding.apply {
-            tvRatingKeyword.text = category.categoryName
-            categoryImageUrl = category.categoryImage
+            tvRatingKeyword.text = updatedCategory.categoryName
+            categoryImageUrl = updatedCategory.categoryImage
             setupWebsosoChips(category)
         }
         isChipSetting = true
@@ -65,7 +72,8 @@ class NovelRatingKeywordViewHolder(
     }
 
     fun updateChipState(category: CategoryModel) {
-        val keywordSelectionMap = category.keywords.associateBy({ it.keywordName }, { it.isSelected })
+        val keywordSelectionMap =
+            category.keywords.associateBy({ it.keywordName }, { it.isSelected })
 
         (0 until binding.wcgNovelRatingKeyword.childCount)
             .map { binding.wcgNovelRatingKeyword.getChildAt(it) }

--- a/app/src/main/res/layout/item_blocked_user.xml
+++ b/app/src/main/res/layout/item_blocked_user.xml
@@ -21,7 +21,6 @@
         <ImageView
             android:id="@+id/iv_blocked_user_avatar"
             cornerRadius="@{14f}"
-            isVectorImage="@{true}"
             loadImageUrl="@{blockedUser.avatarImage}"
             android:layout_width="50dp"
             android:layout_height="50dp"

--- a/app/src/main/res/layout/item_common_keyword.xml
+++ b/app/src/main/res/layout/item_common_keyword.xml
@@ -33,7 +33,6 @@
                 android:layout_marginStart="20dp"
                 android:layout_marginTop="20dp"
                 app:cornerRadius="@{10f}"
-                app:isVectorImage="@{true}"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toTopOf="parent"
                 app:loadImageUrl="@{categoryImageUrl}" />


### PR DESCRIPTION
## 📌𝘐𝘴𝘴𝘶𝘦𝘴
- closed #320

## 📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯
- svg to png 적용
- 차단 유저는 더미가 없어서 사진이 없긴 한데 아마 같은 로직이라 될 겁니다
## 📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵
1. 준서오빠 키워드
<img width="299" alt="스크린샷 2024-09-13 오후 2 36 45" src="https://github.com/user-attachments/assets/0b5f3255-6229-43b7-b3b1-5a2be7b26461">
<br>

2. 탐색 뷰 키워드
<img width="317" alt="스크린샷 2024-09-13 오후 2 36 27" src="https://github.com/user-attachments/assets/4b04e669-88ee-4f75-ba77-069cc50c87ab">

<br>
3. 탐색 유저는 아직 더미가 없음
## 💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴