### PR TITLE
hotfix: 이벤트 트래커 DI 주입을 위한 다이얼로그 바텀시트 AndroidEntryPoint 추가

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -18,8 +18,8 @@ android {
         applicationId = "com.into.websoso"
         minSdk = 30
         targetSdk = 34
-        versionCode = 10007
-        versionName = "1.0.7"
+        versionCode = 10008
+        versionName = "1.0.8"
 
         buildConfigField("String", "BASE_URL", gradleLocalProperties(rootDir).getProperty("base.url"))
         buildConfigField("String", "S3_BASE_URL", gradleLocalProperties(rootDir).getProperty("s3.url"))

--- a/app/src/main/java/com/into/websoso/ui/createFeed/CreateFeedSearchNovelBottomSheetDialog.kt
+++ b/app/src/main/java/com/into/websoso/ui/createFeed/CreateFeedSearchNovelBottomSheetDialog.kt
@@ -18,8 +18,10 @@ import com.into.websoso.ui.createFeed.adapter.SearchNovelAdapter
 import com.into.websoso.ui.createFeed.adapter.SearchNovelItemType.Loading
 import com.into.websoso.ui.createFeed.adapter.SearchNovelItemType.Novels
 import com.into.websoso.ui.createFeed.model.SearchNovelUiState
+import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 
+@AndroidEntryPoint
 class CreateFeedSearchNovelBottomSheetDialog :
     BaseBottomSheetDialog<DialogCreateFeedSearchNovelBinding>(dialog_create_feed_search_novel) {
     @Inject

--- a/app/src/main/java/com/into/websoso/ui/main/feed/dialog/FeedReportDialogFragment.kt
+++ b/app/src/main/java/com/into/websoso/ui/main/feed/dialog/FeedReportDialogFragment.kt
@@ -16,8 +16,10 @@ import com.into.websoso.ui.main.feed.dialog.ReportMenuType.IMPERTINENCE_COMMENT
 import com.into.websoso.ui.main.feed.dialog.ReportMenuType.IMPERTINENCE_FEED
 import com.into.websoso.ui.main.feed.dialog.ReportMenuType.SPOILER_COMMENT
 import com.into.websoso.ui.main.feed.dialog.ReportMenuType.SPOILER_FEED
+import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 
+@AndroidEntryPoint
 class FeedReportDialogFragment :
     BaseDialogFragment<DialogReportPopupMenuBinding>(R.layout.dialog_report_popup_menu) {
     @Inject


### PR DESCRIPTION
## 📌𝘐𝘴𝘴𝘶𝘦𝘴
- closed #511

## 📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯
- 문제는 dialogFragment에 `androidEntryPoint `추가 안 해줘서 traker 못 찾음 이슈로 터지는 거였습니다

## 📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵

https://github.com/user-attachments/assets/66cae999-914b-4c05-9c95-e574f528545a



## 💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴