### PR TITLE
feat: 유저 차단하기 ui 구현 및 api 연결 

### DIFF
--- a/app/src/main/java/com/teamwss/websoso/common/ui/model/ResultFrom.kt
+++ b/app/src/main/java/com/teamwss/websoso/common/ui/model/ResultFrom.kt
@@ -4,6 +4,7 @@ enum class ResultFrom {
     FeedDetailBack,
     FeedDetailRemoved,
     CreateFeed,
+    BlockUser,
     ;
 
     val RESULT_OK: Int = ordinal

--- a/app/src/main/java/com/teamwss/websoso/data/remote/api/UserApi.kt
+++ b/app/src/main/java/com/teamwss/websoso/data/remote/api/UserApi.kt
@@ -35,6 +35,11 @@ interface UserApi {
         @Path("blockId") blockId: Long,
     )
 
+    @POST("blocks")
+    suspend fun postBlockUser(
+        @Query("userId") userId: Long,
+    )
+
     @GET("users/user-novel-stats")
     suspend fun getUserNovelStats(): UserNovelStatsResponseDto
 

--- a/app/src/main/java/com/teamwss/websoso/data/repository/UserRepository.kt
+++ b/app/src/main/java/com/teamwss/websoso/data/repository/UserRepository.kt
@@ -41,6 +41,10 @@ class UserRepository @Inject constructor(
         userApi.deleteBlockedUser(blockId)
     }
 
+    suspend fun saveBlockUser(userId: Long) {
+        userApi.postBlockUser(userId)
+    }
+
     suspend fun fetchUserNovelStats(): UserNovelStatsEntity {
         return userApi.getUserNovelStats().toData()
     }

--- a/app/src/main/java/com/teamwss/websoso/ui/feedDetail/FeedDetailActivity.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/feedDetail/FeedDetailActivity.kt
@@ -249,15 +249,11 @@ class FeedDetailActivity : BaseActivity<ActivityFeedDetailBinding>(R.layout.acti
             when (result.resultCode) {
                 CreateFeed.RESULT_OK -> feedDetailViewModel.updateFeedDetail(feedId)
                 BlockUser.RESULT_OK -> {
-                    val nickname =
-                        result.data?.getStringExtra(BlockUserDialogFragment.USER_NICKNAME)
-                    val blockMessage = nickname?.let {
-                        getString(R.string.block_user_success_message, it)
-                    } ?: getString(R.string.block_user_success_message)
+                    val nickname =  result.data?.getStringExtra(BlockUserDialogFragment.USER_NICKNAME).orEmpty()
 
                     showWebsosoSnackBar(
                         view = binding.root,
-                        message = blockMessage,
+                        message = getString(R.string.block_user_success_message, nickname),
                         icon = R.drawable.ic_novel_detail_check,
                     )
                 }

--- a/app/src/main/java/com/teamwss/websoso/ui/feedDetail/FeedDetailActivity.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/feedDetail/FeedDetailActivity.kt
@@ -17,10 +17,9 @@ import androidx.databinding.ViewDataBinding
 import androidx.lifecycle.lifecycleScope
 import com.teamwss.websoso.R
 import com.teamwss.websoso.common.ui.base.BaseActivity
-import com.teamwss.websoso.common.ui.model.ResultFrom.CreateFeed
-import com.teamwss.websoso.common.ui.model.ResultFrom.FeedDetailBack
-import com.teamwss.websoso.common.ui.model.ResultFrom.FeedDetailRemoved
+import com.teamwss.websoso.common.ui.model.ResultFrom.*
 import com.teamwss.websoso.common.util.SingleEventHandler
+import com.teamwss.websoso.common.util.showWebsosoSnackBar
 import com.teamwss.websoso.common.util.toIntPxFromDp
 import com.teamwss.websoso.databinding.ActivityFeedDetailBinding
 import com.teamwss.websoso.databinding.DialogRemovePopupMenuBinding
@@ -43,6 +42,7 @@ import com.teamwss.websoso.ui.main.feed.dialog.ReportMenuType.IMPERTINENCE_FEED
 import com.teamwss.websoso.ui.main.feed.dialog.ReportMenuType.SPOILER_COMMENT
 import com.teamwss.websoso.ui.main.feed.dialog.ReportMenuType.SPOILER_FEED
 import com.teamwss.websoso.ui.novelDetail.NovelDetailActivity
+import com.teamwss.websoso.ui.otherUserPage.BlockUserDialogFragment
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
@@ -244,7 +244,22 @@ class FeedDetailActivity : BaseActivity<ActivityFeedDetailBinding>(R.layout.acti
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         activityResultCallback = registerForActivityResult(StartActivityForResult()) { result ->
-            if (result.resultCode == CreateFeed.RESULT_OK) feedDetailViewModel.updateFeedDetail(feedId)
+            when (result.resultCode) {
+                CreateFeed.RESULT_OK -> feedDetailViewModel.updateFeedDetail(feedId)
+                BlockUser.RESULT_OK -> {
+                    val nickname =
+                        result.data?.getStringExtra(BlockUserDialogFragment.USER_NICKNAME)
+                    val blockMessage = nickname?.let {
+                        getString(R.string.block_user_success_message, it)
+                    } ?: getString(R.string.block_user_success_message)
+
+                    showWebsosoSnackBar(
+                        view = binding.root,
+                        message = blockMessage,
+                        icon = R.drawable.ic_novel_detail_check,
+                    )
+                }
+            }
         }
         setupView()
         setupObserver()

--- a/app/src/main/java/com/teamwss/websoso/ui/feedDetail/FeedDetailActivity.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/feedDetail/FeedDetailActivity.kt
@@ -96,12 +96,14 @@ class FeedDetailActivity : BaseActivity<ActivityFeedDetailBinding>(R.layout.acti
 
         override fun onProfileClick(userId: Long, isMyFeed: Boolean) {
             // if (isMyFeed) 마이페이지 else 프로필 뷰
+            // TODO: 본인 프로필 or 타유저 프로필로 이동
         }
     }
 
     private fun onCommentClick(): CommentClickListener = object : CommentClickListener {
         override fun onProfileClick(userId: Long, isMyComment: Boolean) {
             // if (isMyComment) 마이페이지 else 프로필 뷰
+            // TODO: 본인 프로필 or 타유저 프로필로 이동/**/
         }
 
         override fun onMoreButtonClick(view: View, commentId: Long, isMyComment: Boolean) {

--- a/app/src/main/java/com/teamwss/websoso/ui/main/feed/FeedFragment.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/main/feed/FeedFragment.kt
@@ -112,6 +112,7 @@ class FeedFragment : BaseFragment<FragmentFeedBinding>(fragment_feed) {
 //        singleEventHandler.throttleFirst(300) {
 //            OtherUserPageActivity.getIntent(requireContext(), userId)
 //        }
+        // TODO: 본인 프로필 or 타유저 프로필로 이동
     }
 
     private fun showMenu(view: View, feedId: Long, isMyFeed: Boolean) {

--- a/app/src/main/java/com/teamwss/websoso/ui/main/feed/FeedFragment.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/main/feed/FeedFragment.kt
@@ -16,17 +16,17 @@ import androidx.databinding.ViewDataBinding
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
 import com.teamwss.websoso.R.color
-import com.teamwss.websoso.R.drawable.ic_blocked_user_snack_bar
+import com.teamwss.websoso.R.drawable.*
 import com.teamwss.websoso.R.id.tv_feed_thumb_up_count
 import com.teamwss.websoso.R.layout.fragment_feed
+import com.teamwss.websoso.R.string.block_user_success_message
 import com.teamwss.websoso.R.string.feed_popup_menu_content_isMyFeed
 import com.teamwss.websoso.R.string.feed_popup_menu_content_report_isNotMyFeed
 import com.teamwss.websoso.R.string.feed_removed_feed_snackbar
 import com.teamwss.websoso.R.style
 import com.teamwss.websoso.common.ui.base.BaseFragment
 import com.teamwss.websoso.common.ui.custom.WebsosoChip
-import com.teamwss.websoso.common.ui.model.ResultFrom.CreateFeed
-import com.teamwss.websoso.common.ui.model.ResultFrom.FeedDetailRemoved
+import com.teamwss.websoso.common.ui.model.ResultFrom.*
 import com.teamwss.websoso.common.util.InfiniteScrollListener
 import com.teamwss.websoso.common.util.SingleEventHandler
 import com.teamwss.websoso.common.util.showWebsosoSnackBar
@@ -50,6 +50,7 @@ import com.teamwss.websoso.ui.main.feed.dialog.ReportMenuType
 import com.teamwss.websoso.ui.main.feed.model.CategoryModel
 import com.teamwss.websoso.ui.main.feed.model.FeedUiState
 import com.teamwss.websoso.ui.novelDetail.NovelDetailActivity
+import com.teamwss.websoso.ui.otherUserPage.BlockUserDialogFragment.Companion.USER_NICKNAME
 import dagger.hilt.android.AndroidEntryPoint
 import java.io.Serializable
 
@@ -234,6 +235,19 @@ class FeedFragment : BaseFragment<FragmentFeedBinding>(fragment_feed) {
                     message = getString(feed_removed_feed_snackbar),
                     icon = ic_blocked_user_snack_bar,
                 )
+
+                BlockUser.RESULT_OK -> {
+                    val nickname = result.data?.getStringExtra(USER_NICKNAME)
+                    val blockMessage = nickname?.let {
+                        getString(block_user_success_message, it)
+                    } ?: getString(block_user_success_message)
+
+                    showWebsosoSnackBar(
+                        view = binding.root,
+                        message = blockMessage,
+                        icon = ic_novel_detail_check,
+                    )
+                }
             }
         }
         initView()

--- a/app/src/main/java/com/teamwss/websoso/ui/novelFeed/NovelFeedFragment.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/novelFeed/NovelFeedFragment.kt
@@ -15,6 +15,9 @@ import androidx.databinding.ViewDataBinding
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
 import com.teamwss.websoso.R
+import com.teamwss.websoso.R.*
+import com.teamwss.websoso.R.drawable.*
+import com.teamwss.websoso.R.string.*
 import com.teamwss.websoso.common.ui.base.BaseFragment
 import com.teamwss.websoso.common.ui.model.ResultFrom.BlockUser
 import com.teamwss.websoso.common.util.InfiniteScrollListener
@@ -40,7 +43,7 @@ import com.teamwss.websoso.ui.otherUserPage.BlockUserDialogFragment
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
-class NovelFeedFragment : BaseFragment<FragmentNovelFeedBinding>(R.layout.fragment_novel_feed) {
+class NovelFeedFragment : BaseFragment<FragmentNovelFeedBinding>(layout.fragment_novel_feed) {
     private val novelId: Long by lazy { requireArguments().getLong(NOVEL_ID) }
     private var _popupBinding: MenuFeedPopupBinding? = null
     private val popupBinding: MenuFeedPopupBinding
@@ -135,7 +138,7 @@ class NovelFeedFragment : BaseFragment<FragmentNovelFeedBinding>(R.layout.fragme
             popup.dismiss()
         }
         menuContentTitle =
-            getString(R.string.feed_popup_menu_content_isMyFeed).split(",")
+            getString(feed_popup_menu_content_isMyFeed).split(",")
         tvFeedPopupFirstItem.isSelected = true
         tvFeedPopupSecondItem.isSelected = true
     }
@@ -159,7 +162,7 @@ class NovelFeedFragment : BaseFragment<FragmentNovelFeedBinding>(R.layout.fragme
             popup.dismiss()
         }
         menuContentTitle =
-            getString(R.string.feed_popup_menu_content_report_isNotMyFeed).split(",")
+            getString(feed_popup_menu_content_report_isNotMyFeed).split(",")
         tvFeedPopupFirstItem.isSelected = false
         tvFeedPopupSecondItem.isSelected = false
     }
@@ -197,13 +200,13 @@ class NovelFeedFragment : BaseFragment<FragmentNovelFeedBinding>(R.layout.fragme
                         val nickname =
                             result.data?.getStringExtra(BlockUserDialogFragment.USER_NICKNAME)
                         val blockMessage = nickname?.let {
-                            getString(R.string.block_user_success_message, it)
-                        } ?: getString(R.string.block_user_success_message)
+                            getString(block_user_success_message, it)
+                        } ?: getString(block_user_success_message)
 
                         showWebsosoSnackBar(
                             view = binding.root,
                             message = blockMessage,
-                            icon = R.drawable.ic_novel_detail_check,
+                            icon = ic_novel_detail_check,
                         )
                     }
                 }

--- a/app/src/main/java/com/teamwss/websoso/ui/novelFeed/NovelFeedFragment.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/novelFeed/NovelFeedFragment.kt
@@ -62,7 +62,7 @@ class NovelFeedFragment : BaseFragment<FragmentNovelFeedBinding>(R.layout.fragme
 
     private fun onClickFeedItem() = object : FeedItemClickListener {
         override fun onProfileClick(userId: Long) {
-            // TODO: 유저 프로필로 이동
+            // TODO: 본인 프로필 or 타유저 프로필로 이동
         }
 
         override fun onMoreButtonClick(view: View, feedId: Long, isMyFeed: Boolean) {

--- a/app/src/main/java/com/teamwss/websoso/ui/otherUserPage/BlockUserDialogFragment.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/otherUserPage/BlockUserDialogFragment.kt
@@ -1,12 +1,13 @@
 package com.teamwss.websoso.ui.otherUserPage
 
+import android.content.Intent
 import android.os.Bundle
 import android.view.View
 import androidx.fragment.app.activityViewModels
 import com.teamwss.websoso.R
 import com.teamwss.websoso.common.ui.base.BaseDialogFragment
+import com.teamwss.websoso.common.ui.model.ResultFrom.BlockUser
 import com.teamwss.websoso.common.util.SingleEventHandler
-import com.teamwss.websoso.common.util.showWebsosoSnackBar
 import com.teamwss.websoso.databinding.DialogBlockUserBinding
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -43,20 +44,18 @@ class BlockUserDialogFragment :
     private fun setupObserver() {
         otherUserPageViewModel.isBlockedCompleted.observe(viewLifecycleOwner) { isBlockedCompleted ->
             if (isBlockedCompleted == true) {
+                val intent = Intent().apply {
+                    putExtra(USER_NICKNAME, otherUserPageViewModel.otherUserProfile.value?.nickname)
+                }
+                activity?.setResult(BlockUser.RESULT_OK, intent)
+                dismiss()
                 requireActivity().finish()
-                showWebsosoSnackBar(
-                    view = binding.root,
-                    message = getString(
-                        R.string.block_user_success_message,
-                        otherUserPageViewModel.otherUserProfile.value?.nickname,
-                    ),
-                    icon = R.drawable.ic_novel_rating_alert,
-                )
             }
         }
     }
 
     companion object {
+        const val USER_NICKNAME = "UserNickname"
         const val TAG = "BlockUserDialog"
 
         fun newInstance(): BlockUserDialogFragment = BlockUserDialogFragment()

--- a/app/src/main/java/com/teamwss/websoso/ui/otherUserPage/BlockUserDialogFragment.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/otherUserPage/BlockUserDialogFragment.kt
@@ -43,7 +43,7 @@ class BlockUserDialogFragment :
 
     private fun setupObserver() {
         otherUserPageViewModel.isBlockedCompleted.observe(viewLifecycleOwner) { isBlockedCompleted ->
-            if (isBlockedCompleted == true) {
+            if (isBlockedCompleted) {
                 val intent = Intent().apply {
                     putExtra(USER_NICKNAME, otherUserPageViewModel.otherUserProfile.value?.nickname)
                 }

--- a/app/src/main/java/com/teamwss/websoso/ui/otherUserPage/BlockUserDialogFragment.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/otherUserPage/BlockUserDialogFragment.kt
@@ -1,0 +1,64 @@
+package com.teamwss.websoso.ui.otherUserPage
+
+import android.os.Bundle
+import android.view.View
+import androidx.fragment.app.activityViewModels
+import com.teamwss.websoso.R
+import com.teamwss.websoso.common.ui.base.BaseDialogFragment
+import com.teamwss.websoso.common.util.SingleEventHandler
+import com.teamwss.websoso.common.util.showWebsosoSnackBar
+import com.teamwss.websoso.databinding.DialogBlockUserBinding
+import dagger.hilt.android.AndroidEntryPoint
+
+@AndroidEntryPoint
+class BlockUserDialogFragment :
+    BaseDialogFragment<DialogBlockUserBinding>(R.layout.dialog_block_user) {
+    private val singleEventHandler: SingleEventHandler by lazy { SingleEventHandler.from() }
+    private val otherUserPageViewModel: OtherUserPageViewModel by activityViewModels()
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        onCancelButtonClick()
+        onBlockButtonClick()
+        setupObserver()
+    }
+
+    private fun onCancelButtonClick() {
+        binding.tvBlockUserCancelButton.setOnClickListener {
+            singleEventHandler.throttleFirst {
+                dismiss()
+            }
+        }
+    }
+
+    private fun onBlockButtonClick() {
+        binding.tvBlockUserButton.setOnClickListener {
+            singleEventHandler.throttleFirst {
+                otherUserPageViewModel.updateBlockedUser()
+            }
+        }
+    }
+
+    private fun setupObserver() {
+        otherUserPageViewModel.isBlockedCompleted.observe(viewLifecycleOwner) { isBlockedCompleted ->
+            if (isBlockedCompleted == true) {
+                requireActivity().finish()
+                showWebsosoSnackBar(
+                    view = binding.root,
+                    message = getString(
+                        R.string.block_user_success_message,
+                        otherUserPageViewModel.otherUserProfile.value?.nickname,
+                    ),
+                    icon = R.drawable.ic_novel_rating_alert,
+                )
+            }
+        }
+    }
+
+    companion object {
+        const val TAG = "BlockUserDialog"
+
+        fun newInstance(): BlockUserDialogFragment = BlockUserDialogFragment()
+    }
+}

--- a/app/src/main/java/com/teamwss/websoso/ui/otherUserPage/OtherUserPageActivity.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/otherUserPage/OtherUserPageActivity.kt
@@ -26,6 +26,7 @@ class OtherUserPageActivity :
     private var _popupBinding: MenuOtherUserPagePopupBinding? = null
     private val popupBinding: MenuOtherUserPagePopupBinding
         get() = _popupBinding ?: error("OtherUserPageActivity")
+    private var menuPopupWindow: PopupWindow? = null
     private val otherUserPageViewModel: OtherUserPageViewModel by viewModels()
     private val viewPagerAdapter: OtherUserPageViewPagerAdapter by lazy {
         OtherUserPageViewPagerAdapter(this)
@@ -47,7 +48,13 @@ class OtherUserPageActivity :
         binding.lifecycleOwner = this
         _popupBinding = MenuOtherUserPagePopupBinding.inflate(layoutInflater)
         popupBinding.lifecycleOwner = this
-        popupBinding.onBlockedUser = otherUserPageViewModel::updateBlockedUser
+        popupBinding.onBlockedUser = ::showBlockUserDialog
+    }
+
+    private fun showBlockUserDialog() {
+        val dialog = BlockUserDialogFragment.newInstance()
+        dialog.show(supportFragmentManager, BlockUserDialogFragment.TAG)
+        menuPopupWindow?.dismiss()
     }
 
     private fun setUpViewPager() {
@@ -99,7 +106,7 @@ class OtherUserPageActivity :
     }
 
     private fun showMenu(view: View) {
-        val popupWindow: PopupWindow = PopupWindow(
+        menuPopupWindow = PopupWindow(
             popupBinding.root,
             WindowManager.LayoutParams.WRAP_CONTENT,
             WindowManager.LayoutParams.WRAP_CONTENT,

--- a/app/src/main/java/com/teamwss/websoso/ui/otherUserPage/OtherUserPageActivity.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/otherUserPage/OtherUserPageActivity.kt
@@ -36,11 +36,17 @@ class OtherUserPageActivity :
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
+        updateUserId()
         bindViewModel()
         setUpViewPager()
         setUpItemVisibilityOnToolBar()
         onBackButtonClick()
         onMoreButtonClick()
+    }
+
+    private fun updateUserId() {
+        val userId = intent.getLongExtra(USER_ID, 0L)
+        otherUserPageViewModel.updateUserId(userId)
     }
 
     private fun bindViewModel() {

--- a/app/src/main/java/com/teamwss/websoso/ui/otherUserPage/OtherUserPageActivity.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/otherUserPage/OtherUserPageActivity.kt
@@ -38,6 +38,7 @@ class OtherUserPageActivity :
 
         updateUserId()
         bindViewModel()
+        bindPopupMenu()
         setUpViewPager()
         setUpItemVisibilityOnToolBar()
         onBackButtonClick()
@@ -52,6 +53,9 @@ class OtherUserPageActivity :
     private fun bindViewModel() {
         binding.otherUserPageViewModel = otherUserPageViewModel
         binding.lifecycleOwner = this
+    }
+
+    private fun bindPopupMenu() {
         _popupBinding = MenuOtherUserPagePopupBinding.inflate(layoutInflater)
         popupBinding.lifecycleOwner = this
         popupBinding.onBlockedUserClick = ::showBlockUserDialog

--- a/app/src/main/java/com/teamwss/websoso/ui/otherUserPage/OtherUserPageActivity.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/otherUserPage/OtherUserPageActivity.kt
@@ -48,7 +48,7 @@ class OtherUserPageActivity :
         binding.lifecycleOwner = this
         _popupBinding = MenuOtherUserPagePopupBinding.inflate(layoutInflater)
         popupBinding.lifecycleOwner = this
-        popupBinding.onBlockedUser = ::showBlockUserDialog
+        popupBinding.onBlockedUserClick = ::showBlockUserDialog
     }
 
     private fun showBlockUserDialog() {

--- a/app/src/main/java/com/teamwss/websoso/ui/otherUserPage/OtherUserPageActivity.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/otherUserPage/OtherUserPageActivity.kt
@@ -1,34 +1,53 @@
 package com.teamwss.websoso.ui.otherUserPage
 
+import android.content.Context
+import android.content.Intent
 import android.os.Bundle
+import android.view.View
+import android.view.WindowManager
+import android.widget.PopupWindow
 import androidx.activity.viewModels
 import androidx.core.content.ContextCompat
 import androidx.core.view.isVisible
 import com.google.android.material.tabs.TabLayoutMediator
 import com.teamwss.websoso.R
 import com.teamwss.websoso.common.ui.base.BaseActivity
+import com.teamwss.websoso.common.util.SingleEventHandler
+import com.teamwss.websoso.common.util.toFloatPxFromDp
+import com.teamwss.websoso.common.util.toIntPxFromDp
 import com.teamwss.websoso.databinding.ActivityOtherUserPageBinding
+import com.teamwss.websoso.databinding.MenuOtherUserPagePopupBinding
 import com.teamwss.websoso.ui.otherUserPage.adapter.OtherUserPageViewPagerAdapter
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
 class OtherUserPageActivity :
     BaseActivity<ActivityOtherUserPageBinding>(R.layout.activity_other_user_page) {
+    private var _popupBinding: MenuOtherUserPagePopupBinding? = null
+    private val popupBinding: MenuOtherUserPagePopupBinding
+        get() = _popupBinding ?: error("OtherUserPageActivity")
     private val otherUserPageViewModel: OtherUserPageViewModel by viewModels()
     private val viewPagerAdapter: OtherUserPageViewPagerAdapter by lazy {
         OtherUserPageViewPagerAdapter(this)
     }
+    private val singleEventHandler: SingleEventHandler by lazy { SingleEventHandler.from() }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
         bindViewModel()
         setUpViewPager()
         setUpItemVisibilityOnToolBar()
+        onBackButtonClick()
+        onMoreButtonClick()
     }
 
     private fun bindViewModel() {
         binding.otherUserPageViewModel = otherUserPageViewModel
         binding.lifecycleOwner = this
+        _popupBinding = MenuOtherUserPagePopupBinding.inflate(layoutInflater)
+        popupBinding.lifecycleOwner = this
+        popupBinding.onBlockedUser = otherUserPageViewModel::updateBlockedUser
     }
 
     private fun setUpViewPager() {
@@ -65,7 +84,43 @@ class OtherUserPageActivity :
         }
     }
 
+    private fun onBackButtonClick() {
+        binding.ivOtherUserPageStickyBack.setOnClickListener {
+            finish()
+        }
+    }
+
+    private fun onMoreButtonClick() {
+        binding.ivOtherUserPageStickyKebab.setOnClickListener {
+            singleEventHandler.throttleFirst {
+                showMenu(binding.ivOtherUserPageStickyKebab)
+            }
+        }
+    }
+
+    private fun showMenu(view: View) {
+        val popupWindow: PopupWindow = PopupWindow(
+            popupBinding.root,
+            WindowManager.LayoutParams.WRAP_CONTENT,
+            WindowManager.LayoutParams.WRAP_CONTENT,
+            true,
+        ).apply {
+            elevation = 2f.toFloatPxFromDp()
+            showAsDropDown(
+                view,
+                POPUP_MARGIN_END.toIntPxFromDp(),
+                POPUP_MARGIN_TOP.toIntPxFromDp(),
+            )
+        }
+    }
+
     companion object {
         private const val TOOLBAR_COLLAPSE_THRESHOLD = 0f
+        private const val POPUP_MARGIN_END = -80
+        private const val POPUP_MARGIN_TOP = 0
+
+        fun getIntent(context: Context): Intent {
+            return Intent(context, OtherUserPageActivity::class.java)
+        }
     }
 }

--- a/app/src/main/java/com/teamwss/websoso/ui/otherUserPage/OtherUserPageActivity.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/otherUserPage/OtherUserPageActivity.kt
@@ -125,9 +125,12 @@ class OtherUserPageActivity :
         private const val TOOLBAR_COLLAPSE_THRESHOLD = 0f
         private const val POPUP_MARGIN_END = -80
         private const val POPUP_MARGIN_TOP = 0
+        private const val USER_ID = "USER_ID"
 
-        fun getIntent(context: Context): Intent {
-            return Intent(context, OtherUserPageActivity::class.java)
+        fun getIntent(context: Context, userId: Long): Intent {
+            return Intent(context, OtherUserPageActivity::class.java).apply {
+                putExtra(USER_ID, userId)
+            }
         }
     }
 }

--- a/app/src/main/java/com/teamwss/websoso/ui/otherUserPage/OtherUserPageViewModel.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/otherUserPage/OtherUserPageViewModel.kt
@@ -18,19 +18,22 @@ class OtherUserPageViewModel @Inject constructor(
     private val _otherUserProfile = MutableLiveData<OtherUserProfileEntity>()
     val otherUserProfile: LiveData<OtherUserProfileEntity> get() = _otherUserProfile
 
-    private val userId: Long = getUserId()
+    private val _userId: MutableLiveData<Long> = MutableLiveData()
+    val userId: LiveData<Long> get() = _userId
 
     private val _isBlockedCompleted: MutableLiveData<Boolean> = MutableLiveData()
     val isBlockedCompleted: LiveData<Boolean> get() = _isBlockedCompleted
 
-    init {
-        updateUserProfile(userId)
+    fun updateUserId(userId: Long) {
+        _userId.value = userId
+
+        updateUserProfile()
     }
 
-    private fun updateUserProfile(userId: Long) {
+    private fun updateUserProfile() {
         viewModelScope.launch {
             runCatching {
-                userRepository.fetchOtherUserProfile(userId)
+                userRepository.fetchOtherUserProfile(userId.value ?: 0L)
             }.onSuccess { otherUserProfile ->
                 _otherUserProfile.value = otherUserProfile
             }.onFailure { exception ->
@@ -38,14 +41,10 @@ class OtherUserPageViewModel @Inject constructor(
         }
     }
 
-    private fun getUserId(): Long {
-        return 3L
-    }
-
     fun updateBlockedUser() {
         viewModelScope.launch {
             runCatching {
-                userRepository.saveBlockUser(userId)
+                userRepository.saveBlockUser(userId.value ?: 0L)
             }.onSuccess {
                 _isBlockedCompleted.value = true
             }.onFailure {}

--- a/app/src/main/java/com/teamwss/websoso/ui/otherUserPage/OtherUserPageViewModel.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/otherUserPage/OtherUserPageViewModel.kt
@@ -20,6 +20,9 @@ class OtherUserPageViewModel @Inject constructor(
 
     private val userId: Long = getUserId()
 
+    private val _isBlockedCompleted: MutableLiveData<Boolean> = MutableLiveData()
+    val isBlockedCompleted: LiveData<Boolean> get() = _isBlockedCompleted
+
     init {
         updateUserProfile(userId)
     }
@@ -36,6 +39,16 @@ class OtherUserPageViewModel @Inject constructor(
     }
 
     private fun getUserId(): Long {
-        return 1L
+        return 3L
+    }
+
+    fun updateBlockedUser() {
+        viewModelScope.launch {
+            runCatching {
+                userRepository.saveBlockUser(userId)
+            }.onSuccess {
+                _isBlockedCompleted.value = true
+            }.onFailure {}
+        }
     }
 }

--- a/app/src/main/res/drawable/btn_block_user.xml
+++ b/app/src/main/res/drawable/btn_block_user.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <corners android:radius="8dp" />
+    <solid android:color="@color/secondary_100_FF675D" />
+</shape>

--- a/app/src/main/res/layout/dialog_block_user.xml
+++ b/app/src/main/res/layout/dialog_block_user.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:background="@drawable/bg_logout_white_radius_12dp"
+        android:paddingHorizontal="20dp"
+        android:paddingVertical="24dp">
+
+        <ImageView
+            android:id="@+id/iv_block_user_exit"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="102dp"
+            android:src="@drawable/ic_logout_exit"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <TextView
+            android:id="@+id/tv_block_user_title"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="18dp"
+            android:text="@string/block_user_title"
+            android:textAppearance="@style/title1"
+            android:textColor="@color/black"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/iv_block_user_exit" />
+
+        <TextView
+            android:id="@+id/tv_block_user_description"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            android:gravity="center"
+            android:text="@string/block_user_description"
+            android:textAppearance="@style/body2"
+            android:textColor="@color/gray_300_52515F"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/tv_block_user_title" />
+
+        <TextView
+            android:id="@+id/tv_block_user_cancel_button"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="18dp"
+            android:background="@drawable/btn_logout_cancel"
+            android:paddingHorizontal="46dp"
+            android:paddingVertical="10dp"
+            android:text="@string/logout_cancel"
+            android:textAppearance="@style/label1"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/tv_block_user_description" />
+
+        <TextView
+            android:id="@+id/tv_block_user_button"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:background="@drawable/btn_block_user"
+            android:paddingHorizontal="46dp"
+            android:paddingVertical="10dp"
+            android:text="@string/block_user_button"
+            android:textAppearance="@style/label1"
+            android:textColor="@color/white"
+            app:layout_constraintBottom_toBottomOf="@id/tv_block_user_cancel_button"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="@id/tv_block_user_cancel_button" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/app/src/main/res/layout/menu_other_user_page_popup.xml
+++ b/app/src/main/res/layout/menu_other_user_page_popup.xml
@@ -4,7 +4,7 @@
     <data>
 
         <variable
-            name="onBlockedUser"
+            name="onBlockedUserClick"
             type="kotlin.jvm.functions.Function0" />
     </data>
 
@@ -20,7 +20,7 @@
             android:layout_height="wrap_content"
             android:background="@drawable/bg_novel_detail_white_radius_14dp"
             android:gravity="center"
-            android:onClick="@{() -> onBlockedUser.invoke()}"
+            android:onClick="@{() -> onBlockedUserClick.invoke()}"
             android:paddingHorizontal="32dp"
             android:paddingVertical="16dp"
             android:text="@string/other_user_page_popup_blocked_user_kebab_button"

--- a/app/src/main/res/layout/menu_other_user_page_popup.xml
+++ b/app/src/main/res/layout/menu_other_user_page_popup.xml
@@ -23,7 +23,7 @@
             android:onClick="@{() -> onBlockedUser.invoke()}"
             android:paddingHorizontal="32dp"
             android:paddingVertical="16dp"
-            android:text="@string/other_user_page_popup_blocked_user_button"
+            android:text="@string/other_user_page_popup_blocked_user_kebab_button"
             android:textAppearance="@style/body2"
             android:textColor="@color/black"
             app:layout_constraintEnd_toEndOf="parent"

--- a/app/src/main/res/layout/menu_other_user_page_popup.xml
+++ b/app/src/main/res/layout/menu_other_user_page_popup.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout>
+
+    <data>
+
+        <variable
+            name="onBlockedUser"
+            type="kotlin.jvm.functions.Function0" />
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:app="http://schemas.android.com/apk/res-auto"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:background="@drawable/bg_feed_popup">
+
+        <TextView
+            android:id="@+id/tv_other_user_page_popup_blocked_user_button"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:background="@drawable/bg_novel_detail_white_radius_14dp"
+            android:gravity="center"
+            android:onClick="@{() -> onBlockedUser.invoke()}"
+            android:paddingHorizontal="32dp"
+            android:paddingVertical="16dp"
+            android:text="@string/other_user_page_popup_blocked_user_button"
+            android:textAppearance="@style/body2"
+            android:textColor="@color/black"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -335,7 +335,10 @@
     <!-- 다른 유저 페이지 뷰 -->
     <string name="other_user_page_library">서재</string>
     <string name="other_user_page_activity">활동</string>
-    <string name="other_user_page_popup_blocked_user_button">차단하기</string>
+    <string name="other_user_page_popup_blocked_user_kebab_button">차단하기</string>
+    <string name="block_user_title">해당 유저를 차단할까요?</string>
+    <string name="block_user_description">차단하면 서로의 피드, 댓글,\n프로필을 볼 수 없어요</string>
+    <string name="block_user_button">차단</string>
 
     <!-- 다른 유저 서재 뷰 -->
     <string name="other_user_library_storage">보관함</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -339,6 +339,7 @@
     <string name="block_user_title">해당 유저를 차단할까요?</string>
     <string name="block_user_description">차단하면 서로의 피드, 댓글,\n프로필을 볼 수 없어요</string>
     <string name="block_user_button">차단</string>
+    <string name="block_user_success_message">%s님을 차단했어요</string>
 
     <!-- 다른 유저 서재 뷰 -->
     <string name="other_user_library_storage">보관함</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -341,7 +341,7 @@
     <string name="other_user_page_activity">활동</string>
     <string name="other_user_page_popup_blocked_user_kebab_button">차단하기</string>
     <string name="block_user_title">해당 유저를 차단할까요?</string>
-    <string name="block_user_description">차단하면 서로의 피드, 댓글,\n프로필을 볼 수 없어요</string>
+    <string name="block_user_description">상대의 게시글, 댓글,\n프로필을 볼 수 없어요</string>
     <string name="block_user_button">차단</string>
     <string name="block_user_success_message">%s님을 차단했어요</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -335,6 +335,7 @@
     <!-- 다른 유저 페이지 뷰 -->
     <string name="other_user_page_library">서재</string>
     <string name="other_user_page_activity">활동</string>
+    <string name="other_user_page_popup_blocked_user_button">차단하기</string>
 
     <!-- 다른 유저 서재 뷰 -->
     <string name="other_user_library_storage">보관함</string>


### PR DESCRIPTION
+) UX라이팅 변경되면 반영하고 머지하겠습니다
변경완료!
<img width="312" alt="스크린샷 2024-09-27 오후 2 07 38" src="https://github.com/user-attachments/assets/7a624773-364e-4a61-896e-55d44e2bbb33">


## 📌𝘐𝘴𝘴𝘶𝘦𝘴
- closed #239 
- closed #245 

## 📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯
- 어쩌다보니 이슈 두 개를 한 번에 해결했네요
- 유저 차단하기 다이얼로그 및 팝업 ui 구현했습니다.
- 유저 차단하기 api 구현했습니다.
- 유저 차단 후 이전 뷰에서 스낵바를 띄워야 하는데, 이 때 스낵바가 뜰 수 있는 곳이 
> 1. 피드 뷰에서 게시글 작성자를 눌렀을 때
> 2. -a 피드 디테일 뷰에서 작성자를 눌렀을 때
> 2. -b 피드 디테일 뷰에서 댓글을 눌렀을 때
> 3. 작품 수다에서 게시글 작성자를 눌렀을 때

이렇게 있습니다. 

## 📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵

1. 피드 뷰에서 게시글 작성자를 눌렀을 때

https://github.com/user-attachments/assets/a025f977-af39-4bcb-ac3b-723bc9ea153f

2. 피드 상세 뷰에서 게시글 작성자를 눌렀을 때

https://github.com/user-attachments/assets/e43d92aa-b602-4ed2-8f24-e37b29cfb4cc

3. 피드 상세 뷰에서 댓글 작성자를 눌렀을 때

https://github.com/user-attachments/assets/17681920-9edd-43cb-aa08-1e81a40dd117

4. 작품 수다에서 게시글 작성자를 눌렀을 때

https://github.com/user-attachments/assets/6b3c6274-b50d-4522-956c-21ef1147c503


## 💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴
to. 해리
// TODO: 로 본인/혹은 타유저 프로필 분기처리 해야할 곳 표시해뒀으니 부탁드립니다. 
`activityResultCallback.launch` 로 뷰를 열어주시면 됩니다!
