### PR TITLE
fix: 타유저 프로필 방문 후 뒤로가기 버튼 눌렀을 때 띄워지는 스낵바 해결

### DIFF
--- a/app/src/main/java/com/teamwss/websoso/common/ui/model/ResultFrom.kt
+++ b/app/src/main/java/com/teamwss/websoso/common/ui/model/ResultFrom.kt
@@ -1,16 +1,15 @@
 package com.teamwss.websoso.common.ui.model
 
-enum class ResultFrom {
-    BlockUser,
-    FeedDetailBack,
-    FeedDetailRemoved,
-    CreateFeed,
-    ChangeUserInfo,
-    ChangeProfileDisclosure,
-    NormalExploreBack,
-    NovelDetailBack,
-    ProfileEditSuccess,
-    ;
+enum class ResultFrom(private val resultCode: Int) {
+    FeedDetailBack(1),
+    FeedDetailRemoved(2),
+    CreateFeed(3),
+    BlockUser(4),
+    ChangeUserInfo(5),
+    ChangeProfileDisclosure(6),
+    NormalExploreBack(7),
+    NovelDetailBack(8),
+    ProfileEditSuccess(9);
 
-    val RESULT_OK: Int = ordinal + 1
+    val RESULT_OK: Int = resultCode
 }

--- a/app/src/main/java/com/teamwss/websoso/common/ui/model/ResultFrom.kt
+++ b/app/src/main/java/com/teamwss/websoso/common/ui/model/ResultFrom.kt
@@ -12,5 +12,5 @@ enum class ResultFrom {
     ProfileEditSuccess,
     ;
 
-    val RESULT_OK: Int = ordinal
+    val RESULT_OK: Int = ordinal + 1
 }


### PR DESCRIPTION
## 📌𝘐𝘴𝘴𝘶𝘦𝘴
- closed #371

## 📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯
- 타유저 프로필 방문 후 뒤로가기 버튼 눌렀을 때도 띄워지는 유저 차단 스낵바 출력 오류를 해결했습니다.

> 문제점) enum class에서 BlockUser가 가장 처음 선언되어 있었습니다.
그럴 경우 `BlockUser.RESULT_OK = 0 `이 됩니다.
<img width="337" alt="스크린샷 2024-09-27 오후 9 42 01" src="https://github.com/user-attachments/assets/6604c4a2-6bee-49d1-83e0-2e8f4abe70a5">

그런데, 여기서 문제는 when 절에서 Result_OK에 대한 분기처리를 진행할 때 ordinal 이 0인 값이 초기값이라 ordinal 이 0인 곳은 무조건 실행이 된다는 거였습니다 .. ㅋ (setResult 코드를 추가하지 않아도 다시 돌아왔을 때 그냥 무조건 0으로 실행이 됐음)

그래서 제가 생각한 방법은 `ordinal + 1` 이긴 했으나 enum class 상수의 인스턴스 필드로 값을 정하는 건 어떨까?
-> 
``` kotlin
enum class(val resultCode: Int) {
   BlockUser(1), 
   FeedDetailRemoved(2),
...
```
ordinal + 1 에서 인스턴스 필드를 생각한 이유는 
**ordinal 자체가 순서를 내포하는데 직접적으로 순서를 변경해도 될까?**
라고 생각했지만, 우리는 ordinal 을 통해서 result_code 를 세팅하는 거니까 괜찮지 않을까! 싶은데 여러분들 의견은 어떤지 궁금해요!

뭐든 .. it's ok .. 입니다. .. 쨋든 해결해서 행복하네요 🥹

## 📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵
용량이 커서 카톡에 올려놨습니다. 이제는 진짜 real 로 됨.

## 💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴
<img width="585" alt="스크린샷 2024-09-27 오후 9 52 03" src="https://github.com/user-attachments/assets/0cec7c18-14b4-4d4a-a1d4-399637558514">

[kotlin 공식문서 - ordinal](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-enum/ordinal.html)

### 더 자세히

[Android 공식문서](https://developer.android.com/reference/android/app/Activity#RESULT_CANCELED)
setResult를 설정하지 않으면, 자동으로 `RESULT_CANCELED ` 가 호출이 되는데 이 경우엔 값이 0 이라 생겼던 이슈였습니다.
<img width="909" alt="스크린샷 2024-09-27 오후 10 11 39" src="https://github.com/user-attachments/assets/226602ce-43c8-488f-9ba4-205f91741c1a">
<img width="906" alt="스크린샷 2024-09-27 오후 10 13 15" src="https://github.com/user-attachments/assets/f87fa496-f687-4a17-8b76-49a1da1e6639">
