### PR TITLE
refactor: 4차 QA 반영

### DIFF
--- a/app/src/main/java/com/teamwss/websoso/ui/main/myPage/myLibrary/MyLibraryFragment.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/main/myPage/myLibrary/MyLibraryFragment.kt
@@ -76,25 +76,23 @@ class MyLibraryFragment : BaseFragment<FragmentMyLibraryBinding>(R.layout.fragme
                 }
             }
 
-            when (myLibraryViewModel.hasNoNovelPreferences()) {
+            when (myLibraryViewModel.hasNovelPreferences()) {
                 true -> {
-                    binding.clMyLibraryNovelPreference.visibility = View.GONE
-                    binding.clMyLibraryUnknownNovelPreference.visibility = View.VISIBLE
-                }
-
-                false -> {
                     binding.clMyLibraryNovelPreference.visibility = View.VISIBLE
                     binding.clMyLibraryUnknownNovelPreference.visibility = View.GONE
                 }
+                false -> {
+                    binding.clMyLibraryNovelPreference.visibility = View.GONE
+                    binding.clMyLibraryUnknownNovelPreference.visibility = View.VISIBLE
+                }
             }
 
-            when (myLibraryViewModel.hasNoAttractivePoints()) {
+            when (myLibraryViewModel.hasAttractivePoints()) {
                 true -> {
-                    binding.clMyLibraryAttractivePoints.visibility = View.GONE
-                }
-
-                false -> {
                     binding.clMyLibraryAttractivePoints.visibility = View.VISIBLE
+                }
+                false -> {
+                    binding.clMyLibraryAttractivePoints.visibility = View.GONE
                 }
             }
 

--- a/app/src/main/java/com/teamwss/websoso/ui/main/myPage/myLibrary/MyLibraryFragment.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/main/myPage/myLibrary/MyLibraryFragment.kt
@@ -76,6 +76,28 @@ class MyLibraryFragment : BaseFragment<FragmentMyLibraryBinding>(R.layout.fragme
                 }
             }
 
+            when (myLibraryViewModel.hasNoNovelPreferences()) {
+                true -> {
+                    binding.clMyLibraryNovelPreference.visibility = View.GONE
+                    binding.clMyLibraryUnknownNovelPreference.visibility = View.VISIBLE
+                }
+
+                false -> {
+                    binding.clMyLibraryNovelPreference.visibility = View.VISIBLE
+                    binding.clMyLibraryUnknownNovelPreference.visibility = View.GONE
+                }
+            }
+
+            when (myLibraryViewModel.hasNoAttractivePoints()) {
+                true -> {
+                    binding.clMyLibraryAttractivePoints.visibility = View.GONE
+                }
+
+                false -> {
+                    binding.clMyLibraryAttractivePoints.visibility = View.VISIBLE
+                }
+            }
+
             restGenrePreferenceAdapter.updateRestGenrePreferenceData(uiState.restGenres)
             updateRestGenrePreferenceVisibility(uiState.isGenreListVisible)
 

--- a/app/src/main/java/com/teamwss/websoso/ui/main/myPage/myLibrary/MyLibraryViewModel.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/main/myPage/myLibrary/MyLibraryViewModel.kt
@@ -100,16 +100,14 @@ class MyLibraryViewModel @Inject constructor(
         }
     }
 
-    fun hasNoNovelPreferences(): Boolean {
+    fun hasNovelPreferences(): Boolean {
         return uiState.value?.novelPreferences?.run {
-            attractivePoints.isEmpty() && keywords.isEmpty()
-        } ?: true
+            attractivePoints.isNotEmpty() || keywords.isNotEmpty()
+        } ?: false
     }
 
-    fun hasNoAttractivePoints(): Boolean {
-        return uiState.value?.novelPreferences?.run {
-            attractivePoints.isEmpty()
-        } ?: true
+    fun hasAttractivePoints(): Boolean {
+        return uiState.value?.novelPreferences?.attractivePoints?.isNotEmpty() ?: false
     }
 
     private fun translateAttractivePoints(attractivePoints: List<String>): List<String> {

--- a/app/src/main/java/com/teamwss/websoso/ui/main/myPage/myLibrary/MyLibraryViewModel.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/main/myPage/myLibrary/MyLibraryViewModel.kt
@@ -100,6 +100,18 @@ class MyLibraryViewModel @Inject constructor(
         }
     }
 
+    fun hasNoNovelPreferences(): Boolean {
+        return uiState.value?.novelPreferences?.run {
+            attractivePoints.isEmpty() && keywords.isEmpty()
+        } ?: true
+    }
+
+    fun hasNoAttractivePoints(): Boolean {
+        return uiState.value?.novelPreferences?.run {
+            attractivePoints.isEmpty()
+        } ?: true
+    }
+
     private fun translateAttractivePoints(attractivePoints: List<String>): List<String> {
         return attractivePoints.mapNotNull { point ->
             AttractivePoints.fromString(point)?.korean

--- a/app/src/main/java/com/teamwss/websoso/ui/otherUserPage/otherUserActivity/OtherUserActivityFragment.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/otherUserPage/otherUserActivity/OtherUserActivityFragment.kt
@@ -230,6 +230,12 @@ class OtherUserActivityFragment :
         doneDialogFragment.show(parentFragmentManager, FeedReportDoneDialogFragment.TAG)
     }
 
+    override fun onResume() {
+        super.onResume()
+
+        view?.requestLayout()
+    }
+
     companion object {
         const val EXTRA_SOURCE = "source"
         const val SOURCE_OTHER_USER_ACTIVITY = "otherUserActivity"

--- a/app/src/main/java/com/teamwss/websoso/ui/otherUserPage/otherUserLibrary/OtherUserLibraryFragment.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/otherUserPage/otherUserLibrary/OtherUserLibraryFragment.kt
@@ -78,6 +78,28 @@ class OtherUserLibraryFragment :
                 }
             }
 
+            when (otherUserLibraryViewModel.hasNoNovelPreferences()) {
+                true -> {
+                    binding.clOtherUserLibraryNovelPreference.visibility = View.GONE
+                    binding.clOtherUserLibraryUnknownNovelPreference.visibility = View.VISIBLE
+                }
+
+                false -> {
+                    binding.clOtherUserLibraryNovelPreference.visibility = View.VISIBLE
+                    binding.clOtherUserLibraryUnknownNovelPreference.visibility = View.GONE
+                }
+            }
+
+            when (otherUserLibraryViewModel.hasNoAttractivePoints()) {
+                true -> {
+                    binding.clOtherUserLibraryAttractivePoints.visibility = View.GONE
+                }
+
+                false -> {
+                    binding.clOtherUserLibraryAttractivePoints.visibility = View.VISIBLE
+                }
+            }
+
             restGenrePreferenceAdapter.updateRestGenrePreferenceData(uiState.restGenres)
             updateRestGenrePreferenceVisibility(uiState.isGenreListVisible)
 

--- a/app/src/main/java/com/teamwss/websoso/ui/otherUserPage/otherUserLibrary/OtherUserLibraryFragment.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/otherUserPage/otherUserLibrary/OtherUserLibraryFragment.kt
@@ -78,25 +78,25 @@ class OtherUserLibraryFragment :
                 }
             }
 
-            when (otherUserLibraryViewModel.hasNoNovelPreferences()) {
+            when (otherUserLibraryViewModel.hasNovelPreferences()) {
                 true -> {
-                    binding.clOtherUserLibraryNovelPreference.visibility = View.GONE
-                    binding.clOtherUserLibraryUnknownNovelPreference.visibility = View.VISIBLE
-                }
-
-                false -> {
                     binding.clOtherUserLibraryNovelPreference.visibility = View.VISIBLE
                     binding.clOtherUserLibraryUnknownNovelPreference.visibility = View.GONE
                 }
+
+                false -> {
+                    binding.clOtherUserLibraryNovelPreference.visibility = View.GONE
+                    binding.clOtherUserLibraryUnknownNovelPreference.visibility = View.VISIBLE
+                }
             }
 
-            when (otherUserLibraryViewModel.hasNoAttractivePoints()) {
+            when (otherUserLibraryViewModel.hasAttractivePoints()) {
                 true -> {
-                    binding.clOtherUserLibraryAttractivePoints.visibility = View.GONE
+                    binding.clOtherUserLibraryAttractivePoints.visibility = View.VISIBLE
                 }
 
                 false -> {
-                    binding.clOtherUserLibraryAttractivePoints.visibility = View.VISIBLE
+                    binding.clOtherUserLibraryAttractivePoints.visibility = View.GONE
                 }
             }
 

--- a/app/src/main/java/com/teamwss/websoso/ui/otherUserPage/otherUserLibrary/OtherUserLibraryFragment.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/otherUserPage/otherUserLibrary/OtherUserLibraryFragment.kt
@@ -186,6 +186,12 @@ class OtherUserLibraryFragment :
         }
     }
 
+    override fun onResume() {
+        super.onResume()
+
+        view?.requestLayout()
+    }
+
     companion object {
         private const val USER_ID_KEY = "USER_ID"
 

--- a/app/src/main/java/com/teamwss/websoso/ui/otherUserPage/otherUserLibrary/OtherUserLibraryViewModel.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/otherUserPage/otherUserLibrary/OtherUserLibraryViewModel.kt
@@ -109,6 +109,18 @@ class OtherUserLibraryViewModel @Inject constructor(
         }
     }
 
+    fun hasNoNovelPreferences(): Boolean {
+        return uiState.value?.novelPreferences?.run {
+            attractivePoints.isEmpty() && keywords.isEmpty()
+        } ?: true
+    }
+
+    fun hasNoAttractivePoints(): Boolean {
+        return uiState.value?.novelPreferences?.run {
+            attractivePoints.isEmpty()
+        } ?: true
+    }
+
     private fun translateAttractivePoints(attractivePoints: List<String>): List<String> {
         return attractivePoints.mapNotNull { point ->
             AttractivePoints.fromString(point)?.korean

--- a/app/src/main/java/com/teamwss/websoso/ui/otherUserPage/otherUserLibrary/OtherUserLibraryViewModel.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/otherUserPage/otherUserLibrary/OtherUserLibraryViewModel.kt
@@ -109,16 +109,14 @@ class OtherUserLibraryViewModel @Inject constructor(
         }
     }
 
-    fun hasNoNovelPreferences(): Boolean {
+    fun hasNovelPreferences(): Boolean {
         return uiState.value?.novelPreferences?.run {
-            attractivePoints.isEmpty() && keywords.isEmpty()
-        } ?: true
+            attractivePoints.isNotEmpty() || keywords.isNotEmpty()
+        } ?: false
     }
 
-    fun hasNoAttractivePoints(): Boolean {
-        return uiState.value?.novelPreferences?.run {
-            attractivePoints.isEmpty()
-        } ?: true
+    fun hasAttractivePoints(): Boolean {
+        return uiState.value?.novelPreferences?.attractivePoints?.isNotEmpty() ?: false
     }
 
     private fun translateAttractivePoints(attractivePoints: List<String>): List<String> {

--- a/app/src/main/res/layout/activity_other_user_page.xml
+++ b/app/src/main/res/layout/activity_other_user_page.xml
@@ -67,10 +67,12 @@
 
                         <TextView
                             android:id="@+id/tv_other_user_page_user_description"
-                            android:layout_width="wrap_content"
+                            android:layout_width="0dp"
                             android:layout_height="wrap_content"
                             android:layout_marginTop="4dp"
+                            android:layout_marginHorizontal="20dp"
                             android:paddingBottom="30dp"
+                            android:gravity="center"
                             android:text='@{otherUserPageViewModel.uiState.otherUserProfile.intro}'
                             android:textAppearance="@style/body2"
                             android:textColor="@color/gray_200_AEADB3"

--- a/app/src/main/res/layout/fragment_my_library.xml
+++ b/app/src/main/res/layout/fragment_my_library.xml
@@ -457,6 +457,50 @@
 
             </androidx.constraintlayout.widget.ConstraintLayout>
 
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:id="@+id/cl_my_library_unknown_novel_preference"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:visibility="gone"
+                app:layout_constraintTop_toBottomOf="@id/cl_my_library_genre_preference">
+
+                <TextView
+                    android:id="@+id/tv_my_library_unknown_novel_preference_title"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/my_library_novel_preference"
+                    android:textAppearance="@style/title1"
+                    android:textColor="@color/black"
+                    android:layout_marginTop="24dp"
+                    android:layout_marginStart="20dp"
+                    app:layout_constraintTop_toTopOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"/>
+
+                <ImageView
+                    android:id="@+id/iv_my_library_unknown_novel_preference_logo"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:src="@drawable/img_my_library_empty_cat"
+                    android:layout_marginTop="36dp"
+                    app:layout_constraintTop_toBottomOf="@id/tv_my_library_unknown_novel_preference_title"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"/>
+
+                <TextView
+                    android:id="@+id/tv_my_library_unknown_novel_novel_preference_instructions"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/my_library_unknown_preference"
+                    android:textAppearance="@style/body2"
+                    android:textColor="@color/gray_200_AEADB3"
+                    android:layout_marginTop="20dp"
+                    android:paddingBottom="10dp"
+                    app:layout_constraintTop_toBottomOf="@id/iv_my_library_unknown_novel_preference_logo"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"/>
+
+            </androidx.constraintlayout.widget.ConstraintLayout>
+
         </androidx.constraintlayout.widget.ConstraintLayout>
 
         <com.teamwss.websoso.common.ui.custom.WebsosoLoadingLayout
@@ -464,7 +508,7 @@
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:elevation="100dp"
-            android:visibility="invisible" />
+            android:visibility="gone" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/app/src/main/res/layout/fragment_other_user_library.xml
+++ b/app/src/main/res/layout/fragment_other_user_library.xml
@@ -457,6 +457,50 @@
 
             </androidx.constraintlayout.widget.ConstraintLayout>
 
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:id="@+id/cl_other_user_library_unknown_novel_preference"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:visibility="gone"
+                app:layout_constraintTop_toBottomOf="@id/cl_other_user_library_genre_preference">
+
+                <TextView
+                    android:id="@+id/tv_other_user_library_unknown_novel_preference_title"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/my_library_novel_preference"
+                    android:textAppearance="@style/title1"
+                    android:textColor="@color/black"
+                    android:layout_marginTop="24dp"
+                    android:layout_marginStart="20dp"
+                    app:layout_constraintTop_toTopOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"/>
+
+                <ImageView
+                    android:id="@+id/iv_other_user_library_unknown_novel_preference_logo"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:src="@drawable/img_my_library_empty_cat"
+                    android:layout_marginTop="36dp"
+                    app:layout_constraintTop_toBottomOf="@id/tv_other_user_library_unknown_novel_preference_title"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"/>
+
+                <TextView
+                    android:id="@+id/tv_other_user_library_unknown_novel_novel_preference_instructions"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/my_library_unknown_preference"
+                    android:textAppearance="@style/body2"
+                    android:textColor="@color/gray_200_AEADB3"
+                    android:layout_marginTop="20dp"
+                    android:paddingBottom="10dp"
+                    app:layout_constraintTop_toBottomOf="@id/iv_other_user_library_unknown_novel_preference_logo"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"/>
+
+            </androidx.constraintlayout.widget.ConstraintLayout>
+
         </androidx.constraintlayout.widget.ConstraintLayout>
 
         <com.teamwss.websoso.common.ui.custom.WebsosoLoadingLayout


### PR DESCRIPTION
## 📌𝘐𝘴𝘴𝘶𝘦𝘴
- closed #457 

## 📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯
- 다른유저페이지 소개 가운데 정렬
- 다른유저페이지 requestLayout 적용
- 작품취향에서 매력포인트 키워드 둘 다 없는 경우 visible 처리
- 작품취향에서 매력포인트가 없는 경우 visible 처리

## 📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵
<img src="https://github.com/user-attachments/assets/505e4aef-e928-403f-815b-a228ff4e90f5" width="300" />
[작품취향에서 매력포인트랑 키워드 둘 다 없는 경우]

<img src="https://github.com/user-attachments/assets/2d5d7e37-78a9-497e-a483-e20a49505910" width="300" />
[작품취향에서 매력포인트만 있는 경우]

<img src="https://github.com/user-attachments/assets/a18b9292-c12c-4ccd-b783-cf6fa2fd3516" width="300" />
[작품취향에서 키워드만 있는 경우]

## 💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴
작품취향 visibel 처리는 다른유저에서도 동일하게 보입니다..!