### PR TITLE
feat: 유저의 userId, userNickname을 받아오는 api 연결 및 dataStore 저장 로직 구현

### DIFF
--- a/app/src/main/java/com/teamwss/websoso/data/mapper/UserMapper.kt
+++ b/app/src/main/java/com/teamwss/websoso/data/mapper/UserMapper.kt
@@ -6,6 +6,7 @@ import com.teamwss.websoso.data.model.GenrePreferenceEntity
 import com.teamwss.websoso.data.model.MyProfileEntity
 import com.teamwss.websoso.data.model.NovelPreferenceEntity
 import com.teamwss.websoso.data.model.OtherUserProfileEntity
+import com.teamwss.websoso.data.model.UserInfoDetailEntity
 import com.teamwss.websoso.data.model.UserInfoEntity
 import com.teamwss.websoso.data.model.UserNovelStatsEntity
 import com.teamwss.websoso.data.model.UserProfileStatusEntity
@@ -14,6 +15,7 @@ import com.teamwss.websoso.data.remote.response.GenrePreferenceResponseDto
 import com.teamwss.websoso.data.remote.response.MyProfileResponseDto
 import com.teamwss.websoso.data.remote.response.NovelPreferenceResponseDto
 import com.teamwss.websoso.data.remote.response.OtherUserProfileResponseDto
+import com.teamwss.websoso.data.remote.response.UserInfoDetailResponseDto
 import com.teamwss.websoso.data.remote.response.UserInfoResponseDto
 import com.teamwss.websoso.data.remote.response.UserNovelStatsResponseDto
 import com.teamwss.websoso.data.remote.response.UserProfileStatusResponseDto
@@ -21,6 +23,13 @@ import com.teamwss.websoso.ui.main.myPage.myActivity.model.Genres
 
 fun UserInfoResponseDto.toData(): UserInfoEntity {
     return UserInfoEntity(
+        userId = this.userId,
+        nickname = this.nickname,
+    )
+}
+
+fun UserInfoDetailResponseDto.toData(): UserInfoDetailEntity {
+    return UserInfoDetailEntity(
         email = email,
         gender = gender,
         birthYear = birth,

--- a/app/src/main/java/com/teamwss/websoso/data/model/UserInfoDetailEntity.kt
+++ b/app/src/main/java/com/teamwss/websoso/data/model/UserInfoDetailEntity.kt
@@ -1,0 +1,7 @@
+package com.teamwss.websoso.data.model
+
+data class UserInfoDetailEntity(
+    val email: String,
+    val gender: String,
+    val birthYear: Int,
+)

--- a/app/src/main/java/com/teamwss/websoso/data/model/UserInfoEntity.kt
+++ b/app/src/main/java/com/teamwss/websoso/data/model/UserInfoEntity.kt
@@ -1,7 +1,6 @@
 package com.teamwss.websoso.data.model
 
 data class UserInfoEntity(
-    val email: String,
-    val gender: String,
-    val birthYear: Int,
+    val userId: Long,
+    val nickname: String,
 )

--- a/app/src/main/java/com/teamwss/websoso/data/remote/api/UserApi.kt
+++ b/app/src/main/java/com/teamwss/websoso/data/remote/api/UserApi.kt
@@ -9,6 +9,7 @@ import com.teamwss.websoso.data.remote.response.GenrePreferenceResponseDto
 import com.teamwss.websoso.data.remote.response.MyProfileResponseDto
 import com.teamwss.websoso.data.remote.response.NovelPreferenceResponseDto
 import com.teamwss.websoso.data.remote.response.OtherUserProfileResponseDto
+import com.teamwss.websoso.data.remote.response.UserInfoDetailResponseDto
 import com.teamwss.websoso.data.remote.response.UserInfoResponseDto
 import com.teamwss.websoso.data.remote.response.UserNicknameValidityResponseDto
 import com.teamwss.websoso.data.remote.response.UserNovelStatsResponseDto
@@ -24,8 +25,11 @@ import retrofit2.http.Query
 
 interface UserApi {
 
-    @GET("users/info")
+    @GET("users/me")
     suspend fun getUserInfo(): UserInfoResponseDto
+
+    @GET("users/info")
+    suspend fun getUserInfoDetail(): UserInfoDetailResponseDto
 
     @GET("blocks")
     suspend fun getBlockedUser(): BlockedUsersResponseDto

--- a/app/src/main/java/com/teamwss/websoso/data/remote/response/UserInfoDetailResponseDto.kt
+++ b/app/src/main/java/com/teamwss/websoso/data/remote/response/UserInfoDetailResponseDto.kt
@@ -1,0 +1,14 @@
+package com.teamwss.websoso.data.remote.response
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class UserInfoDetailResponseDto(
+    @SerialName("email")
+    val email: String,
+    @SerialName("gender")
+    val gender: String,
+    @SerialName("birth")
+    val birth: Int,
+)

--- a/app/src/main/java/com/teamwss/websoso/data/remote/response/UserInfoResponseDto.kt
+++ b/app/src/main/java/com/teamwss/websoso/data/remote/response/UserInfoResponseDto.kt
@@ -5,10 +5,8 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class UserInfoResponseDto(
-    @SerialName("email")
-    val email: String,
-    @SerialName("gender")
-    val gender: String,
-    @SerialName("birth")
-    val birth: Int,
+    @SerialName("userId")
+    val userId: Long,
+    @SerialName("nickname")
+    val nickname: String,
 )

--- a/app/src/main/java/com/teamwss/websoso/data/repository/UserRepository.kt
+++ b/app/src/main/java/com/teamwss/websoso/data/repository/UserRepository.kt
@@ -121,12 +121,12 @@ class UserRepository @Inject constructor(
 
     suspend fun fetchUserId(): Long {
         val preferences = userStorage.data.first()
-        return preferences[USER_ID_KEY]?.toLongOrNull() ?: -1L
+        return preferences[USER_ID_KEY]?.toLongOrNull() ?: DEFAULT_USER_ID
     }
 
     suspend fun fetchNickname(): String {
         val preferences = userStorage.data.first()
-        return preferences[NICKNAME_KEY] ?: "웹소소"
+        return preferences[NICKNAME_KEY] ?: DEFAULT_NICKNAME
     }
 
     suspend fun fetchNovelDetailFirstLaunched(): Boolean {
@@ -166,5 +166,7 @@ class UserRepository @Inject constructor(
         val REFRESH_TOKEN_KEY = stringPreferencesKey("REFRESH_TOKEN")
         val USER_ID_KEY = stringPreferencesKey("USER_ID")
         val NICKNAME_KEY = stringPreferencesKey("NICKNAME")
+        const val DEFAULT_NICKNAME = "웹소소"
+        const val DEFAULT_USER_ID = -1L
     }
 }

--- a/app/src/main/java/com/teamwss/websoso/data/repository/UserRepository.kt
+++ b/app/src/main/java/com/teamwss/websoso/data/repository/UserRepository.kt
@@ -30,7 +30,7 @@ class UserRepository @Inject constructor(
 
     suspend fun fetchUserInfo(): UserInfoEntity {
         val userInfo = userApi.getUserInfo().toData()
-        saveUserInfoToDataStore(userInfo.userId, userInfo.nickname)
+        saveUserInfo(userInfo.userId, userInfo.nickname)
         return userInfo
     }
 
@@ -58,7 +58,7 @@ class UserRepository @Inject constructor(
         userApi.patchProfileStatus(UserProfileStatusRequestDto(isProfilePublic))
     }
 
-    private suspend fun saveUserInfoToDataStore(userId: Long, nickname: String) {
+    private suspend fun saveUserInfo(userId: Long, nickname: String) {
         userStorage.edit { preferences ->
             preferences[USER_ID_KEY] = userId.toString()
             preferences[NICKNAME_KEY] = nickname

--- a/app/src/main/java/com/teamwss/websoso/data/repository/UserRepository.kt
+++ b/app/src/main/java/com/teamwss/websoso/data/repository/UserRepository.kt
@@ -34,6 +34,13 @@ class UserRepository @Inject constructor(
         return userInfo
     }
 
+    private suspend fun saveUserInfo(userId: Long, nickname: String) {
+        userStorage.edit { preferences ->
+            preferences[USER_ID_KEY] = userId.toString()
+            preferences[NICKNAME_KEY] = nickname
+        }
+    }
+
     suspend fun fetchUserInfoDetail(): UserInfoDetailEntity {
         return userApi.getUserInfoDetail().toData()
     }
@@ -56,13 +63,6 @@ class UserRepository @Inject constructor(
 
     suspend fun saveUserProfileStatus(isProfilePublic: Boolean) {
         userApi.patchProfileStatus(UserProfileStatusRequestDto(isProfilePublic))
-    }
-
-    private suspend fun saveUserInfo(userId: Long, nickname: String) {
-        userStorage.edit { preferences ->
-            preferences[USER_ID_KEY] = userId.toString()
-            preferences[NICKNAME_KEY] = nickname
-        }
     }
 
     suspend fun saveUserInfoDetail(gender: String, birthYear: Int) {

--- a/app/src/main/java/com/teamwss/websoso/data/repository/UserRepository.kt
+++ b/app/src/main/java/com/teamwss/websoso/data/repository/UserRepository.kt
@@ -37,7 +37,7 @@ class UserRepository @Inject constructor(
     private suspend fun saveUserInfo(userId: Long, nickname: String) {
         userStorage.edit { preferences ->
             preferences[USER_ID_KEY] = userId.toString()
-            preferences[NICKNAME_KEY] = nickname
+            preferences[USER_NICKNAME_KEY] = nickname
         }
     }
 
@@ -127,12 +127,12 @@ class UserRepository @Inject constructor(
 
     suspend fun fetchNickname(): String {
         val preferences = userStorage.data.first()
-        return preferences[NICKNAME_KEY] ?: DEFAULT_NICKNAME
+        return preferences[USER_NICKNAME_KEY] ?: DEFAULT_USER_NICKNAME
     }
 
     suspend fun fetchGender(): String {
         val preferences = userStorage.data.first()
-        return preferences[GENDER_KEY] ?: DEFAULT_GENDER
+        return preferences[USER_GENDER_KEY] ?: DEFAULT_USER_GENDER
     }
 
     suspend fun fetchNovelDetailFirstLaunched(): Boolean {
@@ -171,10 +171,10 @@ class UserRepository @Inject constructor(
         val ACCESS_TOKEN_KEY = stringPreferencesKey("ACCESS_TOKEN")
         val REFRESH_TOKEN_KEY = stringPreferencesKey("REFRESH_TOKEN")
         val USER_ID_KEY = stringPreferencesKey("USER_ID")
-        val NICKNAME_KEY = stringPreferencesKey("NICKNAME")
-        val GENDER_KEY = stringPreferencesKey("GENDER")
-        const val DEFAULT_NICKNAME = "웹소소"
+        val USER_NICKNAME_KEY = stringPreferencesKey("USER_NICKNAME")
+        val USER_GENDER_KEY = stringPreferencesKey("USER_GENDER")
+        const val DEFAULT_USER_NICKNAME = "웹소소"
         const val DEFAULT_USER_ID = -1L
-        const val DEFAULT_GENDER = "F"
+        const val DEFAULT_USER_GENDER = "F"
     }
 }

--- a/app/src/main/java/com/teamwss/websoso/data/repository/UserRepository.kt
+++ b/app/src/main/java/com/teamwss/websoso/data/repository/UserRepository.kt
@@ -129,6 +129,11 @@ class UserRepository @Inject constructor(
         return preferences[NICKNAME_KEY] ?: DEFAULT_NICKNAME
     }
 
+    suspend fun fetchGender(): String {
+        val preferences = userStorage.data.first()
+        return preferences[GENDER_KEY] ?: DEFAULT_GENDER
+    }
+
     suspend fun fetchNovelDetailFirstLaunched(): Boolean {
         return userStorage.data.first()[NOVEL_DETAIL_FIRST_LAUNCHED_KEY] ?: true
     }
@@ -166,7 +171,9 @@ class UserRepository @Inject constructor(
         val REFRESH_TOKEN_KEY = stringPreferencesKey("REFRESH_TOKEN")
         val USER_ID_KEY = stringPreferencesKey("USER_ID")
         val NICKNAME_KEY = stringPreferencesKey("NICKNAME")
+        val GENDER_KEY = stringPreferencesKey("GENDER")
         const val DEFAULT_NICKNAME = "웹소소"
         const val DEFAULT_USER_ID = -1L
+        const val DEFAULT_GENDER = "F"
     }
 }

--- a/app/src/main/java/com/teamwss/websoso/data/repository/UserRepository.kt
+++ b/app/src/main/java/com/teamwss/websoso/data/repository/UserRepository.kt
@@ -27,8 +27,6 @@ class UserRepository @Inject constructor(
     private val userApi: UserApi,
     private val userStorage: DataStore<Preferences>,
 ) {
-    var userGender: String = "M"
-        private set
 
     suspend fun fetchUserInfo(): UserInfoEntity {
         val userInfo = userApi.getUserInfo().toData()
@@ -99,9 +97,7 @@ class UserRepository @Inject constructor(
                 birth,
                 genrePreferences,
             )
-        ).also {
-            userGender = gender
-        }
+        )
     }
 
     suspend fun fetchNicknameValidity(nickname: String): Boolean {

--- a/app/src/main/java/com/teamwss/websoso/data/repository/UserRepository.kt
+++ b/app/src/main/java/com/teamwss/websoso/data/repository/UserRepository.kt
@@ -108,7 +108,7 @@ class UserRepository @Inject constructor(
         return userApi.getNicknameValidity(nickname).isValid
     }
 
-    suspend fun saveUserProfile(
+    suspend fun saveEditingUserProfile(
         avatarId: Int?,
         nickname: String?,
         intro: String?,

--- a/app/src/main/java/com/teamwss/websoso/data/repository/UserRepository.kt
+++ b/app/src/main/java/com/teamwss/websoso/data/repository/UserRepository.kt
@@ -123,12 +123,12 @@ class UserRepository @Inject constructor(
         }
     }
 
-    suspend fun fetchUserIdFromDataStore(): Long {
+    suspend fun fetchUserId(): Long {
         val preferences = userStorage.data.first()
         return preferences[USER_ID_KEY]?.toLongOrNull() ?: 0L
     }
 
-    suspend fun fetchNicknameFromDataStore(): String {
+    suspend fun fetchNickname(): String {
         val preferences = userStorage.data.first()
         return preferences[NICKNAME_KEY] ?: "웹소소"
     }

--- a/app/src/main/java/com/teamwss/websoso/data/repository/UserRepository.kt
+++ b/app/src/main/java/com/teamwss/websoso/data/repository/UserRepository.kt
@@ -121,7 +121,7 @@ class UserRepository @Inject constructor(
 
     suspend fun fetchUserId(): Long {
         val preferences = userStorage.data.first()
-        return preferences[USER_ID_KEY]?.toLongOrNull() ?: 0L
+        return preferences[USER_ID_KEY]?.toLongOrNull() ?: -1L
     }
 
     suspend fun fetchNickname(): String {

--- a/app/src/main/java/com/teamwss/websoso/data/repository/UserRepository.kt
+++ b/app/src/main/java/com/teamwss/websoso/data/repository/UserRepository.kt
@@ -33,6 +33,7 @@ class UserRepository @Inject constructor(
         saveUserInfoToDataStore(userInfo.userId, userInfo.nickname)
         return userInfo
     }
+
     suspend fun fetchUserInfoDetail(): UserInfoDetailEntity {
         return userApi.getUserInfoDetail().toData()
     }

--- a/app/src/main/java/com/teamwss/websoso/ui/accountInfo/AccountInfoViewModel.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/accountInfo/AccountInfoViewModel.kt
@@ -23,7 +23,7 @@ class AccountInfoViewModel @Inject constructor(
     private fun updateUserEmail() {
         viewModelScope.launch {
             runCatching {
-                userRepository.fetchUserInfo()
+                userRepository.fetchUserInfoDetail()
             }.onSuccess { userInfo ->
                 _userEmail.value = userInfo.email
             }.onFailure {

--- a/app/src/main/java/com/teamwss/websoso/ui/changeUserInfo/ChangeUserInfoViewModel.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/changeUserInfo/ChangeUserInfoViewModel.kt
@@ -34,13 +34,13 @@ class ChangeUserInfoViewModel @Inject constructor(
             _isCompleteButtonEnabled.value = updateCompleteButtonEnabled()
         }
 
-        updateUserInfo()
+        updateUserInfoDetail()
     }
 
-    private fun updateUserInfo() {
+    private fun updateUserInfoDetail() {
         viewModelScope.launch {
             runCatching {
-                userRepository.fetchUserInfo()
+                userRepository.fetchUserInfoDetail()
             }.onSuccess { userInfo ->
                 isInitializeOfGender = Gender.from(userInfo.gender)
                 isInitializeOfBirthYear = userInfo.birthYear
@@ -79,7 +79,7 @@ class ChangeUserInfoViewModel @Inject constructor(
         viewModelScope.launch {
             _uiState.value = uiState.value?.copy(loading = true)
             runCatching {
-                userRepository.saveUserInfo(
+                userRepository.saveUserInfoDetail(
                     gender = uiState.value?.gender?.genderCode
                         ?: isInitializeOfGender.getOppositeGender().genderCode,
                     birthYear = uiState.value?.birthYear ?: isInitializeOfBirthYear,

--- a/app/src/main/java/com/teamwss/websoso/ui/main/MainActivity.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/main/MainActivity.kt
@@ -32,6 +32,7 @@ class MainActivity : BaseActivity<ActivityMainBinding>(R.layout.activity_main) {
 
         setBottomNavigationView()
         handleExploreNavigation()
+        mainViewModel.updateUserInfo()
     }
 
     private fun setBottomNavigationView() {

--- a/app/src/main/java/com/teamwss/websoso/ui/main/MainActivity.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/main/MainActivity.kt
@@ -32,7 +32,6 @@ class MainActivity : BaseActivity<ActivityMainBinding>(R.layout.activity_main) {
 
         setBottomNavigationView()
         handleExploreNavigation()
-        mainViewModel.updateUserInfo()
     }
 
     private fun setBottomNavigationView() {

--- a/app/src/main/java/com/teamwss/websoso/ui/main/MainViewModel.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/main/MainViewModel.kt
@@ -17,10 +17,6 @@ class MainViewModel @Inject constructor(
     private val _mainUiState: MutableLiveData<MainUiState> = MutableLiveData(MainUiState())
     val mainUiState: LiveData<MainUiState> get() = _mainUiState
 
-    init {
-        updateUserInfo()
-    }
-
     fun updateUserInfo() {
         if (mainUiState.value?.isLogin == true) {
             viewModelScope.launch {

--- a/app/src/main/java/com/teamwss/websoso/ui/main/MainViewModel.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/main/MainViewModel.kt
@@ -3,13 +3,44 @@ package com.teamwss.websoso.ui.main
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.teamwss.websoso.data.repository.UserRepository
 import com.teamwss.websoso.ui.main.model.MainUiState
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
+import javax.inject.Inject
 
-class MainViewModel: ViewModel() {
-    private val _mainUiState : MutableLiveData<MainUiState> = MutableLiveData(MainUiState())
-    val mainUiState : LiveData<MainUiState> get() = _mainUiState
+@HiltViewModel
+class MainViewModel @Inject constructor(
+    private val userRepository: UserRepository,
+) : ViewModel() {
+    private val _mainUiState: MutableLiveData<MainUiState> = MutableLiveData(MainUiState())
+    val mainUiState: LiveData<MainUiState> get() = _mainUiState
 
-    fun updateNickname(){
-        // TODO nickname 가져오는 서버통신
+    init {
+        updateUserInfo()
+    }
+
+    fun updateUserInfo() {
+        if (mainUiState.value?.isLogin == true) {
+            viewModelScope.launch {
+                _mainUiState.value = mainUiState.value?.copy(
+                    loading = true
+                )
+                runCatching {
+                    userRepository.fetchUserInfo()
+                }.onSuccess { userInfo ->
+                    _mainUiState.value = mainUiState.value?.copy(
+                        nickname = userInfo.nickname,
+                        loading = false
+                    )
+                }.onFailure {
+                    _mainUiState.value = mainUiState.value?.copy(
+                        error = true,
+                        loading = false
+                    )
+                }
+            }
+        }
     }
 }

--- a/app/src/main/java/com/teamwss/websoso/ui/main/MainViewModel.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/main/MainViewModel.kt
@@ -18,10 +18,6 @@ class MainViewModel @Inject constructor(
     private val _mainUiState: MutableLiveData<MainUiState> = MutableLiveData(MainUiState())
     val mainUiState: LiveData<MainUiState> get() = _mainUiState
 
-    init{
-        updateUserInfo()
-    }
-
     fun updateUserInfo() {
         if (mainUiState.value?.isLogin == true) {
             viewModelScope.launch {

--- a/app/src/main/java/com/teamwss/websoso/ui/main/MainViewModel.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/main/MainViewModel.kt
@@ -21,19 +21,19 @@ class MainViewModel @Inject constructor(
         if (mainUiState.value?.isLogin == true) {
             viewModelScope.launch {
                 _mainUiState.value = mainUiState.value?.copy(
-                    loading = true
+                    loading = true,
                 )
                 runCatching {
                     userRepository.fetchUserInfo()
                 }.onSuccess { userInfo ->
                     _mainUiState.value = mainUiState.value?.copy(
                         nickname = userInfo.nickname,
-                        loading = false
+                        loading = false,
                     )
                 }.onFailure {
                     _mainUiState.value = mainUiState.value?.copy(
                         error = true,
-                        loading = false
+                        loading = false,
                     )
                 }
             }

--- a/app/src/main/java/com/teamwss/websoso/ui/main/MainViewModel.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/main/MainViewModel.kt
@@ -1,5 +1,6 @@
 package com.teamwss.websoso.ui.main
 
+import android.util.Log
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
@@ -16,6 +17,10 @@ class MainViewModel @Inject constructor(
 ) : ViewModel() {
     private val _mainUiState: MutableLiveData<MainUiState> = MutableLiveData(MainUiState())
     val mainUiState: LiveData<MainUiState> get() = _mainUiState
+
+    init{
+        updateUserInfo()
+    }
 
     fun updateUserInfo() {
         if (mainUiState.value?.isLogin == true) {

--- a/app/src/main/java/com/teamwss/websoso/ui/main/feed/FeedViewModel.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/main/feed/FeedViewModel.kt
@@ -29,7 +29,10 @@ class FeedViewModel @Inject constructor(
     val feedUiState: LiveData<FeedUiState> get() = _feedUiState
 
     init {
-        val categories: List<CategoryModel> = when (userRepository.userGender) {
+        // TODO userGender를 가져오는 로직으로 대체 필요
+        val userGender = "F"
+
+        val categories: List<CategoryModel> = when (userGender) {
             "M" -> "전체,판타지,현판,무협,드라마,미스터리,라노벨,로맨스,로판,BL,기타"
             "F" -> "전체,로맨스,로판,BL,판타지,현판,무협,드라마,미스터리,라노벨,기타"
             else -> throw IllegalArgumentException()

--- a/app/src/main/java/com/teamwss/websoso/ui/main/home/HomeFragment.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/main/home/HomeFragment.kt
@@ -8,7 +8,11 @@ import androidx.fragment.app.viewModels
 import com.teamwss.websoso.R
 import com.teamwss.websoso.R.string.home_nickname_interest_feed
 import com.teamwss.websoso.common.ui.base.BaseFragment
-import com.teamwss.websoso.common.ui.model.ResultFrom.*
+import com.teamwss.websoso.common.ui.model.ResultFrom.FeedDetailBack
+import com.teamwss.websoso.common.ui.model.ResultFrom.FeedDetailRemoved
+import com.teamwss.websoso.common.ui.model.ResultFrom.NormalExploreBack
+import com.teamwss.websoso.common.ui.model.ResultFrom.NovelDetailBack
+import com.teamwss.websoso.common.ui.model.ResultFrom.ProfileEditSuccess
 import com.teamwss.websoso.databinding.FragmentHomeBinding
 import com.teamwss.websoso.ui.common.dialog.LoginRequestDialogFragment
 import com.teamwss.websoso.ui.feedDetail.FeedDetailActivity
@@ -53,7 +57,7 @@ class HomeFragment : BaseFragment<FragmentHomeBinding>(R.layout.fragment_home) {
             NormalExploreBack.RESULT_OK -> homeViewModel.updateNovel()
             NovelDetailBack.RESULT_OK -> homeViewModel.updateNovel()
             ProfileEditSuccess.RESULT_OK -> {
-                mainViewModel.updateNickname()
+                mainViewModel.updateUserInfo()
                 homeViewModel.updateNovel()
             }
         }
@@ -98,6 +102,13 @@ class HomeFragment : BaseFragment<FragmentHomeBinding>(R.layout.fragment_home) {
     }
 
     private fun setupObserver() {
+        mainViewModel.mainUiState.observe(viewLifecycleOwner){ uiState ->
+            when{
+                uiState.error -> Unit
+                !uiState.loading -> updateViewVisibilityByLogin(uiState.isLogin, uiState.nickname)
+            }
+        }
+
         homeViewModel.uiState.observe(viewLifecycleOwner) { uiState ->
             when {
                 uiState.error -> Unit
@@ -112,7 +123,6 @@ class HomeFragment : BaseFragment<FragmentHomeBinding>(R.layout.fragment_home) {
                             userInterestFeedAdapter.submitList(uiState.userInterestFeeds)
                             recommendedNovelsByUserTasteAdapter.submitList(uiState.recommendedNovelsByUserTaste)
                         }
-                        updateViewVisibilityByLogin(mainUiState.isLogin, mainUiState.nickname)
                     }
                 }
             }

--- a/app/src/main/java/com/teamwss/websoso/ui/main/home/HomeViewModel.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/main/home/HomeViewModel.kt
@@ -8,7 +8,6 @@ import com.teamwss.websoso.data.model.PopularFeedsEntity
 import com.teamwss.websoso.data.model.PopularNovelsEntity
 import com.teamwss.websoso.data.model.RecommendedNovelsByUserTasteEntity
 import com.teamwss.websoso.data.model.UserInterestFeedMessage
-import com.teamwss.websoso.data.model.UserInterestFeedMessage.NO_ASSOCIATED_FEEDS
 import com.teamwss.websoso.data.model.UserInterestFeedMessage.NO_INTEREST_NOVELS
 import com.teamwss.websoso.data.model.UserInterestFeedsEntity
 import com.teamwss.websoso.data.repository.FeedRepository

--- a/app/src/main/java/com/teamwss/websoso/ui/main/model/MainUiState.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/main/model/MainUiState.kt
@@ -1,7 +1,8 @@
 package com.teamwss.websoso.ui.main.model
 
 data class MainUiState(
+    val loading: Boolean = false,
+    val error: Boolean = false,
     val isLogin: Boolean = true,
-    val userId: Long = 0,
     val nickname: String = "웹소소",
 )

--- a/app/src/main/java/com/teamwss/websoso/ui/profileEdit/ProfileEditViewModel.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/profileEdit/ProfileEditViewModel.kt
@@ -177,7 +177,7 @@ class ProfileEditViewModel @Inject constructor(
 
         viewModelScope.launch {
             runCatching {
-                userRepository.saveUserProfile(
+                userRepository.saveEditingUserProfile(
                     avatarId = (previousProfile.avatarId to currentProfile.avatarId).compareAndReturnNewOrNullValue(),
                     nickname = (previousProfile.nicknameModel.nickname to currentProfile.nicknameModel.nickname).compareAndReturnNewOrNullValue(),
                     intro = (previousProfile.introduction to currentProfile.introduction).compareAndReturnNewOrNullValue(),


### PR DESCRIPTION
## 📌𝘐𝘴𝘴𝘶𝘦𝘴
- closed #360 

## 📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯
- 기존 `userInfo` -> `userInfoDetail` 수정
- 사용자 `nickname`과 `userId`를 받아오는 함수관련 네이밍을 `userInfo`로 작성하였습니다.
- 메인이 생성될 때 한 번만 `nickname`, `userId`를 받아와 데이타스토어 저장합니다.
- 닉네임이나 유저 아이디를 받아오고 싶다면 아래 비동기 함수를 호출하여 미리 저장해두시면 됩니다.

```
   suspend fun fetchUserId(): Long {
        val preferences = userStorage.data.first()
        return preferences[USER_ID_KEY]?.toLongOrNull() ?: DEFAULT_USER_ID
    }

    suspend fun fetchNickname(): String {
        val preferences = userStorage.data.first()
        return preferences[NICKNAME_KEY] ?: DEFAULT_NICKNAME
    }
```


## 📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵

https://github.com/user-attachments/assets/c6c656eb-ca70-485c-8240-6813b4823d7d



## 💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴