### PR TITLE
feat: 인터넷이 끊겼을 때 HomeFragment에서 앱이 터지는 현상 해결 및 기타 이슈 해결

### DIFF
--- a/app/src/main/java/com/teamwss/websoso/ui/login/LoginActivity.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/login/LoginActivity.kt
@@ -60,7 +60,7 @@ class LoginActivity : BaseActivity<ActivityLoginBinding>(R.layout.activity_login
 
                     when (state.isRegistered) {
                         true -> {
-                            startActivity(MainActivity.getIntent(this@LoginActivity,true))
+                            startActivity(MainActivity.getIntent(this@LoginActivity, true))
                         }
 
                         false -> {

--- a/app/src/main/java/com/teamwss/websoso/ui/login/LoginActivity.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/login/LoginActivity.kt
@@ -60,7 +60,7 @@ class LoginActivity : BaseActivity<ActivityLoginBinding>(R.layout.activity_login
 
                     when (state.isRegistered) {
                         true -> {
-                            startActivity(MainActivity.getIntent(this@LoginActivity))
+                            startActivity(MainActivity.getIntent(this@LoginActivity,true))
                         }
 
                         false -> {

--- a/app/src/main/java/com/teamwss/websoso/ui/main/MainViewModel.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/main/MainViewModel.kt
@@ -21,7 +21,7 @@ class MainViewModel @Inject constructor(
     private val _mainUiState: MutableLiveData<MainUiState> = MutableLiveData(MainUiState())
     val mainUiState: LiveData<MainUiState> get() = _mainUiState
 
-    val isLogin: LiveData<Boolean> = savedStateHandle.getLiveData(MainActivity.IS_LOGIN_KEY, true)
+    val isLogin: LiveData<Boolean> = savedStateHandle.getLiveData(MainActivity.IS_LOGIN_KEY)
 
     fun updateUserInfo() {
         viewModelScope.launch {

--- a/app/src/main/java/com/teamwss/websoso/ui/main/home/HomeFragment.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/main/home/HomeFragment.kt
@@ -105,12 +105,13 @@ class HomeFragment : BaseFragment<FragmentHomeBinding>(R.layout.fragment_home) {
     private fun setupObserver() {
         mainViewModel.isLogin.observe(viewLifecycleOwner) { isLogin ->
             homeViewModel.updateHomeData(isLogin = isLogin)
-            if (isLogin) {
-                updateViewVisibilityByLogin(
-                    isLogin,
-                    mainViewModel.mainUiState.value?.nickname,
-                )
-            }
+
+            if (isLogin.not()) binding.tvHomeInterestFeed.text = "관심글"
+        }
+
+        mainViewModel.mainUiState.observe(viewLifecycleOwner) { uiState ->
+            binding.tvHomeInterestFeed.text =
+                getString(home_nickname_interest_feed, uiState.nickname)
         }
 
         homeViewModel.uiState.observe(viewLifecycleOwner) { uiState ->
@@ -121,6 +122,7 @@ class HomeFragment : BaseFragment<FragmentHomeBinding>(R.layout.fragment_home) {
                 }
 
                 !uiState.loading -> {
+                    binding.wllHome.setWebsosoLoadingVisibility(false)
                     popularNovelsAdapter.submitList(uiState.popularNovels)
                     popularFeedsAdapter.submitList(uiState.popularFeeds)
 
@@ -132,21 +134,6 @@ class HomeFragment : BaseFragment<FragmentHomeBinding>(R.layout.fragment_home) {
                             recommendedNovelsByUserTasteAdapter.submitList(uiState.recommendedNovelsByUserTaste)
                         }
                     }
-                }
-            }
-        }
-    }
-
-    private fun updateViewVisibilityByLogin(isLogin: Boolean, nickname: String?) {
-        with(binding) {
-            when (isLogin) {
-                true -> {
-                    tvHomeInterestFeed.text =
-                        getString(home_nickname_interest_feed, nickname)
-                }
-
-                false -> {
-                    tvHomeInterestFeed.text = "관심글"
                 }
             }
         }

--- a/app/src/main/java/com/teamwss/websoso/ui/main/home/HomeFragment.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/main/home/HomeFragment.kt
@@ -106,7 +106,8 @@ class HomeFragment : BaseFragment<FragmentHomeBinding>(R.layout.fragment_home) {
         mainViewModel.isLogin.observe(viewLifecycleOwner) { isLogin ->
             homeViewModel.updateHomeData(isLogin = isLogin)
 
-            if (isLogin.not()) binding.tvHomeInterestFeed.text = "관심글"
+            if (isLogin.not()) binding.tvHomeInterestFeed.text =
+                getString(R.string.home_interest_feed_text)
         }
 
         mainViewModel.mainUiState.observe(viewLifecycleOwner) { uiState ->

--- a/app/src/main/java/com/teamwss/websoso/ui/main/home/HomeFragment.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/main/home/HomeFragment.kt
@@ -115,7 +115,11 @@ class HomeFragment : BaseFragment<FragmentHomeBinding>(R.layout.fragment_home) {
 
         homeViewModel.uiState.observe(viewLifecycleOwner) { uiState ->
             when {
-                uiState.error -> Unit
+                uiState.error -> {
+                    binding.wllHome.setWebsosoLoadingVisibility(true)
+                    binding.wllHome.setErrorLayoutVisibility(true)
+                }
+
                 !uiState.loading -> {
                     popularNovelsAdapter.submitList(uiState.popularNovels)
                     popularFeedsAdapter.submitList(uiState.popularFeeds)

--- a/app/src/main/java/com/teamwss/websoso/ui/main/home/HomeViewModel.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/main/home/HomeViewModel.kt
@@ -74,10 +74,10 @@ class HomeViewModel @Inject constructor(
                     userInterestFeeds = userInterestFeeds.userInterestFeeds,
                     recommendedNovelsByUserTaste = recommendedNovels.tasteNovels
                 )
-            }.onFailure { throwable ->
+            }.onFailure {
                 _uiState.value = uiState.value?.copy(
                     loading = false,
-                    error = true
+                    error = true,
                 )
             }
         }

--- a/app/src/main/java/com/teamwss/websoso/ui/main/myPage/MyPageFragment.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/main/myPage/MyPageFragment.kt
@@ -47,6 +47,12 @@ class MyPageFragment : BaseFragment<FragmentMyPageBinding>(R.layout.fragment_my_
         onProfileEditClick()
     }
 
+    override fun onResume() {
+        super.onResume()
+        mainViewModel.updateUserInfo()
+        myPageViewModel.updateUserProfile()
+    }
+
     private fun bindViewModel() {
         binding.myPageViewModel = myPageViewModel
         binding.lifecycleOwner = viewLifecycleOwner
@@ -96,15 +102,12 @@ class MyPageFragment : BaseFragment<FragmentMyPageBinding>(R.layout.fragment_my_
         myPageViewModel.uiState.observe(viewLifecycleOwner) { uiState ->
             when {
                 uiState.loading -> binding.wllMyPage.setWebsosoLoadingVisibility(true)
-                uiState.error -> binding.wllMyPage.setLoadingLayoutVisibility(false)
-                !uiState.loading -> binding.wllMyPage.setWebsosoLoadingVisibility(false)
-            }
-        }
-
-        myPageViewModel.uiState.observe(viewLifecycleOwner) { uiState ->
-            when {
-                !uiState.loading -> setUpMyProfileImage(uiState.myProfile?.avatarImage.orEmpty())
-                uiState.error -> Unit
+                uiState.error -> binding.wllMyPage.setErrorLayoutVisibility(true)
+                !uiState.loading -> {
+                    binding.wllMyPage.setErrorLayoutVisibility(false)
+                    binding.wllMyPage.setWebsosoLoadingVisibility(false)
+                    setUpMyProfileImage(uiState.myProfile?.avatarImage.orEmpty())
+                }
             }
         }
     }

--- a/app/src/main/java/com/teamwss/websoso/ui/main/myPage/MyPageViewModel.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/main/myPage/MyPageViewModel.kt
@@ -17,10 +17,6 @@ class MyPageViewModel @Inject constructor(
     private val _uiState = MutableLiveData<MyPageUiState>()
     val uiState: LiveData<MyPageUiState> get() = _uiState
 
-    init {
-        updateUserProfile()
-    }
-
     fun updateUserProfile() {
         _uiState.value = uiState.value?.copy(loading = true) ?: MyPageUiState(loading = true)
         viewModelScope.launch {
@@ -29,6 +25,7 @@ class MyPageViewModel @Inject constructor(
             }.onSuccess { myProfileEntity ->
                 _uiState.value = uiState.value?.copy(
                     myProfile = myProfileEntity,
+                    error = false,
                     loading = false,
                 )
             }.onFailure {

--- a/app/src/main/java/com/teamwss/websoso/ui/onboarding/welcome/WelcomeActivity.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/onboarding/welcome/WelcomeActivity.kt
@@ -24,7 +24,7 @@ class WelcomeActivity : BaseActivity<ActivityWelcomeBinding>(R.layout.activity_w
 
     private fun onCompleteButtonClick() {
         binding.btnWelcomeStart.setOnClickListener {
-            startActivity(MainActivity.getIntent(this,true))
+            startActivity(MainActivity.getIntent(this, true))
             finish()
         }
     }

--- a/app/src/main/java/com/teamwss/websoso/ui/onboarding/welcome/WelcomeActivity.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/onboarding/welcome/WelcomeActivity.kt
@@ -24,7 +24,7 @@ class WelcomeActivity : BaseActivity<ActivityWelcomeBinding>(R.layout.activity_w
 
     private fun onCompleteButtonClick() {
         binding.btnWelcomeStart.setOnClickListener {
-            startActivity(MainActivity.getIntent(this))
+            startActivity(MainActivity.getIntent(this,true))
             finish()
         }
     }

--- a/app/src/main/java/com/teamwss/websoso/ui/splash/SplashActivity.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/splash/SplashActivity.kt
@@ -36,7 +36,7 @@ class SplashActivity : BaseActivity<ActivityLoginBinding>(R.layout.activity_spla
     }
 
     private fun navigateToMainActivity() {
-        startActivity(MainActivity.getIntent(this,true))
+        startActivity(MainActivity.getIntent(this, true))
         finish()
     }
 

--- a/app/src/main/java/com/teamwss/websoso/ui/splash/SplashActivity.kt
+++ b/app/src/main/java/com/teamwss/websoso/ui/splash/SplashActivity.kt
@@ -36,7 +36,7 @@ class SplashActivity : BaseActivity<ActivityLoginBinding>(R.layout.activity_spla
     }
 
     private fun navigateToMainActivity() {
-        startActivity(MainActivity.getIntent(this))
+        startActivity(MainActivity.getIntent(this,true))
         finish()
     }
 

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -316,7 +316,7 @@
             android:id="@+id/wll_home"
             android:layout_width="0dp"
             android:layout_height="0dp"
-            android:visibility="invisible"
+            android:visibility="gone"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -311,5 +311,16 @@
                 </androidx.constraintlayout.widget.ConstraintLayout>
             </androidx.constraintlayout.widget.ConstraintLayout>
         </androidx.core.widget.NestedScrollView>
+
+        <com.teamwss.websoso.common.ui.custom.WebsosoLoadingLayout
+            android:id="@+id/wll_home"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:visibility="invisible"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/app/src/main/res/values/deepLinks.xml
+++ b/app/src/main/res/values/deepLinks.xml
@@ -2,6 +2,6 @@
 <resources>
     <string name="inquire_link">http://pf.kakao.com/_kHxlWG</string>
     <string name="websoso_official">https://www.instagram.com/websoso_official/</string>
-    <string name="privacy_policy_link">http://kimmjabc.notion.site</string>
-    <string name="terms_of_use_link">https://kimmjabc.notion.site/e55f0c0e95c249f7998f21563aefa4b4?pvs=4</string>
+    <string name="privacy_policy_link">https://websoso.notion.site/143600bd74688050be18f4da31d9403e?pvs=4</string>
+    <string name="terms_of_use_link">https://websoso.notion.site/143600bd746880668556fb005fcef491?pvs=4</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -246,6 +246,7 @@
     <string name="home_nickname_interest_feed">%1$s님의 관심글</string>
     <string name="home_recommended_novel_rating_format">%1$.1f (%2$d)</string>
     <string name="home_no_associated_feed">관심 등록한 작품과 관련된 글이 없어요</string>
+    <string name="home_interest_feed_text">관심글</string>
 
     <!-- 환경설정 뷰-->
     <string name="setting_title">설정</string>


### PR DESCRIPTION
## 📌𝘐𝘴𝘴𝘶𝘦𝘴
- closed #450
- closed #465 
- closed #466 
- closed #467

## 📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯
### 어쩌다 보니 여러 이슈를 한 PR에서 처리해서 죄송합니다!
- 로띠 더 밝은버전 이미지가 있어서 교체하였습니다.

### HomeFragment 앱이 터졌던 이유

현재 4개의 서버통신 로직을 async를 통해서 4개를 병렬적으로 통신을 진행하는데 네트워크 요청 중 하나라도 실패하면 Deferred.await() 호출 시 throw되어, 남은 작업들도 중단되고 예외를 발생합니다. 이때 예외를 처리를 하지 않아서 앱이 깨져버린 것 같습니다. 그래서 `runCatching`으로 묶어 각 요청의 예외를 처리할 수 있게 하였습니다.

### MyPage 네트워크 오류 대응이 불가 이유
- `MyPageViewModel`이 엑티비티뷰모델이라서 init()을 한 번 호출하였다
- 똑같은 옵저버 함수가 들어가 있어서 이상한 로직이 굴러 갔다.
- onSuccess일 때 `error = false`를 안해줘서 오류였다가 정상화면으로 넘어갈 수 없었다.

### 회원가입시 닉네임 "웹소소"로 나온 이유
- `MainActivity`에서 isLogin에 변화를 보고 유저 정보를 가져올지 말지 결정을 하는데 회원가입시에 `true`를넣어주지 않았습니다 그리고 불필요한 로직을 좀 개선하였습니다.

## 📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵
### Home 네트워크 에러 및 앱 터지는 이슈 해결
https://github.com/user-attachments/assets/23f0ec7b-f929-4c63-a004-bd4f5f6107e5

### MyPage 네트워크 에러 해결
https://github.com/user-attachments/assets/48fcac29-059f-4a9d-ac1c-26b05515c909

### 닉네임 이슈 해결
https://github.com/user-attachments/assets/22d1f085-492f-4b99-a3a5-e343f7495b3b



## 💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴