### PR TITLE
feat: 상세 탐색 화면 로그인 여부에 따른 분기 처리

### DIFF
--- a/app/src/main/java/com/teamwss/websoso/ui/main/explore/ExploreFragment.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/main/explore/ExploreFragment.kt
@@ -53,12 +53,11 @@ class ExploreFragment : BaseFragment<FragmentExploreBinding>(R.layout.fragment_e
     private fun onDetailExploreButtonClick() {
         binding.clExploreDetailSearch.setOnClickListener {
             singleEventHandler.throttleFirst {
-                if (mainViewModel.mainUiState.value?.isLogin == false) {
-                    showLoginRequestDialog()
-                    return@throttleFirst
+                when (mainViewModel.mainUiState.value?.isLogin) {
+                    true -> showDetailExploreDialog()
+                    false -> showLoginRequestDialog()
+                    else -> throw IllegalStateException()
                 }
-
-                showDetailExploreDialog()
             }
         }
     }

--- a/app/src/main/java/com/teamwss/websoso/ui/main/explore/ExploreFragment.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/main/explore/ExploreFragment.kt
@@ -70,10 +70,7 @@ class ExploreFragment : BaseFragment<FragmentExploreBinding>(R.layout.fragment_e
 
     private fun showDetailExploreDialog() {
         val detailExploreBottomSheet = DetailExploreDialogBottomSheet.newInstance()
-        detailExploreBottomSheet.show(
-            this@ExploreFragment.childFragmentManager,
-            DETAIL_BOTTOM_SHEET_TAG,
-        )
+        detailExploreBottomSheet.show(childFragmentManager, DETAIL_BOTTOM_SHEET_TAG)
     }
 
     private fun onReloadPageButtonClick() {

--- a/app/src/main/java/com/teamwss/websoso/ui/main/explore/ExploreFragment.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/main/explore/ExploreFragment.kt
@@ -63,8 +63,8 @@ class ExploreFragment : BaseFragment<FragmentExploreBinding>(R.layout.fragment_e
     }
 
     private fun showLoginRequestDialog() {
-        val dialog = LoginRequestDialogFragment.newInstance()
-        dialog.show(childFragmentManager, LoginRequestDialogFragment.TAG)
+        val loginRequestDialog = LoginRequestDialogFragment.newInstance()
+        loginRequestDialog.show(childFragmentManager, LoginRequestDialogFragment.TAG)
     }
 
     private fun showDetailExploreDialog() {

--- a/app/src/main/java/com/teamwss/websoso/ui/main/explore/ExploreFragment.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/main/explore/ExploreFragment.kt
@@ -2,11 +2,15 @@ package com.teamwss.websoso.ui.main.explore
 
 import android.os.Bundle
 import android.view.View
+import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.viewModels
 import com.teamwss.websoso.R
 import com.teamwss.websoso.common.ui.base.BaseFragment
+import com.teamwss.websoso.common.util.SingleEventHandler
 import com.teamwss.websoso.databinding.FragmentExploreBinding
+import com.teamwss.websoso.ui.common.dialog.LoginRequestDialogFragment
 import com.teamwss.websoso.ui.detailExplore.DetailExploreDialogBottomSheet
+import com.teamwss.websoso.ui.main.MainViewModel
 import com.teamwss.websoso.ui.main.explore.adapter.SosoPickAdapter
 import com.teamwss.websoso.ui.normalExplore.NormalExploreActivity
 import com.teamwss.websoso.ui.novelDetail.NovelDetailActivity
@@ -15,7 +19,9 @@ import dagger.hilt.android.AndroidEntryPoint
 @AndroidEntryPoint
 class ExploreFragment : BaseFragment<FragmentExploreBinding>(R.layout.fragment_explore) {
     private val sosoPickAdapter: SosoPickAdapter by lazy { SosoPickAdapter(::navigateToNovelDetail) }
+    private val singleEventHandler: SingleEventHandler by lazy { SingleEventHandler.from() }
     private val exploreViewModel: ExploreViewModel by viewModels()
+    private val mainViewModel: MainViewModel by activityViewModels()
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
@@ -24,7 +30,7 @@ class ExploreFragment : BaseFragment<FragmentExploreBinding>(R.layout.fragment_e
         onNormalSearchButtonClick()
         onDetailExploreButtonClick()
         onReloadPageButtonClick()
-        setupObserveUiState()
+        setupObserver()
     }
 
     private fun initSosoPickAdapter() {
@@ -46,17 +52,28 @@ class ExploreFragment : BaseFragment<FragmentExploreBinding>(R.layout.fragment_e
 
     private fun onDetailExploreButtonClick() {
         binding.clExploreDetailSearch.setOnClickListener {
-            val existingDialog =
-                this@ExploreFragment.childFragmentManager.findFragmentByTag(DETAIL_BOTTOM_SHEET_TAG)
+            singleEventHandler.throttleFirst {
+                if (mainViewModel.mainUiState.value?.isLogin == false) {
+                    showLoginRequestDialog()
+                    return@throttleFirst
+                }
 
-            if (existingDialog == null) {
-                val detailExploreBottomSheet = DetailExploreDialogBottomSheet.newInstance()
-                detailExploreBottomSheet.show(
-                    this@ExploreFragment.childFragmentManager,
-                    DETAIL_BOTTOM_SHEET_TAG,
-                )
+                showDetailExploreDialog()
             }
         }
+    }
+
+    private fun showLoginRequestDialog() {
+        val dialog = LoginRequestDialogFragment.newInstance()
+        dialog.show(childFragmentManager, LoginRequestDialogFragment.TAG)
+    }
+
+    private fun showDetailExploreDialog() {
+        val detailExploreBottomSheet = DetailExploreDialogBottomSheet.newInstance()
+        detailExploreBottomSheet.show(
+            this@ExploreFragment.childFragmentManager,
+            DETAIL_BOTTOM_SHEET_TAG,
+        )
     }
 
     private fun onReloadPageButtonClick() {
@@ -66,7 +83,7 @@ class ExploreFragment : BaseFragment<FragmentExploreBinding>(R.layout.fragment_e
         }
     }
 
-    private fun setupObserveUiState() {
+    private fun setupObserver() {
         exploreViewModel.uiState.observe(viewLifecycleOwner) { uiState ->
             when {
                 uiState.loading -> binding.wllExplore.setWebsosoLoadingVisibility(true)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -23,7 +23,7 @@
     <string name="explore_detail_search_description">장르, 연재상태, 별점, 키워드로 작품 찾기</string>
     <string name="explore_detail_search_button">내 취향에 맞는 작품 탐색하기</string>
     <string name="explore_soso">소소</string>
-    <string name="explore_sosopick_description">다른 사람들이 최근에 읽고 있는 작품이에요</string>
+    <string name="explore_sosopick_description">다른 독자들이 최근에 읽고 있는 작품이에요</string>
 
     <!-- 상세 탐색 뷰 -->
     <string name="detail_explore_info">정보</string>


### PR DESCRIPTION
## 📌𝘐𝘴𝘴𝘶𝘦𝘴
- closed #283

## 📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯
- 비로그인 시 상세 탐색 진입 불가하기에 로그인 모달 띄우기 구현했습니다.

## 📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵
[로그인 시]


https://github.com/user-attachments/assets/b8456cc0-8986-4408-9e57-f92f0a86d5ee

[비로그인 시]


https://github.com/user-attachments/assets/1ac1ef05-0b56-45b5-9971-2029a05dcf24


## 💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴