### PR TITLE
fix: 푸시 알림 클릭 시 읽음 처리 되지 않는 현상 해결

### DIFF
--- a/app/src/main/java/com/into/websoso/core/common/util/message/WSSFirebaseMessagingService.kt
+++ b/app/src/main/java/com/into/websoso/core/common/util/message/WSSFirebaseMessagingService.kt
@@ -65,7 +65,10 @@ class WSSFirebaseMessagingService : FirebaseMessagingService() {
         return TaskStackBuilder.create(this).run {
             addNextIntent(mainIntent)
             addNextIntentWithParentStack(detailIntent)
-            getPendingIntent(0, PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE)
+            getPendingIntent(
+                notificationId.toInt(),
+                PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+            )
         }
     }
 


### PR DESCRIPTION
## 📌𝘐𝘴𝘴𝘶𝘦𝘴
- closed #574

## 📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯
- pendingIntent 생성 시 requestCode가 0으로 설정되어있어서 재사용되고 있었습니다.
- 따라서 마지막에 receieved 받은 notificationId가 재사용되어 409 에러가 뜸으로써 알림 읽음 처리가 되지 않는 현상이 생겼습니다.
- 따라서 requestCode를 notificationId 값의 int형을 사용하여 해결했습니다.

## 📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵

https://github.com/user-attachments/assets/a735537a-8112-4ed6-a787-cd92d878a115



## 💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴