### PR TITLE
feat: 프로필 공개여부 수정 시 스낵바 메시지 출력 및 UX라이팅 수정 

### DIFF
--- a/app/src/main/java/com/teamwss/websoso/common/ui/model/ResultFrom.kt
+++ b/app/src/main/java/com/teamwss/websoso/common/ui/model/ResultFrom.kt
@@ -4,7 +4,7 @@ enum class ResultFrom {
     FeedDetailBack,
     FeedDetailRemoved,
     CreateFeed,
-    EditProfileDisclosure,
+    ChangeProfileDisclosure,
     ;
 
     val RESULT_OK: Int = ordinal

--- a/app/src/main/java/com/teamwss/websoso/common/ui/model/ResultFrom.kt
+++ b/app/src/main/java/com/teamwss/websoso/common/ui/model/ResultFrom.kt
@@ -4,6 +4,7 @@ enum class ResultFrom {
     FeedDetailBack,
     FeedDetailRemoved,
     CreateFeed,
+    EditProfileDisclosure,
     ;
 
     val RESULT_OK: Int = ordinal

--- a/app/src/main/java/com/teamwss/websoso/ui/profileDisclosure/ProfileDisclosureActivity.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/profileDisclosure/ProfileDisclosureActivity.kt
@@ -6,7 +6,6 @@ import android.os.Bundle
 import androidx.activity.viewModels
 import com.teamwss.websoso.R
 import com.teamwss.websoso.common.ui.base.BaseActivity
-import com.teamwss.websoso.common.ui.model.ResultFrom
 import com.teamwss.websoso.common.ui.model.ResultFrom.*
 import com.teamwss.websoso.databinding.ActivityProfileDisclosureBinding
 import dagger.hilt.android.AndroidEntryPoint
@@ -78,7 +77,7 @@ class ProfileDisclosureActivity :
                 val intent = Intent().apply {
                     putExtra(IS_PROFILE_PUBLIC, profileDisclosureViewModel.isProfilePublic.value)
                 }
-                setResult(EditProfileDisclosure.RESULT_OK, intent)
+                setResult(ChangeProfileDisclosure.RESULT_OK, intent)
                 finish()
             }
         }

--- a/app/src/main/java/com/teamwss/websoso/ui/profileDisclosure/ProfileDisclosureActivity.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/profileDisclosure/ProfileDisclosureActivity.kt
@@ -6,6 +6,8 @@ import android.os.Bundle
 import androidx.activity.viewModels
 import com.teamwss.websoso.R
 import com.teamwss.websoso.common.ui.base.BaseActivity
+import com.teamwss.websoso.common.ui.model.ResultFrom
+import com.teamwss.websoso.common.ui.model.ResultFrom.*
 import com.teamwss.websoso.databinding.ActivityProfileDisclosureBinding
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -72,7 +74,13 @@ class ProfileDisclosureActivity :
         }
 
         profileDisclosureViewModel.isSaveStatusComplete.observe(this) { isSaveStatus ->
-            if (isSaveStatus) finish()
+            if (isSaveStatus) {
+                val intent = Intent().apply {
+                    putExtra(IS_PROFILE_PUBLIC, profileDisclosureViewModel.isProfilePublic.value)
+                }
+                setResult(EditProfileDisclosure.RESULT_OK, intent)
+                finish()
+            }
         }
     }
 
@@ -85,6 +93,7 @@ class ProfileDisclosureActivity :
     }
 
     companion object {
+        const val IS_PROFILE_PUBLIC = "isProfilePublic"
 
         fun getIntent(context: Context): Intent {
             return Intent(context, ProfileDisclosureActivity::class.java)

--- a/app/src/main/java/com/teamwss/websoso/ui/profileDisclosure/ProfileDisclosureActivity.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/profileDisclosure/ProfileDisclosureActivity.kt
@@ -6,8 +6,9 @@ import android.os.Bundle
 import androidx.activity.viewModels
 import com.teamwss.websoso.R
 import com.teamwss.websoso.common.ui.base.BaseActivity
-import com.teamwss.websoso.common.ui.model.ResultFrom.*
+import com.teamwss.websoso.common.ui.model.ResultFrom.ChangeProfileDisclosure
 import com.teamwss.websoso.databinding.ActivityProfileDisclosureBinding
+import com.teamwss.websoso.ui.setting.SettingActivity
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
@@ -74,9 +75,10 @@ class ProfileDisclosureActivity :
 
         profileDisclosureViewModel.isSaveStatusComplete.observe(this) { isSaveStatus ->
             if (isSaveStatus) {
-                val intent = Intent().apply {
-                    putExtra(IS_PROFILE_PUBLIC, profileDisclosureViewModel.isProfilePublic.value)
-                }
+                val intent = SettingActivity.getIntent(
+                    this,
+                    profileDisclosureViewModel.isProfilePublic.value ?: true,
+                )
                 setResult(ChangeProfileDisclosure.RESULT_OK, intent)
                 finish()
             }

--- a/app/src/main/java/com/teamwss/websoso/ui/setting/SettingActivity.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/setting/SettingActivity.kt
@@ -4,9 +4,13 @@ import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
+import androidx.activity.result.ActivityResult
 import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContracts
 import com.teamwss.websoso.R
+import com.teamwss.websoso.R.*
+import com.teamwss.websoso.R.drawable.*
+import com.teamwss.websoso.R.string.*
 import com.teamwss.websoso.common.ui.base.BaseActivity
 import com.teamwss.websoso.common.ui.model.ResultFrom.EditProfileDisclosure
 import com.teamwss.websoso.common.util.showWebsosoSnackBar
@@ -14,7 +18,7 @@ import com.teamwss.websoso.databinding.ActivitySettingBinding
 import com.teamwss.websoso.ui.accountInfo.AccountInfoActivity
 import com.teamwss.websoso.ui.profileDisclosure.ProfileDisclosureActivity
 
-class SettingActivity : BaseActivity<ActivitySettingBinding>(R.layout.activity_setting) {
+class SettingActivity : BaseActivity<ActivitySettingBinding>(layout.activity_setting) {
     private lateinit var activityResultCallback: ActivityResultLauncher<Intent>
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -24,26 +28,30 @@ class SettingActivity : BaseActivity<ActivitySettingBinding>(R.layout.activity_s
             registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
                 when (result.resultCode) {
                     EditProfileDisclosure.RESULT_OK -> {
-                        val isProfilePublic =
-                            result.data?.getBooleanExtra(
-                                ProfileDisclosureActivity.IS_PROFILE_PUBLIC,
-                                false,
-                            )
-                        val message: String = when (isProfilePublic) {
-                            true -> getString(R.string.profile_disclosure_message, "전체 공개")
-                            false -> getString(R.string.profile_disclosure_message, "비공개")
-                            else -> error("")
-                        }
-
-                        showWebsosoSnackBar(
-                            view = binding.root,
-                            message = message,
-                            icon = R.drawable.ic_novel_detail_check,
-                        )
+                        showEditProfileDisclosureSuccessMessage(result)
                     }
                 }
             }
         bindClickListener()
+    }
+
+    private fun showEditProfileDisclosureSuccessMessage(result: ActivityResult) {
+        val isProfilePublic =
+            result.data?.getBooleanExtra(
+                ProfileDisclosureActivity.IS_PROFILE_PUBLIC,
+                false,
+            )
+        val message: String = when (isProfilePublic) {
+            true -> getString(profile_disclosure_message, getString(profile_disclosure_public))
+            false -> getString(profile_disclosure_message, getString(profile_disclosure_private))
+            else -> error("")
+        }
+
+        showWebsosoSnackBar(
+            view = binding.root,
+            message = message,
+            icon = ic_novel_detail_check,
+        )
     }
 
     private fun bindClickListener() {
@@ -64,13 +72,13 @@ class SettingActivity : BaseActivity<ActivitySettingBinding>(R.layout.activity_s
         }
 
         override fun onWebsosoOfficialButtonClick() {
-            val officialUrl = getString(R.string.websoso_official)
+            val officialUrl = getString(websoso_official)
             val intent = Intent(Intent.ACTION_VIEW, Uri.parse(officialUrl))
             startActivity(intent)
         }
 
         override fun onInquireAndFeedbackButtonClick() {
-            val inquireUrl = getString(R.string.inquire_link)
+            val inquireUrl = getString(inquire_link)
             val intent = Intent(Intent.ACTION_VIEW, Uri.parse(inquireUrl))
             startActivity(intent)
         }

--- a/app/src/main/java/com/teamwss/websoso/ui/setting/SettingActivity.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/setting/SettingActivity.kt
@@ -4,17 +4,45 @@ import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
+import androidx.activity.result.ActivityResultLauncher
+import androidx.activity.result.contract.ActivityResultContracts
 import com.teamwss.websoso.R
 import com.teamwss.websoso.common.ui.base.BaseActivity
+import com.teamwss.websoso.common.ui.model.ResultFrom.EditProfileDisclosure
+import com.teamwss.websoso.common.util.showWebsosoSnackBar
 import com.teamwss.websoso.databinding.ActivitySettingBinding
 import com.teamwss.websoso.ui.accountInfo.AccountInfoActivity
 import com.teamwss.websoso.ui.profileDisclosure.ProfileDisclosureActivity
 
 class SettingActivity : BaseActivity<ActivitySettingBinding>(R.layout.activity_setting) {
+    private lateinit var activityResultCallback: ActivityResultLauncher<Intent>
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
+        activityResultCallback =
+            registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
+                when (result.resultCode) {
+                    EditProfileDisclosure.RESULT_OK -> {
+                        val isProfilePublic =
+                            result.data?.getBooleanExtra(
+                                ProfileDisclosureActivity.IS_PROFILE_PUBLIC,
+                                false,
+                            )
+                        val message: String = when (isProfilePublic) {
+                            true -> getString(R.string.profile_disclosure_message, "전체 공개")
+                            false -> getString(R.string.profile_disclosure_message, "비공개")
+                            else -> error("")
+                        }
+
+                        showWebsosoSnackBar(
+                            view = binding.root,
+                            message = message,
+                            icon = R.drawable.ic_novel_detail_check,
+                        )
+                    }
+                }
+            }
         bindClickListener()
     }
 
@@ -32,7 +60,7 @@ class SettingActivity : BaseActivity<ActivitySettingBinding>(R.layout.activity_s
 
         override fun onProfileDisclosureButtonClick() {
             val intent = ProfileDisclosureActivity.getIntent(this@SettingActivity)
-            startActivity(intent)
+            activityResultCallback.launch(intent)
         }
 
         override fun onWebsosoOfficialButtonClick() {

--- a/app/src/main/java/com/teamwss/websoso/ui/setting/SettingActivity.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/setting/SettingActivity.kt
@@ -15,7 +15,7 @@ import com.teamwss.websoso.R.string.profile_disclosure_private
 import com.teamwss.websoso.R.string.profile_disclosure_public
 import com.teamwss.websoso.R.string.websoso_official
 import com.teamwss.websoso.common.ui.base.BaseActivity
-import com.teamwss.websoso.common.ui.model.ResultFrom.EditProfileDisclosure
+import com.teamwss.websoso.common.ui.model.ResultFrom.ChangeProfileDisclosure
 import com.teamwss.websoso.common.util.showWebsosoSnackBar
 import com.teamwss.websoso.databinding.ActivitySettingBinding
 import com.teamwss.websoso.ui.accountInfo.AccountInfoActivity
@@ -30,7 +30,7 @@ class SettingActivity : BaseActivity<ActivitySettingBinding>(layout.activity_set
         activityResultCallback =
             registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
                 when (result.resultCode) {
-                    EditProfileDisclosure.RESULT_OK -> {
+                    ChangeProfileDisclosure.RESULT_OK -> {
                         showEditProfileDisclosureSuccessMessage(result)
                     }
                 }

--- a/app/src/main/java/com/teamwss/websoso/ui/setting/SettingActivity.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/setting/SettingActivity.kt
@@ -7,10 +7,13 @@ import android.os.Bundle
 import androidx.activity.result.ActivityResult
 import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContracts
-import com.teamwss.websoso.R
-import com.teamwss.websoso.R.*
-import com.teamwss.websoso.R.drawable.*
-import com.teamwss.websoso.R.string.*
+import com.teamwss.websoso.R.drawable.ic_novel_detail_check
+import com.teamwss.websoso.R.layout
+import com.teamwss.websoso.R.string.inquire_link
+import com.teamwss.websoso.R.string.profile_disclosure_message
+import com.teamwss.websoso.R.string.profile_disclosure_private
+import com.teamwss.websoso.R.string.profile_disclosure_public
+import com.teamwss.websoso.R.string.websoso_official
 import com.teamwss.websoso.common.ui.base.BaseActivity
 import com.teamwss.websoso.common.ui.model.ResultFrom.EditProfileDisclosure
 import com.teamwss.websoso.common.util.showWebsosoSnackBar
@@ -41,10 +44,9 @@ class SettingActivity : BaseActivity<ActivitySettingBinding>(layout.activity_set
                 ProfileDisclosureActivity.IS_PROFILE_PUBLIC,
                 false,
             )
-        val message: String = when (isProfilePublic) {
+        val message: String = when (isProfilePublic ?: true) {
             true -> getString(profile_disclosure_message, getString(profile_disclosure_public))
             false -> getString(profile_disclosure_message, getString(profile_disclosure_private))
-            else -> error("")
         }
 
         showWebsosoSnackBar(

--- a/app/src/main/java/com/teamwss/websoso/ui/setting/SettingActivity.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/setting/SettingActivity.kt
@@ -25,9 +25,7 @@ class SettingActivity : BaseActivity<ActivitySettingBinding>(layout.activity_set
         ActivityResultContracts.StartActivityForResult()
     ) { result ->
         when (result.resultCode) {
-            ChangeProfileDisclosure.RESULT_OK -> {
-                showEditProfileDisclosureSuccessMessage(result)
-            }
+            ChangeProfileDisclosure.RESULT_OK -> showEditProfileDisclosureSuccessMessage(result)
         }
     }
 

--- a/app/src/main/java/com/teamwss/websoso/ui/setting/SettingActivity.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/setting/SettingActivity.kt
@@ -42,9 +42,9 @@ class SettingActivity : BaseActivity<ActivitySettingBinding>(layout.activity_set
         val isProfilePublic =
             result.data?.getBooleanExtra(
                 ProfileDisclosureActivity.IS_PROFILE_PUBLIC,
-                false,
-            )
-        val message: String = when (isProfilePublic ?: true) {
+                true,
+            ) ?: true
+        val message: String = when (isProfilePublic) {
             true -> getString(profile_disclosure_message, getString(profile_disclosure_public))
             false -> getString(profile_disclosure_message, getString(profile_disclosure_private))
         }

--- a/app/src/main/java/com/teamwss/websoso/ui/setting/SettingActivity.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/setting/SettingActivity.kt
@@ -5,7 +5,6 @@ import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
 import androidx.activity.result.ActivityResult
-import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContracts
 import com.teamwss.websoso.R.drawable.ic_novel_detail_check
 import com.teamwss.websoso.R.layout
@@ -22,19 +21,19 @@ import com.teamwss.websoso.ui.accountInfo.AccountInfoActivity
 import com.teamwss.websoso.ui.profileDisclosure.ProfileDisclosureActivity
 
 class SettingActivity : BaseActivity<ActivitySettingBinding>(layout.activity_setting) {
-    private lateinit var activityResultCallback: ActivityResultLauncher<Intent>
+    private val startActivityLauncher = registerForActivityResult(
+        ActivityResultContracts.StartActivityForResult()
+    ) { result ->
+        when (result.resultCode) {
+            ChangeProfileDisclosure.RESULT_OK -> {
+                showEditProfileDisclosureSuccessMessage(result)
+            }
+        }
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        activityResultCallback =
-            registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
-                when (result.resultCode) {
-                    ChangeProfileDisclosure.RESULT_OK -> {
-                        showEditProfileDisclosureSuccessMessage(result)
-                    }
-                }
-            }
         bindClickListener()
     }
 
@@ -70,7 +69,7 @@ class SettingActivity : BaseActivity<ActivitySettingBinding>(layout.activity_set
 
         override fun onProfileDisclosureButtonClick() {
             val intent = ProfileDisclosureActivity.getIntent(this@SettingActivity)
-            activityResultCallback.launch(intent)
+            startActivityLauncher.launch(intent)
         }
 
         override fun onWebsosoOfficialButtonClick() {
@@ -99,7 +98,7 @@ class SettingActivity : BaseActivity<ActivitySettingBinding>(layout.activity_set
     }
 
     companion object {
-        const val IS_PROFILE_PUBLIC = "isProfilePublic"
+        private const val IS_PROFILE_PUBLIC = "isProfilePublic"
 
         fun getIntent(context: Context): Intent {
             return Intent(context, SettingActivity::class.java)

--- a/app/src/main/java/com/teamwss/websoso/ui/setting/SettingActivity.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/setting/SettingActivity.kt
@@ -85,6 +85,10 @@ class SettingActivity : BaseActivity<ActivitySettingBinding>(layout.activity_set
             startActivity(intent)
         }
 
+        override fun onPrivacyPolicyButtonClick() {
+            // TODO 개인정보 처리방침으로 이동
+        }
+
         override fun onTermsOfUseButtonClick() {
             // TODO 서비스 이용약관으로 이동
         }

--- a/app/src/main/java/com/teamwss/websoso/ui/setting/SettingActivity.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/setting/SettingActivity.kt
@@ -99,9 +99,16 @@ class SettingActivity : BaseActivity<ActivitySettingBinding>(layout.activity_set
     }
 
     companion object {
+        const val IS_PROFILE_PUBLIC = "isProfilePublic"
 
         fun getIntent(context: Context): Intent {
             return Intent(context, SettingActivity::class.java)
+        }
+
+        fun getIntent(context: Context, isProfilePublic: Boolean): Intent {
+            return Intent(context, SettingActivity::class.java).apply {
+                putExtra(IS_PROFILE_PUBLIC, isProfilePublic)
+            }
         }
     }
 }

--- a/app/src/main/java/com/teamwss/websoso/ui/setting/SettingClickListener.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/setting/SettingClickListener.kt
@@ -10,6 +10,8 @@ interface SettingClickListener {
 
     fun onInquireAndFeedbackButtonClick()
 
+    fun onPrivacyPolicyButtonClick()
+
     fun onTermsOfUseButtonClick()
 
     fun onBackButtonClick()

--- a/app/src/main/res/layout/activity_setting.xml
+++ b/app/src/main/res/layout/activity_setting.xml
@@ -46,7 +46,7 @@
             android:onClick="@{() -> onClick.onUserAccountInfoButtonClick()}"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/tv_setting_title">
+            app:layout_constraintTop_toBottomOf="@id/iv_setting_back_button">
 
             <TextView
                 android:layout_width="wrap_content"
@@ -200,13 +200,53 @@
         </androidx.constraintlayout.widget.ConstraintLayout>
 
         <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/cl_setting_privacy_police"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:onClick="@{() -> onClick.onPrivacyPolicyButtonClick()}"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/cl_setting_inquire_and_feedback">
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginVertical="20dp"
+                android:layout_marginStart="20dp"
+                android:text="@string/setting_privacy_police"
+                android:textAppearance="@style/body2"
+                android:textColor="@color/black"
+                app:layout_constraintBottom_toTopOf="@id/view_setting_app_rating_underline"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <ImageView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginEnd="20dp"
+                android:src="@drawable/btn_setting_right"
+                app:layout_constraintBottom_toTopOf="@id/view_setting_app_rating_underline"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <View
+                android:id="@+id/view_setting_app_rating_underline"
+                android:layout_width="0dp"
+                android:layout_height="1dp"
+                android:background="@color/gray_50_F4F5F8"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent" />
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+        <androidx.constraintlayout.widget.ConstraintLayout
             android:id="@+id/cl_setting_terms_of_use"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:onClick="@{() -> onClick.onTermsOfUseButtonClick()}"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/cl_setting_inquire_and_feedback">
+            app:layout_constraintTop_toBottomOf="@id/cl_setting_privacy_police">
 
             <TextView
                 android:layout_width="wrap_content"

--- a/app/src/main/res/layout/dialog_onboarding_birth_year.xml
+++ b/app/src/main/res/layout/dialog_onboarding_birth_year.xml
@@ -17,6 +17,7 @@
             android:layout_marginStart="20dp"
             android:text="@string/onboarding_second_bottom_sheet_birth_year"
             android:textAppearance="@style/title1"
+            android:textColor="@color/black"
             app:layout_constraintBottom_toBottomOf="@id/iv_onboarding_second_bottom_sheet_cancel"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="@id/iv_onboarding_second_bottom_sheet_cancel" />

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -275,6 +275,7 @@
     <string name="profile_disclosure_title">프로필 공개 설정</string>
     <string name="profile_disclosure_complete">완료</string>
     <string name="profile_disclosure_private">비공개</string>
+    <string name="profile_disclosure_public">전체 공개</string>
     <string name="profile_disclosure_message">프로필이 %s로 전환되었어요</string>
 
     <!-- 로그아웃 다이얼로그 뷰 -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -275,6 +275,7 @@
     <string name="profile_disclosure_title">프로필 공개여부</string>
     <string name="profile_disclosure_complete">완료</string>
     <string name="profile_disclosure_private">비공개</string>
+    <string name="profile_disclosure_message">프로필이 %s로 전환되었어요</string>
 
     <!-- 로그아웃 다이얼로그 뷰 -->
     <string name="logout_title">로그아웃 할까요?</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -248,6 +248,7 @@
     <string name="setting_profile_disclosure">프로필 공개 설정</string>
     <string name="setting_websoso_account">웹소소 공식 계정</string>
     <string name="setting_inquire_and_feedback"><![CDATA[문의하기 & 의견 보내기]]></string>
+    <string name="setting_privacy_police">개인정보 처리방침</string>
     <string name="setting_app_rating">앱 평점 남기기</string>
     <string name="setting_terms_of_use">서비스 이용약관</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -245,7 +245,7 @@
     <!-- 환경설정 뷰-->
     <string name="setting_title">설정</string>
     <string name="setting_account_info">계정정보</string>
-    <string name="setting_profile_disclosure">프로필 공개 여부 설정</string>
+    <string name="setting_profile_disclosure">프로필 공개 설정</string>
     <string name="setting_websoso_account">웹소소 공식 계정</string>
     <string name="setting_inquire_and_feedback"><![CDATA[문의하기 & 의견 보내기]]></string>
     <string name="setting_app_rating">앱 평점 남기기</string>
@@ -272,7 +272,7 @@
     <string name="change_user_info_complete">완료</string>
 
     <!-- 프로필 공개여부 뷰 -->
-    <string name="profile_disclosure_title">프로필 공개여부</string>
+    <string name="profile_disclosure_title">프로필 공개 설정</string>
     <string name="profile_disclosure_complete">완료</string>
     <string name="profile_disclosure_private">비공개</string>
     <string name="profile_disclosure_message">프로필이 %s로 전환되었어요</string>


### PR DESCRIPTION
## 📌𝘐𝘴𝘴𝘶𝘦𝘴
- closed #349

## 📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯
- 프로필 공개 여부 수정에 따른 스낵바 메시지를 출력했습니다.
![image](https://github.com/user-attachments/assets/5151483c-e02a-48eb-b586-f8d430562844)
- 추가된 개인정보 처리방침 버튼 ui를 구현했습니다. 
- 수정된 출생연도 색상을 변경했습니다. (기존에도 color 값 없어서 black으로 추가했습니다.)

## 📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵

https://github.com/user-attachments/assets/16b4c06b-480c-4838-be67-b34b1436c45f



## 💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴