### PR TITLE
feat: 마이페이지/다른유저페이지 관련 에러대응 및 로딩화면 구현

### DIFF
--- a/app/src/main/java/com/teamwss/websoso/ui/activityDetail/ActivityDetailActivity.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/activityDetail/ActivityDetailActivity.kt
@@ -46,7 +46,6 @@ class ActivityDetailActivity :
     }
     private val myPageViewModel: MyPageViewModel by viewModels()
     private val otherUserPageViewModel: OtherUserPageViewModel by viewModels()
-
     private val source: String by lazy {
         intent.getStringExtra(MyActivityFragment.EXTRA_SOURCE) ?: ""
     }
@@ -92,9 +91,7 @@ class ActivityDetailActivity :
             when {
                 uiState.isLoading -> binding.wllActivityDetail.setWebsosoLoadingVisibility(true)
                 uiState.error -> binding.wllActivityDetail.setLoadingLayoutVisibility(false)
-                !uiState.isLoading -> {
-                    binding.wllActivityDetail.setWebsosoLoadingVisibility(false)
-                }
+                !uiState.isLoading -> binding.wllActivityDetail.setWebsosoLoadingVisibility(false)
             }
         }
 

--- a/app/src/main/java/com/teamwss/websoso/ui/activityDetail/ActivityDetailActivity.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/activityDetail/ActivityDetailActivity.kt
@@ -87,7 +87,10 @@ class ActivityDetailActivity :
     }
 
     private fun setupObserver() {
-        activityDetailViewModel.activityDetailUiState.observe(this) { uiState ->
+        activityDetailViewModel.uiState.observe(this) { uiState ->
+            val userProfile = getUserProfile()
+            updateAdapterWithActivitiesAndProfile(uiState.activities, userProfile)
+
             when {
                 uiState.isLoading -> binding.wllActivityDetail.setWebsosoLoadingVisibility(true)
                 uiState.error -> binding.wllActivityDetail.setLoadingLayoutVisibility(false)
@@ -95,18 +98,13 @@ class ActivityDetailActivity :
             }
         }
 
-        activityDetailViewModel.activityDetailUiState.observe(this) { uiState ->
-            val userProfile = getUserProfile()
-            updateAdapterWithActivitiesAndProfile(uiState.activities, userProfile)
-        }
-
         when (activityDetailViewModel.source) {
             SOURCE_MY_ACTIVITY -> {
-                myPageViewModel.myPageUiState.observe(this) { uiState ->
+                myPageViewModel.uiState.observe(this) { uiState ->
                     uiState.myProfile?.let { myProfile ->
                         val userProfile = myProfile.toUserProfileModel()
                         updateAdapterWithActivitiesAndProfile(
-                            activityDetailViewModel.activityDetailUiState.value?.activities,
+                            activityDetailViewModel.uiState.value?.activities,
                             userProfile
                         )
                     }
@@ -118,7 +116,7 @@ class ActivityDetailActivity :
                     uiState.otherUserProfile?.let {
                         val userProfile = uiState.otherUserProfile.toUserProfileModel()
                         updateAdapterWithActivitiesAndProfile(
-                            activityDetailViewModel.activityDetailUiState.value?.activities,
+                            activityDetailViewModel.uiState.value?.activities,
                             userProfile,
                         )
                     }
@@ -144,7 +142,7 @@ class ActivityDetailActivity :
     private fun getUserProfile(): UserProfileModel? {
         return when (activityDetailViewModel.source) {
             SOURCE_MY_ACTIVITY -> {
-                myPageViewModel.myPageUiState.value?.myProfile?.toUserProfileModel()
+                myPageViewModel.uiState.value?.myProfile?.toUserProfileModel()
             }
 
             SOURCE_OTHER_USER_ACTIVITY -> {
@@ -240,7 +238,7 @@ class ActivityDetailActivity :
 
     private fun navigateToFeedEdit(feedId: Long) {
         val activityModel =
-            activityDetailViewModel.activityDetailUiState.value?.activities?.find { it.feedId == feedId }
+            activityDetailViewModel.uiState.value?.activities?.find { it.feedId == feedId }
         activityModel?.let { feed ->
             val editFeedModel = EditFeedModel(
                 feedId = feed.feedId,

--- a/app/src/main/java/com/teamwss/websoso/ui/activityDetail/ActivityDetailActivity.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/activityDetail/ActivityDetailActivity.kt
@@ -89,6 +89,16 @@ class ActivityDetailActivity :
 
     private fun setupObserver() {
         activityDetailViewModel.activityDetailUiState.observe(this) { uiState ->
+            when {
+                uiState.isLoading -> binding.wllActivityDetail.setWebsosoLoadingVisibility(true)
+                uiState.error -> binding.wllActivityDetail.setLoadingLayoutVisibility(false)
+                !uiState.isLoading -> {
+                    binding.wllActivityDetail.setWebsosoLoadingVisibility(false)
+                }
+            }
+        }
+
+        activityDetailViewModel.activityDetailUiState.observe(this) { uiState ->
             val userProfile = getUserProfile()
             updateAdapterWithActivitiesAndProfile(uiState.activities, userProfile)
         }
@@ -107,9 +117,9 @@ class ActivityDetailActivity :
             }
 
             SOURCE_OTHER_USER_ACTIVITY -> {
-                otherUserPageViewModel.otherUserProfile.observe(this) { otherUserProfile ->
-                    otherUserProfile?.let {
-                        val userProfile = otherUserProfile.toUserProfileModel()
+                otherUserPageViewModel.uiState.observe(this) { uiState ->
+                    uiState.otherUserProfile?.let {
+                        val userProfile = uiState.otherUserProfile.toUserProfileModel()
                         updateAdapterWithActivitiesAndProfile(
                             activityDetailViewModel.activityDetailUiState.value?.activities,
                             userProfile,
@@ -141,7 +151,7 @@ class ActivityDetailActivity :
             }
 
             SOURCE_OTHER_USER_ACTIVITY -> {
-                otherUserPageViewModel.otherUserProfile.value?.toUserProfileModel()
+                otherUserPageViewModel.uiState.value?.otherUserProfile?.toUserProfileModel()
             }
 
             else -> null

--- a/app/src/main/java/com/teamwss/websoso/ui/activityDetail/ActivityDetailViewModel.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/activityDetail/ActivityDetailViewModel.kt
@@ -26,7 +26,6 @@ class ActivityDetailViewModel @Inject constructor(
     val activityDetailUiState: LiveData<ActivityDetailUiState> get() = _activityDetailUiState
 
     private val _likeState = MutableLiveData<ActivityLikeState>()
-    val likeState: LiveData<ActivityLikeState> get() = _likeState
 
     private val size: Int = ACTIVITY_LOAD_SIZE
 

--- a/app/src/main/java/com/teamwss/websoso/ui/activityDetail/ActivityDetailViewModel.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/activityDetail/ActivityDetailViewModel.kt
@@ -22,8 +22,8 @@ class ActivityDetailViewModel @Inject constructor(
     private val savedStateHandle: SavedStateHandle,
 ) : ViewModel() {
 
-    private val _activityDetailUiState = MutableLiveData<ActivityDetailUiState>()
-    val activityDetailUiState: LiveData<ActivityDetailUiState> get() = _activityDetailUiState
+    private val _uiState = MutableLiveData<ActivityDetailUiState>()
+    val uiState: LiveData<ActivityDetailUiState> get() = _uiState
 
     private val _likeState = MutableLiveData<ActivityLikeState>()
 
@@ -42,7 +42,7 @@ class ActivityDetailViewModel @Inject constructor(
         }
 
     init {
-        _activityDetailUiState.value = ActivityDetailUiState()
+        _uiState.value = ActivityDetailUiState()
     }
 
     fun updateUserActivities(userId: Long) {
@@ -55,22 +55,22 @@ class ActivityDetailViewModel @Inject constructor(
     }
 
     private fun updateMyActivities() {
-        _activityDetailUiState.value = _activityDetailUiState.value?.copy(isLoading = true)
+        _uiState.value = uiState.value?.copy(isLoading = true)
         viewModelScope.launch {
             runCatching {
                 userRepository.fetchMyActivities(
-                    _activityDetailUiState.value?.lastFeedId ?: 0L,
+                    uiState.value?.lastFeedId ?: 0L,
                     size,
                 )
             }.onSuccess { response ->
-                _activityDetailUiState.value = _activityDetailUiState.value?.copy(
+                _uiState.value = uiState.value?.copy(
                     isLoading = false,
                     activities = response.feeds.map { it.toUi() },
                     lastFeedId = response.feeds.lastOrNull()?.feedId?.toLong() ?: 0L,
                     error = false,
                 )
             }.onFailure { exception ->
-                _activityDetailUiState.value = _activityDetailUiState.value?.copy(
+                _uiState.value = uiState.value?.copy(
                     isLoading = false,
                     error = true,
                 )
@@ -79,23 +79,23 @@ class ActivityDetailViewModel @Inject constructor(
     }
 
     private fun updateOtherUserActivities(userId: Long) {
-        _activityDetailUiState.value = _activityDetailUiState.value?.copy(isLoading = true)
+        _uiState.value = uiState.value?.copy(isLoading = true)
         viewModelScope.launch {
             runCatching {
                 userRepository.fetchUserFeeds(
                     userId = userId,
-                    lastFeedId = _activityDetailUiState.value?.lastFeedId ?: 0L,
+                    lastFeedId = uiState.value?.lastFeedId ?: 0L,
                     size = size,
                 )
             }.onSuccess { response ->
-                _activityDetailUiState.value = _activityDetailUiState.value?.copy(
+                _uiState.value = uiState.value?.copy(
                     isLoading = false,
                     activities = response.feeds.map { it.toUi() },
                     lastFeedId = response.feeds.lastOrNull()?.feedId?.toLong() ?: 0L,
                     error = false,
                 )
             }.onFailure { exception ->
-                _activityDetailUiState.value = _activityDetailUiState.value?.copy(
+                _uiState.value = uiState.value?.copy(
                     isLoading = false,
                     error = true,
                 )
@@ -122,8 +122,8 @@ class ActivityDetailViewModel @Inject constructor(
     }
 
     private fun updateLikeStateInUi(feedId: Long, isLiked: Boolean, likeCount: Int) {
-        _activityDetailUiState.value = _activityDetailUiState.value?.copy(
-            activities = _activityDetailUiState.value?.activities?.map { activity ->
+        _uiState.value = uiState.value?.copy(
+            activities = uiState.value?.activities?.map { activity ->
                 if (activity.feedId == feedId) {
                     activity.copy(
                         isLiked = isLiked,
@@ -138,17 +138,17 @@ class ActivityDetailViewModel @Inject constructor(
 
     fun updateRemovedFeed(feedId: Long) {
         viewModelScope.launch {
-            _activityDetailUiState.value = _activityDetailUiState.value?.copy(isLoading = true)
+            _uiState.value = uiState.value?.copy(isLoading = true)
             runCatching {
                 feedRepository.saveRemovedFeed(feedId)
             }.onSuccess {
-                _activityDetailUiState.value = _activityDetailUiState.value?.copy(
+                _uiState.value = uiState.value?.copy(
                     isLoading = false,
-                    activities = _activityDetailUiState.value?.activities?.filter { it.feedId != feedId }
+                    activities = uiState.value?.activities?.filter { it.feedId != feedId }
                         ?: emptyList(),
                 )
             }.onFailure {
-                _activityDetailUiState.value = _activityDetailUiState.value?.copy(
+                _uiState.value = uiState.value?.copy(
                     isLoading = false,
                     error = true,
                 )
@@ -157,15 +157,15 @@ class ActivityDetailViewModel @Inject constructor(
     }
 
     fun updateReportedSpoilerFeed(feedId: Long) {
-        activityDetailUiState.value?.let { feedUiState ->
+        _uiState.value?.let { feedUiState ->
             viewModelScope.launch {
-                _activityDetailUiState.value = feedUiState.copy(isLoading = true)
+                _uiState.value = feedUiState.copy(isLoading = true)
                 runCatching {
                     feedRepository.saveSpoilerFeed(feedId)
                 }.onSuccess {
-                    _activityDetailUiState.value = feedUiState.copy(isLoading = false)
+                    _uiState.value = feedUiState.copy(isLoading = false)
                 }.onFailure {
-                    _activityDetailUiState.value = feedUiState.copy(
+                    _uiState.value = feedUiState.copy(
                         isLoading = false,
                         error = true,
                     )
@@ -175,15 +175,15 @@ class ActivityDetailViewModel @Inject constructor(
     }
 
     fun updateReportedImpertinenceFeed(feedId: Long) {
-        activityDetailUiState.value?.let { feedUiState ->
+        _uiState.value?.let { feedUiState ->
             viewModelScope.launch {
-                _activityDetailUiState.value = feedUiState.copy(isLoading = true)
+                _uiState.value = feedUiState.copy(isLoading = true)
                 runCatching {
                     feedRepository.saveImpertinenceFeed(feedId)
                 }.onSuccess {
-                    _activityDetailUiState.value = feedUiState.copy(isLoading = false)
+                    _uiState.value = feedUiState.copy(isLoading = false)
                 }.onFailure {
-                    _activityDetailUiState.value = feedUiState.copy(
+                    _uiState.value = feedUiState.copy(
                         isLoading = false,
                         error = true,
                     )

--- a/app/src/main/java/com/teamwss/websoso/ui/main/myPage/MyPageFragment.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/main/myPage/MyPageFragment.kt
@@ -96,6 +96,16 @@ class MyPageFragment : BaseFragment<FragmentMyPageBinding>(R.layout.fragment_my_
     private fun setupObserver() {
         myPageViewModel.myPageUiState.observe(viewLifecycleOwner) { uiState ->
             when {
+                uiState.loading -> binding.wllMyPage.setWebsosoLoadingVisibility(true)
+                uiState.error -> binding.wllMyPage.setLoadingLayoutVisibility(false)
+                !uiState.loading -> {
+                    binding.wllMyPage.setWebsosoLoadingVisibility(false)
+                }
+            }
+        }
+
+        myPageViewModel.myPageUiState.observe(viewLifecycleOwner) { uiState ->
+            when {
                 !uiState.loading -> setUpMyProfileImage(uiState.myProfile?.avatarImage.orEmpty())
                 uiState.error -> Unit
             }

--- a/app/src/main/java/com/teamwss/websoso/ui/main/myPage/MyPageFragment.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/main/myPage/MyPageFragment.kt
@@ -41,8 +41,8 @@ class MyPageFragment : BaseFragment<FragmentMyPageBinding>(R.layout.fragment_my_
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         bindViewModel()
-        setUpViewPager()
-        setUpItemVisibilityOnToolBar()
+        setupViewPager()
+        setupItemVisibilityOnToolBar()
         onSettingButtonClick()
         setupObserver()
         onProfileEditClick()
@@ -53,7 +53,7 @@ class MyPageFragment : BaseFragment<FragmentMyPageBinding>(R.layout.fragment_my_
         binding.lifecycleOwner = viewLifecycleOwner
     }
 
-    private fun setUpViewPager() {
+    private fun setupViewPager() {
         val tabTitleItems =
             listOf(getText(R.string.my_page_library), getText(R.string.my_page_activity))
         binding.vpMyPage.adapter = viewPagerAdapter
@@ -63,7 +63,7 @@ class MyPageFragment : BaseFragment<FragmentMyPageBinding>(R.layout.fragment_my_
         }.attach()
     }
 
-    private fun setUpItemVisibilityOnToolBar() {
+    private fun setupItemVisibilityOnToolBar() {
         binding.ablMyPage.addOnOffsetChangedListener { appBarLayout, verticalOffset ->
             val totalScrollRange = appBarLayout.totalScrollRange
             val percentage = (totalScrollRange.toFloat() + verticalOffset) / totalScrollRange
@@ -98,9 +98,7 @@ class MyPageFragment : BaseFragment<FragmentMyPageBinding>(R.layout.fragment_my_
             when {
                 uiState.loading -> binding.wllMyPage.setWebsosoLoadingVisibility(true)
                 uiState.error -> binding.wllMyPage.setLoadingLayoutVisibility(false)
-                !uiState.loading -> {
-                    binding.wllMyPage.setWebsosoLoadingVisibility(false)
-                }
+                !uiState.loading -> binding.wllMyPage.setWebsosoLoadingVisibility(false)
             }
         }
 

--- a/app/src/main/java/com/teamwss/websoso/ui/main/myPage/MyPageFragment.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/main/myPage/MyPageFragment.kt
@@ -94,7 +94,7 @@ class MyPageFragment : BaseFragment<FragmentMyPageBinding>(R.layout.fragment_my_
     }
 
     private fun setupObserver() {
-        myPageViewModel.myPageUiState.observe(viewLifecycleOwner) { uiState ->
+        myPageViewModel.uiState.observe(viewLifecycleOwner) { uiState ->
             when {
                 uiState.loading -> binding.wllMyPage.setWebsosoLoadingVisibility(true)
                 uiState.error -> binding.wllMyPage.setLoadingLayoutVisibility(false)
@@ -102,7 +102,7 @@ class MyPageFragment : BaseFragment<FragmentMyPageBinding>(R.layout.fragment_my_
             }
         }
 
-        myPageViewModel.myPageUiState.observe(viewLifecycleOwner) { uiState ->
+        myPageViewModel.uiState.observe(viewLifecycleOwner) { uiState ->
             when {
                 !uiState.loading -> setUpMyProfileImage(uiState.myProfile?.avatarImage.orEmpty())
                 uiState.error -> Unit

--- a/app/src/main/java/com/teamwss/websoso/ui/main/myPage/MyPageViewModel.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/main/myPage/MyPageViewModel.kt
@@ -15,29 +15,25 @@ import javax.inject.Inject
 class MyPageViewModel @Inject constructor(
     private val userRepository: UserRepository,
 ) : ViewModel() {
-    private val _myPageUiState = MutableLiveData<MyPageUiState>()
-    val myPageUiState: LiveData<MyPageUiState> get() = _myPageUiState
-
-
-    private val _myProfile = MutableLiveData<MyProfileEntity>()
-    val myProfile: LiveData<MyProfileEntity> get() = _myProfile
+    private val _uiState = MutableLiveData<MyPageUiState>()
+    val uiState: LiveData<MyPageUiState> get() = _uiState
 
     init {
         updateUserProfile()
     }
 
     fun updateUserProfile() {
-        _myPageUiState.value = myPageUiState.value?.copy(loading = true) ?: MyPageUiState(loading = true)
+        _uiState.value = uiState.value?.copy(loading = true) ?: MyPageUiState(loading = true)
         viewModelScope.launch {
             runCatching {
                 userRepository.fetchMyProfile()
             }.onSuccess { myProfileEntity ->
-                _myPageUiState.value = myPageUiState.value?.copy(
+                _uiState.value = uiState.value?.copy(
                     myProfile = myProfileEntity,
                     loading = false,
                 )
             }.onFailure {
-                _myPageUiState.value = myPageUiState.value?.copy(
+                _uiState.value = uiState.value?.copy(
                     error = true,
                     loading = false,
                 )

--- a/app/src/main/java/com/teamwss/websoso/ui/main/myPage/myActivity/MyActivityFragment.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/main/myPage/myActivity/MyActivityFragment.kt
@@ -48,17 +48,7 @@ class MyActivityFragment :
     }
 
     private fun setupObserver() {
-        myActivityViewModel.myActivityUiState.observe(viewLifecycleOwner) { uiState ->
-            when {
-                uiState.isLoading -> binding.wllMyActivity.setWebsosoLoadingVisibility(true)
-                uiState.error -> binding.wllMyActivity.setLoadingLayoutVisibility(false)
-                !uiState.isLoading -> {
-                    binding.wllMyActivity.setWebsosoLoadingVisibility(false)
-                }
-            }
-        }
-
-        myActivityViewModel.myActivityUiState.observe(viewLifecycleOwner) { uiState ->
+        myActivityViewModel.uiState.observe(viewLifecycleOwner) { uiState ->
             val userProfile = getUserProfile()
             updateAdapterWithActivitiesAndProfile(uiState.activities, userProfile)
 
@@ -72,16 +62,24 @@ class MyActivityFragment :
                     binding.nsMyActivityExists.visibility = View.VISIBLE
                 }
             }
+
+            when {
+                uiState.isLoading -> binding.wllMyActivity.setWebsosoLoadingVisibility(true)
+                uiState.error -> binding.wllMyActivity.setLoadingLayoutVisibility(false)
+                !uiState.isLoading -> {
+                    binding.wllMyActivity.setWebsosoLoadingVisibility(false)
+                }
+            }
         }
 
-        myPageViewModel.myPageUiState.observe(viewLifecycleOwner) { uiState ->
+        myPageViewModel.uiState.observe(viewLifecycleOwner) { uiState ->
             uiState.myProfile?.let { myProfileEntity ->
                 val userProfile = UserProfileModel(
                     nickname = myProfileEntity.nickname,
                     avatarImage = myProfileEntity.avatarImage,
                 )
                 updateAdapterWithActivitiesAndProfile(
-                    myActivityViewModel.myActivityUiState.value?.activities,
+                    myActivityViewModel.uiState.value?.activities,
                     userProfile,
                 )
             }
@@ -103,7 +101,7 @@ class MyActivityFragment :
     }
 
     private fun getUserProfile(): UserProfileModel {
-        val myProfile = myPageViewModel.myPageUiState.value?.myProfile
+        val myProfile = myPageViewModel.uiState.value?.myProfile
         return UserProfileModel(
             nickname = myProfile?.nickname.orEmpty(),
             avatarImage = myProfile?.avatarImage.orEmpty()
@@ -181,7 +179,7 @@ class MyActivityFragment :
 
     fun navigateToFeedEdit(feedId: Long) {
         val activityModel =
-            myActivityViewModel.myActivityUiState.value?.activities?.find { it.feedId == feedId }
+            myActivityViewModel.uiState.value?.activities?.find { it.feedId == feedId }
         activityModel?.let { feed ->
             val editFeedModel = EditFeedModel(
                 feedId = feed.feedId,

--- a/app/src/main/java/com/teamwss/websoso/ui/main/myPage/myActivity/MyActivityFragment.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/main/myPage/myActivity/MyActivityFragment.kt
@@ -49,6 +49,16 @@ class MyActivityFragment :
 
     private fun setupObserver() {
         myActivityViewModel.myActivityUiState.observe(viewLifecycleOwner) { uiState ->
+            when {
+                uiState.isLoading -> binding.wllMyActivity.setWebsosoLoadingVisibility(true)
+                uiState.error -> binding.wllMyActivity.setLoadingLayoutVisibility(false)
+                !uiState.isLoading -> {
+                    binding.wllMyActivity.setWebsosoLoadingVisibility(false)
+                }
+            }
+        }
+
+        myActivityViewModel.myActivityUiState.observe(viewLifecycleOwner) { uiState ->
             val userProfile = getUserProfile()
             updateAdapterWithActivitiesAndProfile(uiState.activities, userProfile)
 

--- a/app/src/main/java/com/teamwss/websoso/ui/main/myPage/myActivity/MyActivityViewModel.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/main/myPage/myActivity/MyActivityViewModel.kt
@@ -20,8 +20,8 @@ class MyActivityViewModel @Inject constructor(
     private val feedRepository: FeedRepository,
 ) : ViewModel() {
 
-    private val _myActivityUiState: MutableLiveData<MyActivityUiState> = MutableLiveData(MyActivityUiState())
-    val myActivityUiState: LiveData<MyActivityUiState> get() = _myActivityUiState
+    private val _uiState: MutableLiveData<MyActivityUiState> = MutableLiveData(MyActivityUiState())
+    val uiState: LiveData<MyActivityUiState> get() = _uiState
 
     private val _lastFeedId: MutableLiveData<Long> = MutableLiveData(0L)
     val lastFeedId: LiveData<Long> get() = _lastFeedId
@@ -37,20 +37,20 @@ class MyActivityViewModel @Inject constructor(
 
     private fun updateMyActivities() {
         viewModelScope.launch {
-            _myActivityUiState.value = _myActivityUiState.value?.copy(isLoading = true)
+            _uiState.value = uiState.value?.copy(isLoading = true)
             runCatching {
                 userRepository.fetchMyActivities(
                     lastFeedId.value ?: 0L,
                     size,
                 )
             }.onSuccess { response ->
-                _myActivityUiState.value = _myActivityUiState.value?.copy(
+                _uiState.value = uiState.value?.copy(
                     isLoading = false,
                     activities = response.feeds.map { it.toUi() }.take(ACTIVITY_LIMIT_COUNT),
                 )
                 _lastFeedId.value = response.feeds.lastOrNull()?.feedId?.toLong() ?: 0L
             }.onFailure {
-                _myActivityUiState.value = _myActivityUiState.value?.copy(
+                _uiState.value = uiState.value?.copy(
                     isLoading = false,
                     error = true,
                 )
@@ -68,7 +68,7 @@ class MyActivityViewModel @Inject constructor(
                 }
             }.onSuccess {
                 val newLikeCount = if (isLiked) currentLikeCount - 1 else currentLikeCount + 1
-                _myActivityUiState.value = _myActivityUiState.value?.copy(
+                _uiState.value = uiState.value?.copy(
                     likeState = ActivityLikeState(feedId, !isLiked, newLikeCount),
                 )
 
@@ -80,8 +80,8 @@ class MyActivityViewModel @Inject constructor(
     }
 
     private fun saveActivityLikeState(feedId: Long, isLiked: Boolean, likeCount: Int) {
-        _myActivityUiState.value = _myActivityUiState.value?.copy(
-            activities = _myActivityUiState.value?.activities?.map { activity ->
+        _uiState.value = uiState.value?.copy(
+            activities = uiState.value?.activities?.map { activity ->
                 if (activity.feedId == feedId) {
                     activity.copy(
                         isLiked = isLiked,
@@ -96,16 +96,16 @@ class MyActivityViewModel @Inject constructor(
 
     fun updateRemovedFeed(feedId: Long) {
         viewModelScope.launch {
-            _myActivityUiState.value = _myActivityUiState.value?.copy(isLoading = true)
+            _uiState.value = uiState.value?.copy(isLoading = true)
             runCatching {
                 feedRepository.saveRemovedFeed(feedId)
             }.onSuccess {
-                _myActivityUiState.value = _myActivityUiState.value?.copy(
+                _uiState.value = uiState.value?.copy(
                     isLoading = false,
-                    activities = _myActivityUiState.value?.activities?.filter { it.feedId != feedId } ?: emptyList(),
+                    activities = uiState.value?.activities?.filter { it.feedId != feedId } ?: emptyList(),
                 )
             }.onFailure {
-                _myActivityUiState.value = _myActivityUiState.value?.copy(
+                _uiState.value = uiState.value?.copy(
                     isLoading = false,
                     error = true,
                 )

--- a/app/src/main/java/com/teamwss/websoso/ui/main/myPage/myLibrary/MyLibraryFragment.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/main/myPage/myLibrary/MyLibraryFragment.kt
@@ -56,35 +56,33 @@ class MyLibraryFragment : BaseFragment<FragmentMyLibraryBinding>(R.layout.fragme
 
     private fun setUpObserve() {
         myLibraryViewModel.uiState.observe(viewLifecycleOwner) { uiState ->
-            uiState?.let {
-                when {
-                    uiState.isLoading -> binding.wllMyLibrary.setWebsosoLoadingVisibility(true)
-                    uiState.error -> binding.wllMyLibrary.setLoadingLayoutVisibility(false)
-                    !uiState.isLoading -> {
-                        binding.wllMyLibrary.setWebsosoLoadingVisibility(false)
-                    }
+            when {
+                uiState.isLoading -> binding.wllMyLibrary.setWebsosoLoadingVisibility(true)
+                uiState.isError -> binding.wllMyLibrary.setLoadingLayoutVisibility(false)
+                !uiState.isLoading -> {
+                    binding.wllMyLibrary.setWebsosoLoadingVisibility(false)
                 }
-
-                when (myLibraryViewModel.hasNoPreferences()) {
-                    true -> {
-                        binding.clMyLibraryKnownPreference.visibility = View.GONE
-                        binding.clMyLibraryUnknownPreference.visibility = View.VISIBLE
-                    }
-
-                    false -> {
-                        binding.clMyLibraryKnownPreference.visibility = View.VISIBLE
-                        binding.clMyLibraryUnknownPreference.visibility = View.GONE
-                    }
-                }
-
-                restGenrePreferenceAdapter.updateRestGenrePreferenceData(uiState.restGenres)
-                updateRestGenrePreferenceVisibility(uiState.isGenreListVisible)
-
-                uiState.novelPreferences?.let { updateNovelPreferencesKeywords(it) }
-                updateDominantGenres(uiState.topGenres)
-
-                applyTextColors(uiState.translatedAttractivePoints.joinToString(", ") + getString(R.string.my_library_attractive_point_fixed_text))
             }
+
+            when (myLibraryViewModel.hasNoPreferences()) {
+                true -> {
+                    binding.clMyLibraryKnownPreference.visibility = View.GONE
+                    binding.clMyLibraryUnknownPreference.visibility = View.VISIBLE
+                }
+
+                false -> {
+                    binding.clMyLibraryKnownPreference.visibility = View.VISIBLE
+                    binding.clMyLibraryUnknownPreference.visibility = View.GONE
+                }
+            }
+
+            restGenrePreferenceAdapter.updateRestGenrePreferenceData(uiState.restGenres)
+            updateRestGenrePreferenceVisibility(uiState.isGenreListVisible)
+
+            uiState.novelPreferences?.let { updateNovelPreferencesKeywords(it) }
+            updateDominantGenres(uiState.topGenres)
+
+            applyTextColors(uiState.translatedAttractivePoints.joinToString(", ") + getString(R.string.my_library_attractive_point_fixed_text))
         }
     }
 

--- a/app/src/main/java/com/teamwss/websoso/ui/main/myPage/myLibrary/MyLibraryFragment.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/main/myPage/myLibrary/MyLibraryFragment.kt
@@ -45,39 +45,36 @@ class MyLibraryFragment : BaseFragment<FragmentMyLibraryBinding>(R.layout.fragme
     }
 
     private fun setUpObserve() {
-        myLibraryViewModel.novelStats.observe(viewLifecycleOwner) { stats ->
-            when (myLibraryViewModel.hasNoPreferences(stats)) {
-                true -> {
-                    binding.clMyLibraryKnownPreference.visibility = View.GONE
-                    binding.clMyLibraryUnknownPreference.visibility = View.VISIBLE
+        myLibraryViewModel.uiState.observe(viewLifecycleOwner) { uiState ->
+            uiState?.let {
+                when {
+                    uiState.isLoading -> binding.wllMyLibrary.setWebsosoLoadingVisibility(true)
+                    uiState.error -> binding.wllMyLibrary.setLoadingLayoutVisibility(false)
+                    !uiState.isLoading -> {
+                        binding.wllMyLibrary.setWebsosoLoadingVisibility(false)
+                    }
                 }
-                false -> {
-                    binding.clMyLibraryKnownPreference.visibility = View.VISIBLE
-                    binding.clMyLibraryUnknownPreference.visibility = View.GONE
+
+                when (myLibraryViewModel.hasNoPreferences()) {
+                    true -> {
+                        binding.clMyLibraryKnownPreference.visibility = View.GONE
+                        binding.clMyLibraryUnknownPreference.visibility = View.VISIBLE
+                    }
+
+                    false -> {
+                        binding.clMyLibraryKnownPreference.visibility = View.VISIBLE
+                        binding.clMyLibraryUnknownPreference.visibility = View.GONE
+                    }
                 }
+
+                restGenrePreferenceAdapter.updateRestGenrePreferenceData(uiState.restGenres)
+                updateRestGenrePreferenceVisibility(uiState.isGenreListVisible)
+
+                uiState.novelPreferences?.let { updateNovelPreferencesKeywords(it) }
+                updateDominantGenres(uiState.topGenres)
+
+                applyTextColors(uiState.translatedAttractivePoints.joinToString(", ") + getString(R.string.my_library_attractive_point_fixed_text))
             }
-        }
-
-        myLibraryViewModel.restGenres.observe(viewLifecycleOwner) { genres ->
-            restGenrePreferenceAdapter.updateRestGenrePreferenceData(genres)
-        }
-
-        myLibraryViewModel.isGenreListVisible.observe(viewLifecycleOwner) { isVisible ->
-            updateRestGenrePreferenceVisibility(isVisible)
-        }
-
-        myLibraryViewModel.translatedAttractivePoints.observe(viewLifecycleOwner) { translatedPoints ->
-            val combinedText =
-                translatedPoints.joinToString(", ") + getString(R.string.my_library_attractive_point_fixed_text)
-            applyTextColors(combinedText)
-        }
-
-        myLibraryViewModel.novelPreferences.observe(viewLifecycleOwner) { novelPreferences ->
-            updateNovelPreferencesKeywords(novelPreferences)
-        }
-
-        myLibraryViewModel.topGenres.observe(viewLifecycleOwner) { topGenres ->
-            updateDominantGenres(topGenres)
         }
     }
 

--- a/app/src/main/java/com/teamwss/websoso/ui/main/myPage/myLibrary/MyLibraryViewModel.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/main/myPage/myLibrary/MyLibraryViewModel.kt
@@ -43,19 +43,19 @@ class MyLibraryViewModel @Inject constructor(
             runCatching {
                 userRepository.fetchUserNovelStats(userId)
             }.onSuccess { novelStats ->
-                _uiState.value = _uiState.value?.copy(
+                _uiState.value = uiState.value?.copy(
                     novelStats = novelStats,
                     isError = false,
                     isLoading = false,
                 )
             }.onFailure {
-                _uiState.value = _uiState.value?.copy(isLoading = false, isError = true)
+                _uiState.value = uiState.value?.copy(isLoading = false, isError = true)
             }
         }
     }
 
     fun hasNoPreferences(): Boolean {
-        return _uiState.value?.novelStats?.run {
+        return uiState.value?.novelStats?.run {
             interestNovelCount == 0 && watchingNovelCount == 0 &&
                     watchedNovelCount == 0 && quitNovelCount == 0
         } ?: true
@@ -67,19 +67,19 @@ class MyLibraryViewModel @Inject constructor(
                 userRepository.fetchGenrePreference(userId)
             }.onSuccess { genres ->
                 val sortedGenres = genres.sortedByDescending { it.genreCount }
-                _uiState.value = _uiState.value?.copy(
+                _uiState.value = uiState.value?.copy(
                     topGenres = sortedGenres.take(TOP_GENRE_COUNT),
                     restGenres = sortedGenres.drop(TOP_GENRE_COUNT),
                     isError = false,
                 )
             }.onFailure {
-                _uiState.value = _uiState.value?.copy(isError = true)
+                _uiState.value = uiState.value?.copy(isError = true)
             }
         }
     }
 
     fun updateToggleGenresVisibility() {
-        _uiState.value = _uiState.value?.copy(
+        _uiState.value = uiState.value?.copy(
             isGenreListVisible = _uiState.value?.isGenreListVisible?.not() ?: false
         )
     }
@@ -89,13 +89,13 @@ class MyLibraryViewModel @Inject constructor(
             runCatching {
                 userRepository.fetchNovelPreferences(userId)
             }.onSuccess { novelPreferences ->
-                _uiState.value = _uiState.value?.copy(
+                _uiState.value = uiState.value?.copy(
                     novelPreferences = novelPreferences,
                     translatedAttractivePoints = translateAttractivePoints(novelPreferences.attractivePoints),
                     isError = false,
                 )
             }.onFailure {
-                _uiState.value = _uiState.value?.copy(isError = true)
+                _uiState.value = uiState.value?.copy(isError = true)
             }
         }
     }

--- a/app/src/main/java/com/teamwss/websoso/ui/main/myPage/myLibrary/MyLibraryViewModel.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/main/myPage/myLibrary/MyLibraryViewModel.kt
@@ -79,8 +79,9 @@ class MyLibraryViewModel @Inject constructor(
     }
 
     fun updateToggleGenresVisibility() {
-        _uiState.value =
-            _uiState.value?.copy(isGenreListVisible = !_uiState.value!!.isGenreListVisible)
+        _uiState.value = _uiState.value?.copy(
+            isGenreListVisible = _uiState.value?.isGenreListVisible?.not() ?: false
+        )
     }
 
     private fun updateNovelPreferences(userId: Long) {

--- a/app/src/main/java/com/teamwss/websoso/ui/main/myPage/myLibrary/MyLibraryViewModel.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/main/myPage/myLibrary/MyLibraryViewModel.kt
@@ -23,6 +23,7 @@ class MyLibraryViewModel @Inject constructor(
     val attractivePointsText: LiveData<String> get() = _attractivePointsText
 
     var userId: Long = -1
+        private set
 
     init {
         updateMyLibrary()
@@ -44,11 +45,11 @@ class MyLibraryViewModel @Inject constructor(
             }.onSuccess { novelStats ->
                 _uiState.value = _uiState.value?.copy(
                     novelStats = novelStats,
-                    error = false,
+                    isError = false,
                     isLoading = false,
                 )
             }.onFailure {
-                _uiState.value = _uiState.value?.copy(isLoading = false, error = true)
+                _uiState.value = _uiState.value?.copy(isLoading = false, isError = true)
             }
         }
     }
@@ -67,12 +68,12 @@ class MyLibraryViewModel @Inject constructor(
             }.onSuccess { genres ->
                 val sortedGenres = genres.sortedByDescending { it.genreCount }
                 _uiState.value = _uiState.value?.copy(
-                    topGenres = sortedGenres.take(3),
-                    restGenres = sortedGenres.drop(3),
-                    error = false,
+                    topGenres = sortedGenres.take(TOP_GENRE_COUNT),
+                    restGenres = sortedGenres.drop(TOP_GENRE_COUNT),
+                    isError = false,
                 )
             }.onFailure {
-                _uiState.value = _uiState.value?.copy(error = true)
+                _uiState.value = _uiState.value?.copy(isError = true)
             }
         }
     }
@@ -90,10 +91,10 @@ class MyLibraryViewModel @Inject constructor(
                 _uiState.value = _uiState.value?.copy(
                     novelPreferences = novelPreferences,
                     translatedAttractivePoints = translateAttractivePoints(novelPreferences.attractivePoints),
-                    error = false,
+                    isError = false,
                 )
             }.onFailure {
-                _uiState.value = _uiState.value?.copy(error = true)
+                _uiState.value = _uiState.value?.copy(isError = true)
             }
         }
     }
@@ -102,5 +103,9 @@ class MyLibraryViewModel @Inject constructor(
         return attractivePoints.mapNotNull { point ->
             AttractivePoints.fromString(point)?.korean
         }
+    }
+
+    companion object {
+        private const val TOP_GENRE_COUNT = 3
     }
 }

--- a/app/src/main/java/com/teamwss/websoso/ui/main/myPage/myLibrary/MyLibraryViewModel.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/main/myPage/myLibrary/MyLibraryViewModel.kt
@@ -4,11 +4,9 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.teamwss.websoso.data.model.GenrePreferenceEntity
-import com.teamwss.websoso.data.model.NovelPreferenceEntity
-import com.teamwss.websoso.data.model.UserNovelStatsEntity
 import com.teamwss.websoso.data.repository.UserRepository
 import com.teamwss.websoso.ui.main.myPage.myLibrary.model.AttractivePoints
+import com.teamwss.websoso.ui.main.myPage.myLibrary.model.MyLibraryUiState
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -18,31 +16,13 @@ class MyLibraryViewModel @Inject constructor(
     private val userRepository: UserRepository,
 ) : ViewModel() {
 
-    private val _genres = MutableLiveData<List<GenrePreferenceEntity>>()
-    val genres: LiveData<List<GenrePreferenceEntity>> get() = _genres
-
-    private val _dominantGenres = MutableLiveData<List<GenrePreferenceEntity>>()
-    val topGenres: LiveData<List<GenrePreferenceEntity>> get() = _dominantGenres
-
-    private val _restGenres = MutableLiveData<List<GenrePreferenceEntity>>()
-    val restGenres: LiveData<List<GenrePreferenceEntity>> get() = _restGenres
-
-    private val _isGenreListVisible = MutableLiveData<Boolean>(false)
-    val isGenreListVisible: LiveData<Boolean> get() = _isGenreListVisible
-
-    private val _novelPreferences = MutableLiveData<NovelPreferenceEntity>()
-    val novelPreferences: LiveData<NovelPreferenceEntity> get() = _novelPreferences
+    private val _uiState = MutableLiveData(MyLibraryUiState())
+    val uiState: LiveData<MyLibraryUiState> get() = _uiState
 
     private val _attractivePointsText = MutableLiveData<String>()
     val attractivePointsText: LiveData<String> get() = _attractivePointsText
 
-    private val _translatedAttractivePoints = MutableLiveData<List<String>>()
-    val translatedAttractivePoints: LiveData<List<String>> get() = _translatedAttractivePoints
-
-    private val _novelStats = MutableLiveData<UserNovelStatsEntity>()
-    val novelStats: LiveData<UserNovelStatsEntity> get() = _novelStats
-
-    private var userId: Long = -1
+    var userId: Long = -1
 
     init {
         viewModelScope.launch {
@@ -58,17 +38,22 @@ class MyLibraryViewModel @Inject constructor(
             runCatching {
                 userRepository.fetchUserNovelStats(userId)
             }.onSuccess { novelStats ->
-                _novelStats.value = novelStats
-            }.onFailure { exception ->
+                _uiState.value = _uiState.value?.copy(
+                    novelStats = novelStats,
+                    error = false,
+                    isLoading = false,
+                )
+            }.onFailure {
+                _uiState.value = _uiState.value?.copy(isLoading = false, error = true)
             }
         }
     }
 
-    fun hasNoPreferences(stats: UserNovelStatsEntity): Boolean {
-        return stats.interestNovelCount == 0 &&
-                stats.watchingNovelCount == 0 &&
-                stats.watchedNovelCount == 0 &&
-                stats.quitNovelCount == 0
+    fun hasNoPreferences(): Boolean {
+        return _uiState.value?.novelStats?.run {
+            interestNovelCount == 0 && watchingNovelCount == 0 &&
+                    watchedNovelCount == 0 && quitNovelCount == 0
+        } ?: true
     }
 
     private fun updateGenrePreference(userId: Long) {
@@ -77,16 +62,20 @@ class MyLibraryViewModel @Inject constructor(
                 userRepository.fetchGenrePreference(userId)
             }.onSuccess { genres ->
                 val sortedGenres = genres.sortedByDescending { it.genreCount }
-
-                _dominantGenres.value = sortedGenres.take(3)
-                _restGenres.value = sortedGenres.drop(3)
-            }.onFailure { exception ->
+                _uiState.value = _uiState.value?.copy(
+                    topGenres = sortedGenres.take(3),
+                    restGenres = sortedGenres.drop(3),
+                    error = false,
+                )
+            }.onFailure {
+                _uiState.value = _uiState.value?.copy(error = true)
             }
         }
     }
 
     fun updateToggleGenresVisibility() {
-        _isGenreListVisible.value = _isGenreListVisible.value?.not() ?: false
+        _uiState.value =
+            _uiState.value?.copy(isGenreListVisible = !_uiState.value!!.isGenreListVisible)
     }
 
     private fun updateNovelPreferences(userId: Long) {
@@ -94,10 +83,13 @@ class MyLibraryViewModel @Inject constructor(
             runCatching {
                 userRepository.fetchNovelPreferences(userId)
             }.onSuccess { novelPreferences ->
-                _novelPreferences.value = novelPreferences
-                _translatedAttractivePoints.value =
-                    translateAttractivePoints(novelPreferences.attractivePoints)
-            }.onFailure { exception ->
+                _uiState.value = _uiState.value?.copy(
+                    novelPreferences = novelPreferences,
+                    translatedAttractivePoints = translateAttractivePoints(novelPreferences.attractivePoints),
+                    error = false,
+                )
+            }.onFailure {
+                _uiState.value = _uiState.value?.copy(error = true)
             }
         }
     }

--- a/app/src/main/java/com/teamwss/websoso/ui/main/myPage/myLibrary/model/MyLibraryUiState.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/main/myPage/myLibrary/model/MyLibraryUiState.kt
@@ -6,7 +6,7 @@ import com.teamwss.websoso.data.model.UserNovelStatsEntity
 
 data class MyLibraryUiState(
     val isLoading: Boolean = false,
-    val error: Boolean = false,
+    val isError: Boolean = false,
     val novelStats: UserNovelStatsEntity? = null,
     val topGenres: List<GenrePreferenceEntity> = emptyList(),
     val restGenres: List<GenrePreferenceEntity> = emptyList(),

--- a/app/src/main/java/com/teamwss/websoso/ui/main/myPage/myLibrary/model/MyLibraryUiState.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/main/myPage/myLibrary/model/MyLibraryUiState.kt
@@ -1,0 +1,16 @@
+package com.teamwss.websoso.ui.main.myPage.myLibrary.model
+
+import com.teamwss.websoso.data.model.GenrePreferenceEntity
+import com.teamwss.websoso.data.model.NovelPreferenceEntity
+import com.teamwss.websoso.data.model.UserNovelStatsEntity
+
+data class MyLibraryUiState(
+    val isLoading: Boolean = false,
+    val error: Boolean = false,
+    val novelStats: UserNovelStatsEntity? = null,
+    val topGenres: List<GenrePreferenceEntity> = emptyList(),
+    val restGenres: List<GenrePreferenceEntity> = emptyList(),
+    val novelPreferences: NovelPreferenceEntity? = null,
+    val translatedAttractivePoints: List<String> = emptyList(),
+    val isGenreListVisible: Boolean = false,
+)

--- a/app/src/main/java/com/teamwss/websoso/ui/otherUserPage/BlockUserDialogFragment.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/otherUserPage/BlockUserDialogFragment.kt
@@ -42,10 +42,10 @@ class BlockUserDialogFragment :
     }
 
     private fun setupObserver() {
-        otherUserPageViewModel.isBlockedCompleted.observe(viewLifecycleOwner) { isBlockedCompleted ->
-            if (isBlockedCompleted) {
+        otherUserPageViewModel.uiState.observe(viewLifecycleOwner) { uiState ->
+            if (uiState.isBlockedCompleted) {
                 val intent = Intent().apply {
-                    putExtra(USER_NICKNAME, otherUserPageViewModel.otherUserProfile.value?.nickname)
+                    putExtra(USER_NICKNAME, otherUserPageViewModel.uiState.value?.otherUserProfile?.nickname)
                 }
                 activity?.setResult(BlockUser.RESULT_OK, intent)
                 dismiss()

--- a/app/src/main/java/com/teamwss/websoso/ui/otherUserPage/OtherUserPageActivity.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/otherUserPage/OtherUserPageActivity.kt
@@ -72,12 +72,22 @@ class OtherUserPageActivity :
     }
 
     private fun setupObserver() {
-        otherUserPageViewModel.otherUserProfile.observe(this) { otherUserProfile ->
-            setUpMyProfileImage(otherUserProfile.avatarImage.orEmpty())
+        otherUserPageViewModel.uiState.observe(this) { uiState ->
+            when {
+                uiState.isLoading -> binding.wllOtherUserPage.setWebsosoLoadingVisibility(true)
+                uiState.error -> binding.wllOtherUserPage.setLoadingLayoutVisibility(false)
+                !uiState.isLoading -> {
+                    binding.wllOtherUserPage.setWebsosoLoadingVisibility(false)
+                }
+            }
         }
 
-        otherUserPageViewModel.otherUserProfile.observe(this) { profile ->
-            if (profile.isProfilePublic) {
+        otherUserPageViewModel.uiState.observe(this) { uiState ->
+            setUpMyProfileImage(uiState.otherUserProfile?.avatarImage.orEmpty())
+        }
+
+        otherUserPageViewModel.uiState.observe(this) { uiState ->
+            if (uiState.otherUserProfile?.isProfilePublic == true) {
                 binding.vpOtherUserPage.visibility = View.VISIBLE
                 binding.clOtherUserPageNoPublic.visibility = View.GONE
             } else {

--- a/app/src/main/java/com/teamwss/websoso/ui/otherUserPage/OtherUserPageActivity.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/otherUserPage/OtherUserPageActivity.kt
@@ -80,21 +80,22 @@ class OtherUserPageActivity :
                     binding.wllOtherUserPage.setWebsosoLoadingVisibility(false)
                 }
             }
-        }
 
-        otherUserPageViewModel.uiState.observe(this) { uiState ->
+            when (uiState.otherUserProfile?.isProfilePublic) {
+                true -> {
+                    binding.vpOtherUserPage.visibility = View.VISIBLE
+                    binding.clOtherUserPageNoPublic.visibility = View.GONE
+                }
+
+                false, null -> {
+                    binding.vpOtherUserPage.visibility = View.GONE
+                    binding.clOtherUserPageNoPublic.visibility = View.VISIBLE
+                }
+            }
+
             setUpMyProfileImage(uiState.otherUserProfile?.avatarImage.orEmpty())
         }
 
-        otherUserPageViewModel.uiState.observe(this) { uiState ->
-            if (uiState.otherUserProfile?.isProfilePublic == true) {
-                binding.vpOtherUserPage.visibility = View.VISIBLE
-                binding.clOtherUserPageNoPublic.visibility = View.GONE
-            } else {
-                binding.vpOtherUserPage.visibility = View.GONE
-                binding.clOtherUserPageNoPublic.visibility = View.VISIBLE
-            }
-        }
     }
 
     private fun setUpMyProfileImage(otherUserProfileUrl: String) {

--- a/app/src/main/java/com/teamwss/websoso/ui/otherUserPage/OtherUserPageViewModel.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/otherUserPage/OtherUserPageViewModel.kt
@@ -18,9 +18,12 @@ class OtherUserPageViewModel @Inject constructor(
     private val _uiState = MutableLiveData(OtherUserPageUiState())
     val uiState: LiveData<OtherUserPageUiState> get() = _uiState
 
-    fun updateUserId(userId: Long) {
-        _uiState.value = _uiState.value?.copy(userId = userId, isLoading = true)
-        updateUserProfile(userId)
+    private var userId: Long = 0L
+
+    fun updateUserId(newUserId: Long) {
+        userId = newUserId
+        _uiState.value = _uiState.value?.copy(isLoading = true)
+        updateUserProfile(newUserId)
     }
 
     private fun updateUserProfile(userId: Long) {
@@ -46,7 +49,7 @@ class OtherUserPageViewModel @Inject constructor(
         _uiState.value = _uiState.value?.copy(isLoading = true)
         viewModelScope.launch {
             runCatching {
-                userRepository.saveBlockUser(_uiState.value?.userId ?: 0L)
+                userRepository.saveBlockUser(userId)
             }.onSuccess {
                 _uiState.value = _uiState.value?.copy(
                     isBlockedCompleted = true,

--- a/app/src/main/java/com/teamwss/websoso/ui/otherUserPage/OtherUserPageViewModel.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/otherUserPage/OtherUserPageViewModel.kt
@@ -4,8 +4,8 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.teamwss.websoso.data.model.OtherUserProfileEntity
 import com.teamwss.websoso.data.repository.UserRepository
+import com.teamwss.websoso.ui.otherUserPage.model.OtherUserPageUiState
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -15,39 +15,50 @@ class OtherUserPageViewModel @Inject constructor(
     private val userRepository: UserRepository,
 ) : ViewModel() {
 
-    private val _otherUserProfile = MutableLiveData<OtherUserProfileEntity>()
-    val otherUserProfile: LiveData<OtherUserProfileEntity> get() = _otherUserProfile
-
-    private val _userId: MutableLiveData<Long> = MutableLiveData()
-    val userId: LiveData<Long> get() = _userId
-
-    private val _isBlockedCompleted: MutableLiveData<Boolean> = MutableLiveData()
-    val isBlockedCompleted: LiveData<Boolean> get() = _isBlockedCompleted
+    private val _uiState = MutableLiveData(OtherUserPageUiState())
+    val uiState: LiveData<OtherUserPageUiState> get() = _uiState
 
     fun updateUserId(userId: Long) {
-        _userId.value = userId
-
-        updateUserProfile()
+        _uiState.value = _uiState.value?.copy(userId = userId, isLoading = true)
+        updateUserProfile(userId)
     }
 
-    private fun updateUserProfile() {
+    private fun updateUserProfile(userId: Long) {
         viewModelScope.launch {
             runCatching {
-                userRepository.fetchOtherUserProfile(userId.value ?: 0L)
+                userRepository.fetchOtherUserProfile(userId)
             }.onSuccess { otherUserProfile ->
-                _otherUserProfile.value = otherUserProfile
-            }.onFailure { exception ->
+                _uiState.value = _uiState.value?.copy(
+                    otherUserProfile = otherUserProfile,
+                    isLoading = false,
+                    error = false,
+                )
+            }.onFailure {
+                _uiState.value = _uiState.value?.copy(
+                    isLoading = false,
+                    error = true,
+                )
             }
         }
     }
 
     fun updateBlockedUser() {
+        _uiState.value = _uiState.value?.copy(isLoading = true)
         viewModelScope.launch {
             runCatching {
-                userRepository.saveBlockUser(userId.value ?: 0L)
+                userRepository.saveBlockUser(_uiState.value?.userId ?: 0L)
             }.onSuccess {
-                _isBlockedCompleted.value = true
-            }.onFailure {}
+                _uiState.value = _uiState.value?.copy(
+                    isBlockedCompleted = true,
+                    isLoading = false,
+                    error = false,
+                )
+            }.onFailure {
+                _uiState.value = _uiState.value?.copy(
+                    isLoading = false,
+                    error = true,
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/com/teamwss/websoso/ui/otherUserPage/model/OtherUserPageUiState.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/otherUserPage/model/OtherUserPageUiState.kt
@@ -1,0 +1,11 @@
+package com.teamwss.websoso.ui.otherUserPage.model
+
+import com.teamwss.websoso.data.model.OtherUserProfileEntity
+
+data class OtherUserPageUiState(
+    val otherUserProfile: OtherUserProfileEntity? = null,
+    val userId: Long = 0L,
+    val isBlockedCompleted: Boolean = false,
+    val isLoading: Boolean = false,
+    val error: Boolean = false,
+)

--- a/app/src/main/java/com/teamwss/websoso/ui/otherUserPage/model/OtherUserPageUiState.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/otherUserPage/model/OtherUserPageUiState.kt
@@ -4,7 +4,6 @@ import com.teamwss.websoso.data.model.OtherUserProfileEntity
 
 data class OtherUserPageUiState(
     val otherUserProfile: OtherUserProfileEntity? = null,
-    val userId: Long = 0L,
     val isBlockedCompleted: Boolean = false,
     val isLoading: Boolean = false,
     val error: Boolean = false,

--- a/app/src/main/java/com/teamwss/websoso/ui/otherUserPage/otherUserActivity/OtherUserActivityFragment.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/otherUserPage/otherUserActivity/OtherUserActivityFragment.kt
@@ -53,13 +53,24 @@ class OtherUserActivityFragment :
     }
 
     private fun setupObserver() {
-        otherUserActivityViewModel.otherUserActivityUiState.observe(viewLifecycleOwner) { uiState ->
+        otherUserPageViewModel.uiState.observe(viewLifecycleOwner) { uiState ->
             when {
                 uiState.isLoading -> binding.wllOtherUserActivity.setWebsosoLoadingVisibility(true)
                 uiState.error -> binding.wllOtherUserActivity.setLoadingLayoutVisibility(false)
                 !uiState.isLoading -> {
                     binding.wllOtherUserActivity.setWebsosoLoadingVisibility(false)
                 }
+            }
+
+            uiState.otherUserProfile?.let {
+                val userProfile = UserProfileModel(
+                    nickname = it.nickname,
+                    avatarImage = it.avatarImage,
+                )
+                updateAdapterWithActivitiesAndProfile(
+                    otherUserActivityViewModel.otherUserActivityUiState.value?.activities,
+                    userProfile,
+                )
             }
         }
 
@@ -76,19 +87,6 @@ class OtherUserActivityFragment :
                     binding.clOtherUserActivityExistsNull.visibility = View.GONE
                     binding.nsOtherUserActivityExists.visibility = View.VISIBLE
                 }
-            }
-        }
-
-        otherUserPageViewModel.uiState.observe(viewLifecycleOwner) { uiState ->
-            uiState.otherUserProfile?.let {
-                val userProfile = UserProfileModel(
-                    nickname = it.nickname,
-                    avatarImage = it.avatarImage,
-                )
-                updateAdapterWithActivitiesAndProfile(
-                    otherUserActivityViewModel.otherUserActivityUiState.value?.activities,
-                    userProfile,
-                )
             }
         }
     }

--- a/app/src/main/java/com/teamwss/websoso/ui/otherUserPage/otherUserActivity/OtherUserActivityFragment.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/otherUserPage/otherUserActivity/OtherUserActivityFragment.kt
@@ -54,6 +54,16 @@ class OtherUserActivityFragment :
 
     private fun setupObserver() {
         otherUserActivityViewModel.otherUserActivityUiState.observe(viewLifecycleOwner) { uiState ->
+            when {
+                uiState.isLoading -> binding.wllOtherUserActivity.setWebsosoLoadingVisibility(true)
+                uiState.error -> binding.wllOtherUserActivity.setLoadingLayoutVisibility(false)
+                !uiState.isLoading -> {
+                    binding.wllOtherUserActivity.setWebsosoLoadingVisibility(false)
+                }
+            }
+        }
+
+        otherUserActivityViewModel.otherUserActivityUiState.observe(viewLifecycleOwner) { uiState ->
             val userProfile = getUserProfile()
             updateAdapterWithActivitiesAndProfile(uiState.activities, userProfile)
 
@@ -69,8 +79,8 @@ class OtherUserActivityFragment :
             }
         }
 
-        otherUserPageViewModel.otherUserProfile.observe(viewLifecycleOwner) { otherUserProfile ->
-            otherUserProfile?.let {
+        otherUserPageViewModel.uiState.observe(viewLifecycleOwner) { uiState ->
+            uiState.otherUserProfile?.let {
                 val userProfile = UserProfileModel(
                     nickname = it.nickname,
                     avatarImage = it.avatarImage,
@@ -98,10 +108,10 @@ class OtherUserActivityFragment :
     }
 
     private fun getUserProfile(): UserProfileModel {
-        val profile = otherUserPageViewModel.otherUserProfile.value
+        val profile = otherUserPageViewModel.uiState.value?.otherUserProfile
         return UserProfileModel(
             nickname = profile?.nickname.orEmpty(),
-            avatarImage = profile?.avatarImage.orEmpty()
+            avatarImage = profile?.avatarImage.orEmpty(),
         )
     }
 

--- a/app/src/main/java/com/teamwss/websoso/ui/otherUserPage/otherUserLibrary/OtherUserLibraryFragment.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/otherUserPage/otherUserLibrary/OtherUserLibraryFragment.kt
@@ -53,8 +53,16 @@ class OtherUserLibraryFragment :
     }
 
     private fun setupObserve() {
-        otherUserLibraryViewModel.novelStats.observe(viewLifecycleOwner) { stats ->
-            when (otherUserLibraryViewModel.hasNoPreferences(stats)) {
+        otherUserLibraryViewModel.uiState.observe(viewLifecycleOwner) { uiState ->
+            when {
+                uiState.isLoading -> binding.wllOtherUserLibrary.setWebsosoLoadingVisibility(true)
+                uiState.error -> binding.wllOtherUserLibrary.setLoadingLayoutVisibility(false)
+                !uiState.isLoading -> {
+                    binding.wllOtherUserLibrary.setWebsosoLoadingVisibility(false)
+                }
+            }
+
+            when (otherUserLibraryViewModel.hasNoPreferences()) {
                 true -> {
                     binding.clOtherUserLibraryKnownPreference.visibility = View.GONE
                     binding.clOtherUserLibraryUnknownPreference.visibility = View.VISIBLE
@@ -64,28 +72,14 @@ class OtherUserLibraryFragment :
                     binding.clOtherUserLibraryUnknownPreference.visibility = View.GONE
                 }
             }
-        }
 
-        otherUserLibraryViewModel.restGenres.observe(viewLifecycleOwner) { genres ->
-            restGenrePreferenceAdapter.updateRestGenrePreferenceData(genres)
-        }
+            restGenrePreferenceAdapter.updateRestGenrePreferenceData(uiState.restGenres)
+            updateRestGenrePreferenceVisibility(uiState.isGenreListVisible)
 
-        otherUserLibraryViewModel.isGenreListVisible.observe(viewLifecycleOwner) { isVisible ->
-            updateRestGenrePreferenceVisibility(isVisible)
-        }
+            uiState.novelPreferences?.let { updateNovelPreferencesKeywords(it) }
+            updateDominantGenres(uiState.topGenres)
 
-        otherUserLibraryViewModel.translatedAttractivePoints.observe(viewLifecycleOwner) { translatedPoints ->
-            val combinedText =
-                translatedPoints.joinToString(", ") + getString(R.string.my_library_attractive_point_fixed_text)
-            applyTextColors(combinedText)
-        }
-
-        otherUserLibraryViewModel.novelPreferences.observe(viewLifecycleOwner) { novelPreferences ->
-            updateNovelPreferencesKeywords(novelPreferences)
-        }
-
-        otherUserLibraryViewModel.topGenres.observe(viewLifecycleOwner) { topGenres ->
-            updateDominantGenres(topGenres)
+            applyTextColors(uiState.translatedAttractivePoints.joinToString(", ") + getString(R.string.my_library_attractive_point_fixed_text))
         }
     }
 

--- a/app/src/main/java/com/teamwss/websoso/ui/otherUserPage/otherUserLibrary/OtherUserLibraryViewModel.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/otherUserPage/otherUserLibrary/OtherUserLibraryViewModel.kt
@@ -4,11 +4,9 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.teamwss.websoso.data.model.GenrePreferenceEntity
-import com.teamwss.websoso.data.model.NovelPreferenceEntity
-import com.teamwss.websoso.data.model.UserNovelStatsEntity
 import com.teamwss.websoso.data.repository.UserRepository
 import com.teamwss.websoso.ui.main.myPage.myLibrary.model.AttractivePoints
+import com.teamwss.websoso.ui.otherUserPage.otherUserLibrary.model.OtherUserLibraryUiState
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -18,35 +16,18 @@ class OtherUserLibraryViewModel @Inject constructor(
     private val userRepository: UserRepository,
 ) : ViewModel() {
 
-    private val _genres = MutableLiveData<List<GenrePreferenceEntity>>()
-    val genres: LiveData<List<GenrePreferenceEntity>> get() = _genres
-
-    private val _dominantGenres = MutableLiveData<List<GenrePreferenceEntity>>()
-    val topGenres: LiveData<List<GenrePreferenceEntity>> get() = _dominantGenres
-
-    private val _restGenres = MutableLiveData<List<GenrePreferenceEntity>>()
-    val restGenres: LiveData<List<GenrePreferenceEntity>> get() = _restGenres
-
-    private val _isGenreListVisible = MutableLiveData<Boolean>(false)
-    val isGenreListVisible: LiveData<Boolean> get() = _isGenreListVisible
-
-    private val _novelPreferences = MutableLiveData<NovelPreferenceEntity>()
-    val novelPreferences: LiveData<NovelPreferenceEntity> get() = _novelPreferences
+    private val _uiState = MutableLiveData(OtherUserLibraryUiState())
+    val uiState: LiveData<OtherUserLibraryUiState> get() = _uiState
 
     private val _attractivePointsText = MutableLiveData<String>()
     val attractivePointsText: LiveData<String> get() = _attractivePointsText
 
-    private val _translatedAttractivePoints = MutableLiveData<List<String>>()
-    val translatedAttractivePoints: LiveData<List<String>> get() = _translatedAttractivePoints
-
-    private val _novelStats = MutableLiveData<UserNovelStatsEntity>()
-    val novelStats: LiveData<UserNovelStatsEntity> get() = _novelStats
-
-    private val _userId: MutableLiveData<Long> = MutableLiveData()
+    private val _userId = MutableLiveData<Long>()
     val userId: LiveData<Long> get() = _userId
 
     fun updateUserId(userId: Long) {
         _userId.value = userId
+        _uiState.value = _uiState.value?.copy(isLoading = true)
         updateNovelStats(userId)
         updateGenrePreference(userId)
         updateNovelPreferences(userId)
@@ -57,13 +38,21 @@ class OtherUserLibraryViewModel @Inject constructor(
             runCatching {
                 userRepository.fetchUserNovelStats(userId)
             }.onSuccess { novelStats ->
-                _novelStats.value = novelStats
-            }.onFailure { exception ->
+                _uiState.value = _uiState.value?.copy(
+                    novelStats = novelStats,
+                    isLoading = false,
+                )
+            }.onFailure {
+                _uiState.value = _uiState.value?.copy(
+                    isLoading = false,
+                    error = true,
+                )
             }
         }
     }
 
-    fun hasNoPreferences(stats: UserNovelStatsEntity): Boolean {
+    fun hasNoPreferences(): Boolean {
+        val stats = _uiState.value?.novelStats ?: return true
         return stats.interestNovelCount == 0 &&
                 stats.watchingNovelCount == 0 &&
                 stats.watchedNovelCount == 0 &&
@@ -76,16 +65,20 @@ class OtherUserLibraryViewModel @Inject constructor(
                 userRepository.fetchGenrePreference(userId)
             }.onSuccess { genres ->
                 val sortedGenres = genres.sortedByDescending { it.genreCount }
-
-                _dominantGenres.value = sortedGenres.take(3)
-                _restGenres.value = sortedGenres.drop(3)
-            }.onFailure { exception ->
+                _uiState.value = _uiState.value?.copy(
+                    topGenres = sortedGenres.take(3),
+                    restGenres = sortedGenres.drop(3),
+                )
+            }.onFailure {
+                _uiState.value = _uiState.value?.copy(error = true)
             }
         }
     }
 
     fun updateToggleGenresVisibility() {
-        _isGenreListVisible.value = _isGenreListVisible.value?.not() ?: false
+        _uiState.value = _uiState.value?.copy(
+            isGenreListVisible = !_uiState.value?.isGenreListVisible!!
+        )
     }
 
     private fun updateNovelPreferences(userId: Long) {
@@ -93,10 +86,12 @@ class OtherUserLibraryViewModel @Inject constructor(
             runCatching {
                 userRepository.fetchNovelPreferences(userId)
             }.onSuccess { novelPreferences ->
-                _novelPreferences.value = novelPreferences
-                _translatedAttractivePoints.value =
-                    translateAttractivePoints(novelPreferences.attractivePoints)
-            }.onFailure { exception ->
+                _uiState.value = _uiState.value?.copy(
+                    novelPreferences = novelPreferences,
+                    translatedAttractivePoints = translateAttractivePoints(novelPreferences.attractivePoints),
+                )
+            }.onFailure {
+                _uiState.value = _uiState.value?.copy(error = true)
             }
         }
     }

--- a/app/src/main/java/com/teamwss/websoso/ui/otherUserPage/otherUserLibrary/model/OtherUserLibraryUiState.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/otherUserPage/otherUserLibrary/model/OtherUserLibraryUiState.kt
@@ -1,0 +1,16 @@
+package com.teamwss.websoso.ui.otherUserPage.otherUserLibrary.model
+
+import com.teamwss.websoso.data.model.GenrePreferenceEntity
+import com.teamwss.websoso.data.model.NovelPreferenceEntity
+import com.teamwss.websoso.data.model.UserNovelStatsEntity
+
+data class OtherUserLibraryUiState(
+    val isLoading: Boolean = false,
+    val error: Boolean = false,
+    val novelStats: UserNovelStatsEntity? = null,
+    val topGenres: List<GenrePreferenceEntity> = emptyList(),
+    val restGenres: List<GenrePreferenceEntity> = emptyList(),
+    val novelPreferences: NovelPreferenceEntity? = null,
+    val translatedAttractivePoints: List<String> = emptyList(),
+    val isGenreListVisible: Boolean = false,
+)

--- a/app/src/main/java/com/teamwss/websoso/ui/userStorage/UserStorageActivity.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/userStorage/UserStorageActivity.kt
@@ -78,6 +78,16 @@ class UserStorageActivity : BaseActivity<ActivityStorageBinding>(R.layout.activi
 
     private fun setupObserver() {
         userStorageViewModel.uiState.observe(this) { uiState ->
+            when {
+                uiState.loading -> binding.wllStorage.setWebsosoLoadingVisibility(true)
+                uiState.error -> binding.wllStorage.setLoadingLayoutVisibility(false)
+                !uiState.loading -> {
+                    binding.wllStorage.setWebsosoLoadingVisibility(false)
+                }
+            }
+        }
+
+        userStorageViewModel.uiState.observe(this) { uiState ->
             updateStorageNovel(uiState)
             binding.clStorageNull.visibility =
                 if (uiState.userNovelCount == 0L) View.VISIBLE else View.GONE

--- a/app/src/main/java/com/teamwss/websoso/ui/userStorage/UserStorageViewModel.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/userStorage/UserStorageViewModel.kt
@@ -19,8 +19,7 @@ class UserStorageViewModel @Inject constructor(
     private val userRepository: UserRepository,
 ) : ViewModel() {
 
-    private val _uiState: MutableLiveData<UserStorageUiState> =
-        MutableLiveData(UserStorageUiState())
+    private val _uiState: MutableLiveData<UserStorageUiState> = MutableLiveData(UserStorageUiState())
     val uiState: LiveData<UserStorageUiState> get() = _uiState
 
     private val _isRatingChanged = MutableLiveData<Boolean>()
@@ -82,14 +81,14 @@ class UserStorageViewModel @Inject constructor(
                 userRepository.fetchUserStorage(
                     userId = userId,
                     readStatus = readStatus,
-                    lastUserNovelId = _uiState.value?.lastUserNovelId ?: 0L,
+                    lastUserNovelId = uiState.value?.lastUserNovelId ?: 0L,
                     size = STORAGE_NOVEL_SIZE,
                     sortType = sortType.titleEn,
                 )
             }.onSuccess { response ->
                 val isLoadable = response.isLoadable && response.userNovels.isNotEmpty()
 
-                _uiState.value = _uiState.value?.copy(
+                _uiState.value = uiState.value?.copy(
                     loading = false,
                     userNovelCount = response.userNovelCount,
                     userNovelRating = response.userNovelRating,
@@ -99,7 +98,7 @@ class UserStorageViewModel @Inject constructor(
                 )
 
             }.onFailure {
-                _uiState.value = _uiState.value?.copy(
+                _uiState.value = uiState.value?.copy(
                     loading = false,
                     error = true,
                 )

--- a/app/src/main/java/com/teamwss/websoso/ui/userStorage/UserStorageViewModel.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/userStorage/UserStorageViewModel.kt
@@ -35,13 +35,8 @@ class UserStorageViewModel @Inject constructor(
     ) {
         this.source = source
         this.userId = receivedUserId
-    }
 
-    init {
-        updateReadStatus(
-            StorageTab.INTEREST.readStatus,
-            forceLoad = true,
-        )
+        updateReadStatus(StorageTab.INTEREST.readStatus, forceLoad = true)
     }
 
     fun updateRatingChanged() {
@@ -85,7 +80,7 @@ class UserStorageViewModel @Inject constructor(
         viewModelScope.launch {
             runCatching {
                 userRepository.fetchUserStorage(
-                    userId = 2L,
+                    userId = userId,
                     readStatus = readStatus,
                     lastUserNovelId = _uiState.value?.lastUserNovelId ?: 0L,
                     size = STORAGE_NOVEL_SIZE,

--- a/app/src/main/res/layout/activity_activity_detail.xml
+++ b/app/src/main/res/layout/activity_activity_detail.xml
@@ -57,5 +57,12 @@
             app:layout_constraintTop_toBottomOf="@id/cl_activity_detail_toolbar"
             tools:listitem="@layout/item_my_activity" />
 
+        <com.teamwss.websoso.common.ui.custom.WebsosoLoadingLayout
+            android:id="@+id/wll_activity_detail"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:elevation="100dp"
+            android:visibility="invisible" />
+
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/app/src/main/res/layout/activity_other_user_page.xml
+++ b/app/src/main/res/layout/activity_other_user_page.xml
@@ -57,7 +57,7 @@
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:layout_marginTop="20dp"
-                            android:text='@{otherUserPageViewModel.otherUserProfile.nickname}'
+                            android:text='@{otherUserPageViewModel.uiState.otherUserProfile.nickname}'
                             android:textAppearance="@style/headline1"
                             android:textColor="@color/black"
                             app:layout_constraintEnd_toEndOf="parent"
@@ -71,7 +71,7 @@
                             android:layout_height="wrap_content"
                             android:layout_marginTop="4dp"
                             android:paddingBottom="30dp"
-                            android:text='@{otherUserPageViewModel.otherUserProfile.intro}'
+                            android:text='@{otherUserPageViewModel.uiState.otherUserProfile.intro}'
                             android:textAppearance="@style/body2"
                             android:textColor="@color/gray_200_AEADB3"
                             app:layout_constraintEnd_toEndOf="parent"
@@ -109,7 +109,7 @@
                                 android:layout_width="wrap_content"
                                 android:layout_height="wrap_content"
                                 android:paddingVertical="12dp"
-                                android:text='@{otherUserPageViewModel.otherUserProfile.nickname}'
+                                android:text='@{otherUserPageViewModel.uiState.otherUserProfile.nickname}'
                                 android:textAppearance="@style/title2"
                                 android:textColor="@color/black"
                                 android:visibility="gone"
@@ -206,7 +206,7 @@
                             android:layout_height="wrap_content"
                             android:layout_marginTop="20dp"
                             android:gravity="center"
-                            android:text='@{String.format(@string/other_user_page_no_public, otherUserPageViewModel.otherUserProfile.nickname)}'
+                            android:text='@{String.format(@string/other_user_page_no_public, otherUserPageViewModel.uiState.otherUserProfile.nickname)}'
                             android:textAppearance="@style/body2"
                             android:textColor="@color/gray_200_AEADB3"
                             app:layout_constraintTop_toBottomOf="@id/iv_other_user_page_no_public"
@@ -218,6 +218,13 @@
                 </androidx.constraintlayout.widget.ConstraintLayout>
 
             </androidx.core.widget.NestedScrollView>
+
+            <com.teamwss.websoso.common.ui.custom.WebsosoLoadingLayout
+                android:id="@+id/wll_other_user_page"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:elevation="100dp"
+                android:visibility="invisible" />
 
         </androidx.coordinatorlayout.widget.CoordinatorLayout>
 

--- a/app/src/main/res/layout/activity_storage.xml
+++ b/app/src/main/res/layout/activity_storage.xml
@@ -202,6 +202,13 @@
 
         </androidx.constraintlayout.widget.ConstraintLayout>
 
+        <com.teamwss.websoso.common.ui.custom.WebsosoLoadingLayout
+            android:id="@+id/wll_storage"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:elevation="100dp"
+            android:visibility="invisible" />
+
     </androidx.constraintlayout.widget.ConstraintLayout>
 
 </layout>

--- a/app/src/main/res/layout/fragment_my_activity.xml
+++ b/app/src/main/res/layout/fragment_my_activity.xml
@@ -69,5 +69,12 @@
                     android:textColor="@color/primary_100_6A5DFD" />
             </LinearLayout>
         </androidx.core.widget.NestedScrollView>
+
+        <com.teamwss.websoso.common.ui.custom.WebsosoLoadingLayout
+            android:id="@+id/wll_my_activity"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:elevation="100dp"
+            android:visibility="invisible" />
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/app/src/main/res/layout/fragment_my_library.xml
+++ b/app/src/main/res/layout/fragment_my_library.xml
@@ -70,7 +70,7 @@
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:layout_weight="1"
-                        android:text='@{String.valueOf(myLibraryViewModel.novelStats.interestNovelCount)}'
+                        android:text='@{String.valueOf(myLibraryViewModel.uiState.novelStats.interestNovelCount)}'
                         android:textAppearance="@style/title2"
                         android:textColor="@color/black"
                         tools:text="12"/>
@@ -105,7 +105,7 @@
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:layout_weight="1"
-                        android:text='@{String.valueOf(myLibraryViewModel.novelStats.watchingNovelCount)}'
+                        android:text='@{String.valueOf(myLibraryViewModel.uiState.novelStats.watchingNovelCount)}'
                         android:textAppearance="@style/title2"
                         android:textColor="@color/black"
                         tools:text="12"/>
@@ -135,7 +135,7 @@
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:layout_weight="1"
-                        android:text='@{String.valueOf(myLibraryViewModel.novelStats.watchedNovelCount)}'
+                        android:text='@{String.valueOf(myLibraryViewModel.uiState.novelStats.watchedNovelCount)}'
                         android:textAppearance="@style/title2"
                         android:textColor="@color/black"
                         tools:text="12"/>
@@ -165,7 +165,7 @@
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:layout_weight="1"
-                        android:text="@{String.valueOf(myLibraryViewModel.novelStats.quitNovelCount)}"
+                        android:text="@{String.valueOf(myLibraryViewModel.uiState.novelStats.quitNovelCount)}"
                         android:textAppearance="@style/title2"
                         android:textColor="@color/black"
                         tools:text="12"/>
@@ -289,7 +289,7 @@
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:layout_marginTop="12dp"
-                            android:text="@{myLibraryViewModel.topGenres[0].genreName}"
+                            android:text="@{myLibraryViewModel.uiState.topGenres[0].genreName}"
                             android:textAppearance="@style/title3"
                             android:textColor="@color/black"
                             tools:text="로판" />
@@ -299,7 +299,7 @@
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:layout_marginTop="2dp"
-                            android:text='@{String.format(@string/my_library_genre_count, myLibraryViewModel.topGenres[0].genreCount)}'
+                            android:text='@{String.format(@string/my_library_genre_count, myLibraryViewModel.uiState.topGenres[0].genreCount)}'
                             android:textAppearance="@style/body5"
                             android:textColor="@color/gray_200_AEADB3"
                             tools:text="12편" />
@@ -325,7 +325,7 @@
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:layout_marginTop="12dp"
-                            android:text="@{myLibraryViewModel.topGenres[1].genreName}"
+                            android:text="@{myLibraryViewModel.uiState.topGenres[1].genreName}"
                             android:textAppearance="@style/title3"
                             android:textColor="@color/black"
                             tools:text="로판" />
@@ -335,7 +335,7 @@
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:layout_marginTop="2dp"
-                            android:text='@{String.format(@string/my_library_genre_count, myLibraryViewModel.topGenres[1].genreCount)}'
+                            android:text='@{String.format(@string/my_library_genre_count, myLibraryViewModel.uiState.topGenres[1].genreCount)}'
                             android:textAppearance="@style/body5"
                             android:textColor="@color/gray_200_AEADB3"
                             tools:text="12편" />
@@ -361,7 +361,7 @@
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:layout_marginTop="12dp"
-                            android:text="@{myLibraryViewModel.topGenres[2].genreName}"
+                            android:text="@{myLibraryViewModel.uiState.topGenres[2].genreName}"
                             android:textAppearance="@style/title3"
                             android:textColor="@color/black"
                             tools:text="로판" />
@@ -371,7 +371,7 @@
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:layout_marginTop="2dp"
-                            android:text='@{String.format(@string/my_library_genre_count, myLibraryViewModel.topGenres[2].genreCount)}'
+                            android:text='@{String.format(@string/my_library_genre_count, myLibraryViewModel.uiState.topGenres[2].genreCount)}'
                             android:textAppearance="@style/body5"
                             android:textColor="@color/gray_200_AEADB3"
                             tools:text="12편" />
@@ -397,7 +397,7 @@
                     android:layout_marginTop="20dp"
                     android:onClick="@{() -> myLibraryViewModel.updateToggleGenresVisibility()}"
                     android:padding="8dp"
-                    android:src="@{myLibraryViewModel.isGenreListVisible ? @drawable/ic_my_library_upper_path : @drawable/ic_my_library_lower_path}"
+                    android:src="@{myLibraryViewModel.uiState.isGenreListVisible ? @drawable/ic_my_library_upper_path : @drawable/ic_my_library_lower_path}"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toBottomOf="@id/lv_my_library_rest_genre" />
@@ -453,11 +453,18 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="16dp"
-                    app:layout_constraintTop_toBottomOf="@id/cl_my_library_attractive_points"/>
+                    app:layout_constraintTop_toBottomOf="@id/cl_my_library_attractive_points" />
 
             </androidx.constraintlayout.widget.ConstraintLayout>
 
         </androidx.constraintlayout.widget.ConstraintLayout>
+
+        <com.teamwss.websoso.common.ui.custom.WebsosoLoadingLayout
+            android:id="@+id/wll_my_library"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:elevation="100dp"
+            android:visibility="invisible" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/app/src/main/res/layout/fragment_my_page.xml
+++ b/app/src/main/res/layout/fragment_my_page.xml
@@ -190,6 +190,13 @@
 
         </androidx.coordinatorlayout.widget.CoordinatorLayout>
 
+        <com.teamwss.websoso.common.ui.custom.WebsosoLoadingLayout
+            android:id="@+id/wll_my_page"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:elevation="100dp"
+            android:visibility="invisible" />
+
     </androidx.constraintlayout.widget.ConstraintLayout>
 
 </layout>

--- a/app/src/main/res/layout/fragment_my_page.xml
+++ b/app/src/main/res/layout/fragment_my_page.xml
@@ -71,7 +71,7 @@
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:layout_marginTop="20dp"
-                            android:text='@{myPageViewModel.myPageUiState.myProfile.nickname}'
+                            android:text='@{myPageViewModel.uiState.myProfile.nickname}'
                             android:textAppearance="@style/headline1"
                             android:textColor="@color/black"
                             app:layout_constraintEnd_toEndOf="parent"
@@ -87,7 +87,7 @@
                             android:layout_marginHorizontal="20dp"
                             android:paddingBottom="30dp"
                             android:gravity="center"
-                            android:text='@{myPageViewModel.myPageUiState.myProfile.intro}'
+                            android:text='@{myPageViewModel.uiState.myProfile.intro}'
                             android:textAppearance="@style/body2"
                             android:textColor="@color/gray_200_AEADB3"
                             app:layout_constraintEnd_toEndOf="parent"

--- a/app/src/main/res/layout/fragment_other_user_activity.xml
+++ b/app/src/main/res/layout/fragment_other_user_activity.xml
@@ -69,5 +69,12 @@
 
             </LinearLayout>
         </androidx.core.widget.NestedScrollView>
+
+        <com.teamwss.websoso.common.ui.custom.WebsosoLoadingLayout
+            android:id="@+id/wll_other_user_activity"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:elevation="100dp"
+            android:visibility="invisible" />
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/app/src/main/res/layout/fragment_other_user_library.xml
+++ b/app/src/main/res/layout/fragment_other_user_library.xml
@@ -70,7 +70,7 @@
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:layout_weight="1"
-                        android:text='@{String.valueOf(otherUserLibraryViewModel.novelStats.interestNovelCount)}'
+                        android:text='@{String.valueOf(otherUserLibraryViewModel.uiState.novelStats.interestNovelCount)}'
                         android:textAppearance="@style/title2"
                         android:textColor="@color/black"
                         tools:text="12" />
@@ -105,7 +105,7 @@
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:layout_weight="1"
-                        android:text='@{String.valueOf(otherUserLibraryViewModel.novelStats.watchingNovelCount)}'
+                        android:text='@{String.valueOf(otherUserLibraryViewModel.uiState.novelStats.watchingNovelCount)}'
                         android:textAppearance="@style/title2"
                         android:textColor="@color/black"
                         tools:text="12" />
@@ -135,7 +135,7 @@
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:layout_weight="1"
-                        android:text='@{String.valueOf(otherUserLibraryViewModel.novelStats.watchedNovelCount)}'
+                        android:text='@{String.valueOf(otherUserLibraryViewModel.uiState.novelStats.watchedNovelCount)}'
                         android:textAppearance="@style/title2"
                         android:textColor="@color/black"
                         tools:text="12" />
@@ -165,7 +165,7 @@
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:layout_weight="1"
-                        android:text="@{String.valueOf(otherUserLibraryViewModel.novelStats.quitNovelCount)}"
+                        android:text="@{String.valueOf(otherUserLibraryViewModel.uiState.novelStats.quitNovelCount)}"
                         android:textAppearance="@style/title2"
                         android:textColor="@color/black"
                         tools:text="12" />
@@ -289,7 +289,7 @@
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:layout_marginTop="12dp"
-                            android:text="@{otherUserLibraryViewModel.topGenres[0].genreName}"
+                            android:text="@{otherUserLibraryViewModel.uiState.topGenres[0].genreName}"
                             android:textAppearance="@style/title3"
                             android:textColor="@color/black"
                             tools:text="로판" />
@@ -299,7 +299,7 @@
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:layout_marginTop="2dp"
-                            android:text='@{String.format(@string/other_user_library_genre_count, otherUserLibraryViewModel.topGenres[0].genreCount)}'
+                            android:text='@{String.format(@string/other_user_library_genre_count, otherUserLibraryViewModel.uiState.topGenres[0].genreCount)}'
                             android:textAppearance="@style/body5"
                             android:textColor="@color/gray_200_AEADB3"
                             tools:text="12편" />
@@ -325,7 +325,7 @@
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:layout_marginTop="12dp"
-                            android:text="@{otherUserLibraryViewModel.topGenres[1].genreName}"
+                            android:text="@{otherUserLibraryViewModel.uiState.topGenres[1].genreName}"
                             android:textAppearance="@style/title3"
                             android:textColor="@color/black"
                             tools:text="로판" />
@@ -335,7 +335,7 @@
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:layout_marginTop="2dp"
-                            android:text='@{String.format(@string/other_user_library_genre_count, otherUserLibraryViewModel.topGenres[1].genreCount)}'
+                            android:text='@{String.format(@string/other_user_library_genre_count, otherUserLibraryViewModel.uiState.topGenres[1].genreCount)}'
                             android:textAppearance="@style/body5"
                             android:textColor="@color/gray_200_AEADB3"
                             tools:text="12편" />
@@ -361,7 +361,7 @@
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:layout_marginTop="12dp"
-                            android:text="@{otherUserLibraryViewModel.topGenres[2].genreName}"
+                            android:text="@{otherUserLibraryViewModel.uiState.topGenres[2].genreName}"
                             android:textAppearance="@style/title3"
                             android:textColor="@color/black"
                             tools:text="로판" />
@@ -371,7 +371,7 @@
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:layout_marginTop="2dp"
-                            android:text='@{String.format(@string/other_user_library_genre_count, otherUserLibraryViewModel.topGenres[2].genreCount)}'
+                            android:text='@{String.format(@string/other_user_library_genre_count, otherUserLibraryViewModel.uiState.topGenres[2].genreCount)}'
                             android:textAppearance="@style/body5"
                             android:textColor="@color/gray_200_AEADB3"
                             tools:text="12편" />
@@ -397,7 +397,7 @@
                     android:layout_marginTop="20dp"
                     android:onClick="@{() -> otherUserLibraryViewModel.updateToggleGenresVisibility()}"
                     android:padding="8dp"
-                    android:src="@{otherUserLibraryViewModel.isGenreListVisible ? @drawable/ic_my_library_upper_path : @drawable/ic_my_library_lower_path}"
+                    android:src="@{otherUserLibraryViewModel.uiState.isGenreListVisible ? @drawable/ic_my_library_upper_path : @drawable/ic_my_library_lower_path}"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toBottomOf="@id/lv_other_user_library_rest_genre" />
@@ -458,6 +458,13 @@
             </androidx.constraintlayout.widget.ConstraintLayout>
 
         </androidx.constraintlayout.widget.ConstraintLayout>
+
+        <com.teamwss.websoso.common.ui.custom.WebsosoLoadingLayout
+            android:id="@+id/wll_other_user_library"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:elevation="100dp"
+            android:visibility="invisible" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 


### PR DESCRIPTION
## 📌𝘐𝘴𝘴𝘶𝘦𝘴
- closed #377

## 📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯
- 마이페이지, 내 서재, 내 활동 에러대응 및 로딩화면
- 다른유저페이지, 다른유저 서재, 다른유저 활동 에러대응 및 로딩화면
- 활동디테일 에러대응 및 로딩화면
- 보관함 에러대응 및 로딩화면

## 📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵

https://github.com/user-attachments/assets/597a8cf5-81c2-45e6-83d3-159f756fbb4c



## 💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴
활동 새로고침은 무한스크롤 구현현하면서 같이할게욤