### PR TITLE
hotfix: 토큰 401 에러 해결 

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -18,7 +18,7 @@ android {
         applicationId = "com.into.websoso"
         minSdk = 30
         targetSdk = 34
-        versionCode = 9
+        versionCode = 10011
         versionName = "1.0.9"
 
         buildConfigField(

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -18,13 +18,29 @@ android {
         applicationId = "com.into.websoso"
         minSdk = 30
         targetSdk = 34
-        versionCode = 10008
-        versionName = "1.0.8"
+        versionCode = 9
+        versionName = "1.0.9"
 
-        buildConfigField("String", "BASE_URL", gradleLocalProperties(rootDir).getProperty("base.url"))
-        buildConfigField("String", "S3_BASE_URL", gradleLocalProperties(rootDir).getProperty("s3.url"))
-        buildConfigField("String", "KAKAO_APP_KEY", gradleLocalProperties(rootDir).getProperty("kakao.app.key"))
-        buildConfigField("String", "AMPLITUDE_KEY", gradleLocalProperties(rootDir).getProperty("amplitude.key"))
+        buildConfigField(
+            "String",
+            "BASE_URL",
+            gradleLocalProperties(rootDir).getProperty("base.url")
+        )
+        buildConfigField(
+            "String",
+            "S3_BASE_URL",
+            gradleLocalProperties(rootDir).getProperty("s3.url")
+        )
+        buildConfigField(
+            "String",
+            "KAKAO_APP_KEY",
+            gradleLocalProperties(rootDir).getProperty("kakao.app.key")
+        )
+        buildConfigField(
+            "String",
+            "AMPLITUDE_KEY",
+            gradleLocalProperties(rootDir).getProperty("amplitude.key")
+        )
 
         manifestPlaceholders["kakaoAppKey"] = gradleLocalProperties(rootDir)
             .getProperty("kakao.app.key").replace("\"", "")

--- a/app/src/main/java/com/into/websoso/ui/splash/SplashActivity.kt
+++ b/app/src/main/java/com/into/websoso/ui/splash/SplashActivity.kt
@@ -9,6 +9,7 @@ import com.into.websoso.databinding.ActivityLoginBinding
 import com.into.websoso.ui.login.LoginActivity
 import com.into.websoso.ui.main.MainActivity
 import com.into.websoso.ui.splash.dialog.MinimumVersionDialogFragment
+import com.kakao.sdk.user.UserApiClient
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -21,25 +22,40 @@ class SplashActivity : BaseActivity<ActivityLoginBinding>(R.layout.activity_spla
         super.onCreate(savedInstanceState)
 
         setupObserver()
-        splashViewModel.autoLogin()
     }
 
     private fun setupObserver() {
-        splashViewModel.isAutoLogin.observe(this) { isAutoLogin ->
-            lifecycleScope.launch {
-                delay(1000L)
-                splashViewModel.updateMinimumVersion { isUpdateRequired ->
-                    if (isUpdateRequired) {
-                        showMinimumVersionDialog()
-                    } else {
-                        when (isAutoLogin) {
-                            true -> navigateToMainActivity()
-                            false -> navigateToLoginActivity()
-                        }
-                    }
+        splashViewModel.isUpdateRequired.observe(this) { isUpdateRequired ->
+            if (isUpdateRequired) {
+                showMinimumVersionDialog()
+                return@observe
+            }
+            splashViewModel.updateMyProfile()
+        }
+
+        splashViewModel.error.observe(this) { isError ->
+            if (isError) {
+                UserApiClient.instance.logout {
+                    startActivity(LoginActivity.getIntent(this))
                 }
             }
         }
+
+        splashViewModel.isAutoLogin.observe(this) { isAutoLogin ->
+            lifecycleScope.launch {
+                delay(1000L)
+                when (isAutoLogin) {
+                    true -> navigateToMainActivity()
+                    false -> navigateToLoginActivity()
+                }
+            }
+        }
+    }
+
+    private fun showMinimumVersionDialog() {
+        val dialog = MinimumVersionDialogFragment.newInstance()
+        dialog.isCancelable = false
+        dialog.show(supportFragmentManager, MINIMUM_VERSION_TAG)
     }
 
     private fun navigateToMainActivity() {
@@ -50,12 +66,6 @@ class SplashActivity : BaseActivity<ActivityLoginBinding>(R.layout.activity_spla
     private fun navigateToLoginActivity() {
         startActivity(LoginActivity.getIntent(this))
         finish()
-    }
-
-    private fun showMinimumVersionDialog() {
-        val dialog = MinimumVersionDialogFragment.newInstance()
-        dialog.isCancelable = false
-        dialog.show(supportFragmentManager, MINIMUM_VERSION_TAG)
     }
 
     companion object {


### PR DESCRIPTION
## 📌𝘐𝘴𝘴𝘶𝘦𝘴
- closed #560

## 📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯
- 리프레시 토큰 만료 시 401이 뜨고 로그인 뷰로 이동하지 않는 문제를 해결했습니다.

[ 로직 ]
1. 스플래시에서 강제업데이트 확인 
- 강업 필요 : 강제 업데이트 다이얼로그 띄움
- 강업 불필요 : 토큰이 필요한 내 프로필 (my-profile) api 호출

2. 토큰 필요한 내 프로필 api 호출 시 
- success 시 (토큰 문제 없음) : `isAutoLogin` 여부 파악 후 홈으로 이동
- fail 시 (토큰 문제 있음) : viewModel 프로퍼티에 `error` 라는 친구 추가해서 error 값 true 로 변경 및 로컬에 저장된 토큰 삭제, activity 에서 observing 후 true 값 들어왔을 시에 로그아웃 및 로그인 뷰로 이동

## 📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵


## 💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴
`WebsosoAuthenticator` 코드는 손 안댔고 일시적인 야매 방법으로 스플래시에서 api 통신하도록 구현했습니다.
땡스 투 산군...

+ 아직 디버깅용 / 릴리즈용 안 나눠진 master 브랜치라서 또 개발 서버 배포하는 일 없도록 확인했습니다
<img width="395" alt="스크린샷 2025-01-24 오전 2 35 39" src="https://github.com/user-attachments/assets/2ae58f0d-71fa-4e17-97d2-5fc87625b693" />
