### PR TITLE
feat: 탈퇴한 회원 프로필 진입 차단 구현

### DIFF
--- a/app/src/main/java/com/teamwss/websoso/common/ui/model/ResultFrom.kt
+++ b/app/src/main/java/com/teamwss/websoso/common/ui/model/ResultFrom.kt
@@ -14,6 +14,7 @@ enum class ResultFrom {
     ProfileEditSuccess,
     OtherUserProfileBack,
     NovelRating,
+    WithdrawUser,
     ;
 
     val RESULT_OK: Int = ordinal + 1

--- a/app/src/main/java/com/teamwss/websoso/ui/feedDetail/FeedDetailActivity.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/feedDetail/FeedDetailActivity.kt
@@ -20,22 +20,17 @@ import androidx.databinding.ViewDataBinding
 import androidx.lifecycle.lifecycleScope
 import coil.load
 import coil.transform.RoundedCornersTransformation
+import com.teamwss.websoso.R
 import com.teamwss.websoso.R.id.tv_feed_thumb_up_count
 import com.teamwss.websoso.R.layout.activity_feed_detail
 import com.teamwss.websoso.R.string.feed_popup_menu_content_isMyFeed
 import com.teamwss.websoso.R.string.feed_popup_menu_content_report_isNotMyFeed
 import com.teamwss.websoso.common.ui.base.BaseActivity
-import com.teamwss.websoso.common.ui.model.ResultFrom.BlockUser
-import com.teamwss.websoso.common.ui.model.ResultFrom.CreateFeed
-import com.teamwss.websoso.common.ui.model.ResultFrom.Feed
-import com.teamwss.websoso.common.ui.model.ResultFrom.FeedDetailBack
-import com.teamwss.websoso.common.ui.model.ResultFrom.FeedDetailRefreshed
-import com.teamwss.websoso.common.ui.model.ResultFrom.FeedDetailRemoved
-import com.teamwss.websoso.common.ui.model.ResultFrom.NovelDetailBack
-import com.teamwss.websoso.common.ui.model.ResultFrom.OtherUserProfileBack
+import com.teamwss.websoso.common.ui.model.ResultFrom.*
 import com.teamwss.websoso.common.util.SingleEventHandler
 import com.teamwss.websoso.common.util.getS3ImageUrl
 import com.teamwss.websoso.common.util.hideKeyboard
+import com.teamwss.websoso.common.util.showWebsosoSnackBar
 import com.teamwss.websoso.common.util.toFloatPxFromDp
 import com.teamwss.websoso.common.util.toIntPxFromDp
 import com.teamwss.websoso.databinding.ActivityFeedDetailBinding
@@ -323,6 +318,14 @@ class FeedDetailActivity : BaseActivity<ActivityFeedDetailBinding>(activity_feed
                         }
                         setResult(BlockUser.RESULT_OK, intent)
                         if (!isFinishing) finish()
+                    }
+
+                    WithdrawUser.RESULT_OK -> {
+                        showWebsosoSnackBar(
+                            view = binding.root,
+                            message = getString(R.string.other_user_page_withdraw_user),
+                            icon = R.drawable.ic_blocked_user_snack_bar,
+                        )
                     }
                 }
             }

--- a/app/src/main/java/com/teamwss/websoso/ui/main/feed/FeedFragment.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/main/feed/FeedFragment.kt
@@ -29,12 +29,7 @@ import com.teamwss.websoso.R.string.feed_removed_feed_snackbar
 import com.teamwss.websoso.R.style
 import com.teamwss.websoso.common.ui.base.BaseFragment
 import com.teamwss.websoso.common.ui.custom.WebsosoChip
-import com.teamwss.websoso.common.ui.model.ResultFrom.BlockUser
-import com.teamwss.websoso.common.ui.model.ResultFrom.CreateFeed
-import com.teamwss.websoso.common.ui.model.ResultFrom.FeedDetailBack
-import com.teamwss.websoso.common.ui.model.ResultFrom.FeedDetailRemoved
-import com.teamwss.websoso.common.ui.model.ResultFrom.NovelDetailBack
-import com.teamwss.websoso.common.ui.model.ResultFrom.OtherUserProfileBack
+import com.teamwss.websoso.common.ui.model.ResultFrom.*
 import com.teamwss.websoso.common.util.InfiniteScrollListener
 import com.teamwss.websoso.common.util.SingleEventHandler
 import com.teamwss.websoso.common.util.showWebsosoSnackBar
@@ -283,6 +278,14 @@ class FeedFragment : BaseFragment<FragmentFeedBinding>(fragment_feed) {
                             view = binding.root,
                             message = getString(block_user_success_message, nickname),
                             icon = ic_novel_detail_check,
+                        )
+                    }
+
+                    WithdrawUser.RESULT_OK -> {
+                        showWebsosoSnackBar(
+                            view = binding.root,
+                            message = getString(R.string.other_user_page_withdraw_user),
+                            icon = ic_blocked_user_snack_bar,
                         )
                     }
                 }

--- a/app/src/main/java/com/teamwss/websoso/ui/novelFeed/NovelFeedFragment.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/novelFeed/NovelFeedFragment.kt
@@ -15,12 +15,17 @@ import androidx.databinding.ViewDataBinding
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
 import com.teamwss.websoso.R
-import com.teamwss.websoso.R.*
-import com.teamwss.websoso.R.drawable.*
-import com.teamwss.websoso.R.string.*
+import com.teamwss.websoso.R.drawable.ic_blocked_user_snack_bar
+import com.teamwss.websoso.R.drawable.ic_novel_detail_check
+import com.teamwss.websoso.R.layout
+import com.teamwss.websoso.R.string.block_user_success_message
+import com.teamwss.websoso.R.string.feed_popup_menu_content_isMyFeed
+import com.teamwss.websoso.R.string.feed_popup_menu_content_report_isNotMyFeed
+import com.teamwss.websoso.R.string.other_user_page_withdraw_user
 import com.teamwss.websoso.common.ui.base.BaseFragment
-import com.teamwss.websoso.common.ui.model.ResultFrom
 import com.teamwss.websoso.common.ui.model.ResultFrom.BlockUser
+import com.teamwss.websoso.common.ui.model.ResultFrom.OtherUserProfileBack
+import com.teamwss.websoso.common.ui.model.ResultFrom.WithdrawUser
 import com.teamwss.websoso.common.util.InfiniteScrollListener
 import com.teamwss.websoso.common.util.SingleEventHandler
 import com.teamwss.websoso.common.util.showWebsosoSnackBar
@@ -247,7 +252,7 @@ class NovelFeedFragment : BaseFragment<FragmentNovelFeedBinding>(layout.fragment
         activityResultCallback =
             registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
                 when (result.resultCode) {
-                    ResultFrom.OtherUserProfileBack.RESULT_OK -> novelFeedViewModel.updateRefreshedFeeds(
+                    OtherUserProfileBack.RESULT_OK -> novelFeedViewModel.updateRefreshedFeeds(
                         novelId
                     )
 
@@ -265,6 +270,14 @@ class NovelFeedFragment : BaseFragment<FragmentNovelFeedBinding>(layout.fragment
                         )
 
                         novelFeedViewModel.updateRefreshedFeeds(novelId)
+                    }
+
+                    WithdrawUser.RESULT_OK -> {
+                        showWebsosoSnackBar(
+                            view = binding.root,
+                            message = getString(other_user_page_withdraw_user),
+                            icon = ic_blocked_user_snack_bar,
+                        )
                     }
                 }
             }

--- a/app/src/main/java/com/teamwss/websoso/ui/otherUserPage/OtherUserPageActivity.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/otherUserPage/OtherUserPageActivity.kt
@@ -15,7 +15,8 @@ import coil.transform.CircleCropTransformation
 import com.google.android.material.tabs.TabLayoutMediator
 import com.teamwss.websoso.R
 import com.teamwss.websoso.common.ui.base.BaseActivity
-import com.teamwss.websoso.common.ui.model.ResultFrom.OtherUserProfileBack
+import com.teamwss.websoso.common.ui.model.ResultFrom
+import com.teamwss.websoso.common.ui.model.ResultFrom.*
 import com.teamwss.websoso.common.util.SingleEventHandler
 import com.teamwss.websoso.common.util.getS3ImageUrl
 import com.teamwss.websoso.common.util.toFloatPxFromDp
@@ -83,6 +84,13 @@ class OtherUserPageActivity :
             } else {
                 binding.vpOtherUserPage.visibility = View.GONE
                 binding.clOtherUserPageNoPublic.visibility = View.VISIBLE
+            }
+        }
+
+        otherUserPageViewModel.isWithdrawUser.observe(this) { isWithdrawUser ->
+            if (isWithdrawUser) {
+                setResult(WithdrawUser.RESULT_OK, intent)
+                finish()
             }
         }
     }

--- a/app/src/main/java/com/teamwss/websoso/ui/otherUserPage/OtherUserPageViewModel.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/otherUserPage/OtherUserPageViewModel.kt
@@ -24,6 +24,9 @@ class OtherUserPageViewModel @Inject constructor(
     private val _isBlockedCompleted: MutableLiveData<Boolean> = MutableLiveData()
     val isBlockedCompleted: LiveData<Boolean> get() = _isBlockedCompleted
 
+    private val _isWithdrawUser: MutableLiveData<Boolean> = MutableLiveData(false)
+    val isWithdrawUser: LiveData<Boolean> get() = _isWithdrawUser
+
     fun updateUserId(userId: Long) {
         _userId.value = userId
 
@@ -37,6 +40,9 @@ class OtherUserPageViewModel @Inject constructor(
             }.onSuccess { otherUserProfile ->
                 _otherUserProfile.value = otherUserProfile
             }.onFailure { exception ->
+                if (exception.message?.contains(WITHDRAW_USER_CODE) == true) {
+                    _isWithdrawUser.value = true
+                }
             }
         }
     }
@@ -49,5 +55,9 @@ class OtherUserPageViewModel @Inject constructor(
                 _isBlockedCompleted.value = true
             }.onFailure {}
         }
+    }
+
+    companion object {
+        private const val WITHDRAW_USER_CODE = "403"
     }
 }

--- a/app/src/main/java/com/teamwss/websoso/ui/withdraw/second/WithdrawSecondViewModel.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/withdraw/second/WithdrawSecondViewModel.kt
@@ -77,6 +77,7 @@ class WithdrawSecondViewModel @Inject constructor(
                 authRepository.withdraw(withdrawReason)
             }.onSuccess {
                 _isWithDrawSuccess.value = true
+                authRepository.updateIsAutoLogin(false)
             }.onFailure {
                 _isWithDrawSuccess.value = false
             }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -345,6 +345,7 @@
     <string name="other_user_page_activity">활동</string>
     <string name="other_user_page_popup_blocked_user_kebab_button">차단하기</string>
     <string name="other_user_page_no_public">%1$s님의 프로필은\n비공개 상태에요</string>
+    <string name="other_user_page_withdraw_user">웹소소를 떠난 유저예요</string>
     <string name="block_user_title">해당 유저를 차단할까요?</string>
     <string name="block_user_description">상대의 게시글, 댓글,\n프로필을 볼 수 없어요</string>
     <string name="block_user_button">차단</string>


### PR DESCRIPTION
## 📌𝘐𝘴𝘴𝘶𝘦𝘴
- closed #424

## 📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯
- 탈퇴한 회원 프로필 진입 시 `403` 에러 판단 후 차단하는 로직 구현했습니다.
- `OtherUserPageActivity` 가 열린 후 api 호출로 판단하는 거라 잠깐 새로운 스택 뷰가 쌓입니다.
- 탈퇴한 회원일 경우 스낵바 메시지를 출력합니다.

## 📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵

https://github.com/user-attachments/assets/7e82ce9d-bc05-46d1-9a23-6edea9797251

## 💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴
<img width="1185" alt="스크린샷 2024-11-14 오후 7 28 59" src="https://github.com/user-attachments/assets/9f62c3b3-2478-471d-9441-91e0db9bd12d">

runCatching 에서 exception.message 찍어보니까 `HTTP 403` 이렇게 떠서 403이 포함됐을 경우로 판단했습니다.
추후에 에러 응답값 관련해서 회의하고 바뀌면 그 때 수정하겠습니다. 구현해보니까 403 에러를 뷰에서 판단한다는 게 좀 이상한 것 같기도 하고 .. .. 데이터 레이어에서 상태 코드 확인해서 어떤 에러인지 판단하고, 뷰에서는 그 에러만 받아와서 사용하도록 하는 로직은 어떨지? 다른 분들 의견이 궁금합니다.
