### PR TITLE
feat: 공지 자세히 보기 구현

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -56,6 +56,10 @@
             android:exported="false"
             android:screenOrientation="portrait" />
         <activity
+            android:name=".ui.noticeDetail.NoticeDetailActivity"
+            android:exported="false"
+            android:screenOrientation="portrait" />
+        <activity
             android:name=".ui.feedDetail.FeedDetailActivity"
             android:exported="false"
             android:screenOrientation="portrait" />
@@ -101,7 +105,7 @@
             android:screenOrientation="portrait" />
         <activity
             android:name=".ui.profileEdit.ProfileEditActivity"
-            android:exported="false"
+            android:exported="true"
             android:screenOrientation="portrait" />
         <activity
             android:name=".ui.activityDetail.ActivityDetailActivity"
@@ -111,10 +115,10 @@
             android:name=".ui.otherUserPage.OtherUserPageActivity"
             android:exported="false"
             android:screenOrientation="portrait" />
-
         <activity
             android:name=".ui.userStorage.UserStorageActivity"
             android:exported="false"
             android:screenOrientation="portrait" />
     </application>
+
 </manifest>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -105,7 +105,7 @@
             android:screenOrientation="portrait" />
         <activity
             android:name=".ui.profileEdit.ProfileEditActivity"
-            android:exported="true"
+            android:exported="false"
             android:screenOrientation="portrait" />
         <activity
             android:name=".ui.activityDetail.ActivityDetailActivity"

--- a/app/src/main/java/com/teamwss/websoso/ui/notice/NoticeActivity.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/notice/NoticeActivity.kt
@@ -8,6 +8,7 @@ import com.teamwss.websoso.R
 import com.teamwss.websoso.common.ui.base.BaseActivity
 import com.teamwss.websoso.databinding.ActivityNoticeBinding
 import com.teamwss.websoso.ui.main.MainActivity
+import com.teamwss.websoso.ui.notice.adapter.NoticeAdapter
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint

--- a/app/src/main/java/com/teamwss/websoso/ui/notice/NoticeActivity.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/notice/NoticeActivity.kt
@@ -9,6 +9,8 @@ import com.teamwss.websoso.common.ui.base.BaseActivity
 import com.teamwss.websoso.databinding.ActivityNoticeBinding
 import com.teamwss.websoso.ui.main.MainActivity
 import com.teamwss.websoso.ui.notice.adapter.NoticeAdapter
+import com.teamwss.websoso.ui.notice.model.NoticeModel
+import com.teamwss.websoso.ui.noticeDetail.NoticeDetailActivity
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
@@ -17,8 +19,11 @@ class NoticeActivity : BaseActivity<ActivityNoticeBinding>(R.layout.activity_not
     private val noticeViewModel: NoticeViewModel by viewModels()
 
     private val noticeAdapter: NoticeAdapter by lazy {
-        NoticeAdapter()
+        NoticeAdapter(::navigateToNoticeDetail)
     }
+
+    private fun navigateToNoticeDetail(noticeItem: NoticeModel) =
+        startActivity(NoticeDetailActivity.getIntent(this, noticeItem))
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/app/src/main/java/com/teamwss/websoso/ui/notice/NoticeActivity.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/notice/NoticeActivity.kt
@@ -22,8 +22,8 @@ class NoticeActivity : BaseActivity<ActivityNoticeBinding>(R.layout.activity_not
         NoticeAdapter(::navigateToNoticeDetail)
     }
 
-    private fun navigateToNoticeDetail(noticeItem: NoticeModel) =
-        startActivity(NoticeDetailActivity.getIntent(this, noticeItem))
+    private fun navigateToNoticeDetail(notice: NoticeModel) =
+        startActivity(NoticeDetailActivity.getIntent(this, notice))
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/app/src/main/java/com/teamwss/websoso/ui/notice/adapter/NoticeAdapter.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/notice/adapter/NoticeAdapter.kt
@@ -8,7 +8,7 @@ import com.teamwss.websoso.databinding.ItemNoticeBinding
 import com.teamwss.websoso.ui.notice.model.NoticeModel
 
 class NoticeAdapter(
-    private val onNoticeClick: (noticeItem: NoticeModel) -> Unit,
+    private val onNoticeClick: (notice: NoticeModel) -> Unit,
 ) : ListAdapter<NoticeModel, NoticeViewHolder>(NoticeModelDiffCallback) {
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): NoticeViewHolder {

--- a/app/src/main/java/com/teamwss/websoso/ui/notice/adapter/NoticeAdapter.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/notice/adapter/NoticeAdapter.kt
@@ -7,11 +7,13 @@ import androidx.recyclerview.widget.ListAdapter
 import com.teamwss.websoso.databinding.ItemNoticeBinding
 import com.teamwss.websoso.ui.notice.model.NoticeModel
 
-class NoticeAdapter : ListAdapter<NoticeModel, NoticeViewHolder>(NoticeModelDiffCallback) {
+class NoticeAdapter(
+    private val onNoticeClick: (noticeItem: NoticeModel) -> Unit,
+) : ListAdapter<NoticeModel, NoticeViewHolder>(NoticeModelDiffCallback) {
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): NoticeViewHolder {
         val binding = ItemNoticeBinding.inflate(LayoutInflater.from(parent.context), parent, false)
-        return NoticeViewHolder(binding)
+        return NoticeViewHolder(binding, onNoticeClick)
     }
 
     override fun onBindViewHolder(holder: NoticeViewHolder, position: Int) {

--- a/app/src/main/java/com/teamwss/websoso/ui/notice/adapter/NoticeAdapter.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/notice/adapter/NoticeAdapter.kt
@@ -1,4 +1,4 @@
-package com.teamwss.websoso.ui.notice
+package com.teamwss.websoso.ui.notice.adapter
 
 import android.view.LayoutInflater
 import android.view.ViewGroup

--- a/app/src/main/java/com/teamwss/websoso/ui/notice/adapter/NoticeViewHolder.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/notice/adapter/NoticeViewHolder.kt
@@ -1,4 +1,4 @@
-package com.teamwss.websoso.ui.notice
+package com.teamwss.websoso.ui.notice.adapter
 
 import androidx.recyclerview.widget.RecyclerView
 import coil.load

--- a/app/src/main/java/com/teamwss/websoso/ui/notice/adapter/NoticeViewHolder.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/notice/adapter/NoticeViewHolder.kt
@@ -8,15 +8,15 @@ import com.teamwss.websoso.ui.notice.model.NoticeModel
 
 class NoticeViewHolder(
     private val binding: ItemNoticeBinding,
-    onNoticeClick: (noticeItem: NoticeModel) -> Unit,
+    onNoticeClick: (notice: NoticeModel) -> Unit,
 ) : RecyclerView.ViewHolder(binding.root) {
 
     init {
         binding.onClick = onNoticeClick
     }
 
-    fun bind(noticeModel: NoticeModel) {
-        binding.notice = noticeModel
+    fun bind(notice: NoticeModel) {
+        binding.notice = notice
 
         // 1차 릴리즈에는 공지사항만 존재 하기 때문에 고정 이미지를 사용합니다.
         binding.ivItemNoticeIcon.load(R.drawable.ic_home_alert)

--- a/app/src/main/java/com/teamwss/websoso/ui/notice/adapter/NoticeViewHolder.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/notice/adapter/NoticeViewHolder.kt
@@ -6,10 +6,16 @@ import com.teamwss.websoso.R
 import com.teamwss.websoso.databinding.ItemNoticeBinding
 import com.teamwss.websoso.ui.notice.model.NoticeModel
 
-class NoticeViewHolder(private val binding: ItemNoticeBinding) :
-    RecyclerView.ViewHolder(binding.root) {
-    fun bind(noticeModel: NoticeModel) {
+class NoticeViewHolder(
+    private val binding: ItemNoticeBinding,
+    onNoticeClick: (noticeItem: NoticeModel) -> Unit,
+) : RecyclerView.ViewHolder(binding.root) {
 
+    init {
+        binding.onClick = onNoticeClick
+    }
+
+    fun bind(noticeModel: NoticeModel) {
         binding.notice = noticeModel
 
         // 1차 릴리즈에는 공지사항만 존재 하기 때문에 고정 이미지를 사용합니다.

--- a/app/src/main/java/com/teamwss/websoso/ui/notice/model/NoticeModel.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/notice/model/NoticeModel.kt
@@ -1,7 +1,9 @@
 package com.teamwss.websoso.ui.notice.model
 
+import java.io.Serializable
+
 data class NoticeModel(
     val createDate: String,
     val noticeTitle: String,
     val noticeContent: String,
-)
+) : Serializable

--- a/app/src/main/java/com/teamwss/websoso/ui/noticeDetail/NoticeDetailActivity.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/noticeDetail/NoticeDetailActivity.kt
@@ -15,7 +15,7 @@ class NoticeDetailActivity :
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        val noticeItem = intent.getParcelableExtra<NoticeModel>(NOTICE_DETAIL_KEY)
+        val noticeItem = intent.getSerializableExtra(NOTICE_DETAIL_KEY) as? NoticeModel
         binding.noticeItem = noticeItem
 
         onBackButtonClick()

--- a/app/src/main/java/com/teamwss/websoso/ui/noticeDetail/NoticeDetailActivity.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/noticeDetail/NoticeDetailActivity.kt
@@ -1,0 +1,46 @@
+package com.teamwss.websoso.ui.noticeDetail
+
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import androidx.activity.addCallback
+import com.teamwss.websoso.R
+import com.teamwss.websoso.common.ui.base.BaseActivity
+import com.teamwss.websoso.databinding.ActivityNoticeDetailBinding
+import com.teamwss.websoso.ui.notice.model.NoticeModel
+
+class NoticeDetailActivity :
+    BaseActivity<ActivityNoticeDetailBinding>(R.layout.activity_notice_detail) {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        val noticeItem = intent.getParcelableExtra<NoticeModel>(NOTICE_DETAIL_KEY)
+        binding.noticeItem = noticeItem
+
+        onBackButtonClick()
+        handleBackPressed()
+    }
+
+    private fun onBackButtonClick() {
+        binding.ivNoticeDetailBack.setOnClickListener {
+            finish()
+        }
+    }
+
+    private fun handleBackPressed() {
+        onBackPressedDispatcher.addCallback(this) {
+            finish()
+        }
+    }
+
+    companion object {
+        const val NOTICE_DETAIL_KEY = "NOTICE_ITEM_KEY"
+
+        fun getIntent(context: Context, noticeModel: NoticeModel): Intent {
+            return Intent(context, NoticeDetailActivity::class.java).apply {
+                putExtra(NOTICE_DETAIL_KEY, noticeModel)
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/teamwss/websoso/ui/noticeDetail/NoticeDetailActivity.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/noticeDetail/NoticeDetailActivity.kt
@@ -35,7 +35,7 @@ class NoticeDetailActivity :
     }
 
     companion object {
-        const val NOTICE_DETAIL_KEY = "NOTICE_ITEM_KEY"
+        const val NOTICE_DETAIL_KEY = "NOTICE_DETAIL_KEY"
 
         fun getIntent(context: Context, noticeModel: NoticeModel): Intent {
             return Intent(context, NoticeDetailActivity::class.java).apply {

--- a/app/src/main/res/layout/activity_notice_detail.xml
+++ b/app/src/main/res/layout/activity_notice_detail.xml
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <data>
+
+        <variable
+            name="noticeItem"
+            type="com.teamwss.websoso.ui.notice.model.NoticeModel" />
+
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        tools:context=".ui.noticeDetail.NoticeDetailActivity">
+
+        <TextView
+            android:id="@+id/tv_notice_detail_notice"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:paddingVertical="20dp"
+            android:text="@string/notice_notification"
+            android:textAppearance="@style/title2"
+            android:textColor="@color/black"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <ImageView
+            android:id="@+id/iv_notice_detail_back"
+            android:layout_width="44dp"
+            android:layout_height="0dp"
+            android:layout_marginStart="6dp"
+            android:src="@drawable/ic_notice_back"
+            app:layout_constraintBottom_toBottomOf="@+id/tv_notice_detail_notice"
+            app:layout_constraintDimensionRatio="1"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="@id/tv_notice_detail_notice" />
+
+        <TextView
+            android:id="@+id/tv_notice_detail_notice_title"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="20dp"
+            android:layout_marginTop="20dp"
+            android:text="@{noticeItem.noticeTitle}"
+            android:textAppearance="@style/headline1"
+            android:textColor="@color/black"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/tv_notice_detail_notice"
+            tools:text="리뷰 기능 변경 관련 공지" />
+
+        <TextView
+            android:id="@+id/tv_notice_detail_notice_date"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="10dp"
+            android:text="@{noticeItem.createDate}"
+            android:textAppearance="@style/body5"
+            android:textColor="@color/gray_200_AEADB3"
+            app:layout_constraintStart_toStartOf="@id/tv_notice_detail_notice_title"
+            app:layout_constraintTop_toBottomOf="@id/tv_notice_detail_notice_title"
+            tools:text="2024.06.22" />
+
+        <View
+            android:id="@+id/v_notice_detail_divider"
+            android:layout_width="0dp"
+            android:layout_height="1dp"
+            android:layout_marginTop="20dp"
+            android:background="@color/gray_50_F4F5F8"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/tv_notice_detail_notice_date" />
+
+        <TextView
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:layout_marginTop="24dp"
+            android:paddingHorizontal="20dp"
+            android:scrollbars="vertical"
+            android:text="@{noticeItem.noticeContent}"
+            android:textAppearance="@style/body2"
+            android:textColor="@color/black"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintHorizontal_bias="0.0"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/v_notice_detail_divider"
+            app:layout_constraintVertical_bias="0.0"
+            tools:text="아\n아\n아\n아\n아\n아\n아\n아\n아\n아\n아\n아\n아\n아\n아\n아\n아\n아\n아\n아\n아\n아\n아\n아\n아\n아\n아\n아\n" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/app/src/main/res/layout/item_notice.xml
+++ b/app/src/main/res/layout/item_notice.xml
@@ -22,7 +22,7 @@
             app:layout_constraintDimensionRatio="1"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"
-            tools:src="@mipmap/ic_launcher" />
+            tools:src="@drawable/ic_home_alert" />
 
         <TextView
             android:id="@+id/tv_item_notice_title"

--- a/app/src/main/res/layout/item_notice.xml
+++ b/app/src/main/res/layout/item_notice.xml
@@ -8,12 +8,17 @@
         <variable
             name="notice"
             type="com.teamwss.websoso.ui.notice.model.NoticeModel" />
+
+        <variable
+            name="onClick"
+            type="kotlin.jvm.functions.Function1" />
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:padding="20dp">
+        android:padding="20dp"
+        android:onClick="@{() -> onClick.invoke(notice)}">
 
         <ImageView
             android:id="@+id/iv_item_notice_icon"


### PR DESCRIPTION
## 📌𝘐𝘴𝘴𝘶𝘦𝘴
- closed #389

## 📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯
- 공지 아이템을 선택시 자세히 보기 기능을 구현하였습니다

## 📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵

https://github.com/user-attachments/assets/268aca07-dbf7-4ef7-ade7-f95215066ba2

## 💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴