### PR TITLE
feat: 로그아웃 시 fcm 토큰 제거 로직 구현

### DIFF
--- a/app/src/main/java/com/into/websoso/data/remote/api/AuthApi.kt
+++ b/app/src/main/java/com/into/websoso/data/remote/api/AuthApi.kt
@@ -15,7 +15,6 @@ import retrofit2.http.POST
 import retrofit2.http.Query
 
 interface AuthApi {
-
     @POST("auth/login/kakao")
     suspend fun loginWithKakao(
         @Header("Kakao-Access-Token") accessToken: String,

--- a/app/src/main/java/com/into/websoso/data/remote/request/LogoutRequestDto.kt
+++ b/app/src/main/java/com/into/websoso/data/remote/request/LogoutRequestDto.kt
@@ -4,7 +4,9 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class LogoutRequestDto (
+data class LogoutRequestDto(
     @SerialName("refreshToken")
     val refreshToken: String,
+    @SerialName("deviceIdentifier")
+    val deviceIdentifier: String,
 )

--- a/app/src/main/java/com/into/websoso/data/repository/AuthRepository.kt
+++ b/app/src/main/java/com/into/websoso/data/repository/AuthRepository.kt
@@ -11,119 +11,123 @@ import com.into.websoso.data.remote.request.UserProfileRequestDto
 import com.into.websoso.data.remote.request.WithdrawRequestDto
 import javax.inject.Inject
 
-class AuthRepository @Inject constructor(
-    private val authApi: AuthApi,
-    private val preferences: SharedPreferences,
-) {
-
-    var accessToken: String
-        get() = preferences.getString(ACCESS_TOKEN_KEY, "").orEmpty()
-        private set(value) = preferences.edit().putString(ACCESS_TOKEN_KEY, value).apply()
-
-    var refreshToken: String
-        get() = preferences.getString(REFRESH_TOKEN_KEY, "").orEmpty()
-        private set(value) = preferences.edit().putString(REFRESH_TOKEN_KEY, value).apply()
-
-    var isAutoLogin: Boolean
-        get() = preferences.getBoolean(AUTO_LOGIN_KEY, false)
-        private set(value) = preferences.edit().putBoolean(AUTO_LOGIN_KEY, value).apply()
-
-    suspend fun loginWithKakao(accessToken: String): LoginEntity {
-        val response = authApi.loginWithKakao(accessToken)
-        this.accessToken = response.authorization
-        this.refreshToken = response.refreshToken
-        return response.toData()
-    }
-
-    suspend fun fetchNicknameValidity(authorization: String, nickname: String): Boolean {
-        return authApi.getNicknameValidity("Bearer $authorization", nickname).isValid
-    }
-
-    suspend fun signUp(
-        authorization: String,
-        nickname: String,
-        gender: String,
-        birth: Int,
-        genrePreferences: List<String>,
+class AuthRepository
+    @Inject
+    constructor(
+        private val authApi: AuthApi,
+        private val preferences: SharedPreferences,
     ) {
-        authApi.postUserProfile(
-            "Bearer $authorization",
-            UserProfileRequestDto(nickname, gender, birth, genrePreferences),
-        )
-    }
+        var accessToken: String
+            get() = preferences.getString(ACCESS_TOKEN_KEY, "").orEmpty()
+            private set(value) = preferences.edit().putString(ACCESS_TOKEN_KEY, value).apply()
 
-    suspend fun logout() {
-        runCatching {
-            if (accessToken.isNotEmpty() && refreshToken.isNotEmpty()) {
-                authApi.logout("Bearer $accessToken", LogoutRequestDto(refreshToken))
+        var refreshToken: String
+            get() = preferences.getString(REFRESH_TOKEN_KEY, "").orEmpty()
+            private set(value) = preferences.edit().putString(REFRESH_TOKEN_KEY, value).apply()
+
+        var isAutoLogin: Boolean
+            get() = preferences.getBoolean(AUTO_LOGIN_KEY, false)
+            private set(value) = preferences.edit().putBoolean(AUTO_LOGIN_KEY, value).apply()
+
+        suspend fun loginWithKakao(accessToken: String): LoginEntity {
+            val response = authApi.loginWithKakao(accessToken)
+            this.accessToken = response.authorization
+            this.refreshToken = response.refreshToken
+            return response.toData()
+        }
+
+        suspend fun fetchNicknameValidity(
+            authorization: String,
+            nickname: String,
+        ): Boolean = authApi.getNicknameValidity("Bearer $authorization", nickname).isValid
+
+        suspend fun signUp(
+            authorization: String,
+            nickname: String,
+            gender: String,
+            birth: Int,
+            genrePreferences: List<String>,
+        ) {
+            authApi.postUserProfile(
+                "Bearer $authorization",
+                UserProfileRequestDto(nickname, gender, birth, genrePreferences),
+            )
+        }
+
+        suspend fun logout(deviceIdentifier: String) {
+            runCatching {
+                if (accessToken.isNotEmpty() && refreshToken.isNotEmpty()) {
+                    authApi.logout(
+                        "Bearer $accessToken",
+                        LogoutRequestDto(refreshToken, deviceIdentifier),
+                    )
+                }
+            }.onSuccess {
+                clearTokens()
+            }.onFailure {
+                it.printStackTrace()
             }
-        }.onSuccess {
-            clearTokens()
-        }.onFailure {
-            it.printStackTrace()
         }
-    }
 
-    suspend fun withdraw(reason: String) {
-        runCatching {
-            if (accessToken.isNotEmpty() && refreshToken.isNotEmpty()) {
-                authApi.withdraw("Bearer $accessToken", WithdrawRequestDto(reason, refreshToken))
+        suspend fun withdraw(reason: String) {
+            runCatching {
+                if (accessToken.isNotEmpty() && refreshToken.isNotEmpty()) {
+                    authApi.withdraw("Bearer $accessToken", WithdrawRequestDto(reason, refreshToken))
+                }
+            }.onSuccess {
+                clearTokens()
+            }.onFailure {
+                it.printStackTrace()
             }
-        }.onSuccess {
-            clearTokens()
-        }.onFailure {
-            it.printStackTrace()
+        }
+
+        fun clearTokens() {
+            preferences.edit().apply {
+                remove(ACCESS_TOKEN_KEY)
+                remove(REFRESH_TOKEN_KEY)
+                apply()
+            }
+        }
+
+        suspend fun reissueToken(): String? =
+            runCatching {
+                val response = authApi.reissueToken(TokenReissueRequestDto(refreshToken))
+                accessToken = response.authorization
+                refreshToken = response.refreshToken
+                response.authorization
+            }.getOrElse {
+                it.printStackTrace()
+                null
+            }
+
+        fun updateAccessToken(accessToken: String) {
+            this.accessToken = accessToken
+        }
+
+        fun updateRefreshToken(refreshToken: String) {
+            this.refreshToken = refreshToken
+        }
+
+        fun updateIsAutoLogin(isAutoLogin: Boolean) {
+            this.isAutoLogin = isAutoLogin
+        }
+
+        suspend fun saveFCMToken(
+            fcmToken: String,
+            deviceIdentifier: String,
+        ) {
+            authApi.postFCMToken(
+                authorization = "Bearer $accessToken",
+                FCMTokenRequestDto(
+                    fcmToken = fcmToken,
+                    deviceIdentifier = deviceIdentifier,
+                ),
+            )
+        }
+
+        companion object {
+            private const val ACCESS_TOKEN_KEY = "ACCESS_TOKEN"
+            private const val REFRESH_TOKEN_KEY = "REFRESH_TOKEN"
+            private const val AUTO_LOGIN_KEY = "AUTO_LOGIN"
         }
     }
-
-    fun clearTokens() {
-        preferences.edit().apply {
-            remove(ACCESS_TOKEN_KEY)
-            remove(REFRESH_TOKEN_KEY)
-            apply()
-        }
-    }
-
-    suspend fun reissueToken(): String? {
-        return runCatching {
-            val response = authApi.reissueToken(TokenReissueRequestDto(refreshToken))
-            accessToken = response.authorization
-            refreshToken = response.refreshToken
-            response.authorization
-        }.getOrElse {
-            it.printStackTrace()
-            null
-        }
-    }
-
-    fun updateAccessToken(accessToken: String) {
-        this.accessToken = accessToken
-    }
-
-    fun updateRefreshToken(refreshToken: String) {
-        this.refreshToken = refreshToken
-    }
-
-    fun updateIsAutoLogin(isAutoLogin: Boolean) {
-        this.isAutoLogin = isAutoLogin
-    }
-
-    suspend fun saveFCMToken(
-        fcmToken: String,
-        deviceIdentifier: String,
-    ) {
-        authApi.postFCMToken(
-            authorization = "Bearer $accessToken",
-            FCMTokenRequestDto(
-                fcmToken = fcmToken,
-                deviceIdentifier = deviceIdentifier,
-            ),
-        )
-    }
-
-    companion object {
-        private const val ACCESS_TOKEN_KEY = "ACCESS_TOKEN"
-        private const val REFRESH_TOKEN_KEY = "REFRESH_TOKEN"
-        private const val AUTO_LOGIN_KEY = "AUTO_LOGIN"
-    }
-}

--- a/app/src/main/java/com/into/websoso/data/repository/AuthRepository.kt
+++ b/app/src/main/java/com/into/websoso/data/repository/AuthRepository.kt
@@ -15,19 +15,19 @@ class AuthRepository
     @Inject
     constructor(
         private val authApi: AuthApi,
-        private val preferences: SharedPreferences,
+        private val authStorage: SharedPreferences,
     ) {
         var accessToken: String
-            get() = preferences.getString(ACCESS_TOKEN_KEY, "").orEmpty()
-            private set(value) = preferences.edit().putString(ACCESS_TOKEN_KEY, value).apply()
+            get() = authStorage.getString(ACCESS_TOKEN_KEY, "").orEmpty()
+            private set(value) = authStorage.edit().putString(ACCESS_TOKEN_KEY, value).apply()
 
         var refreshToken: String
-            get() = preferences.getString(REFRESH_TOKEN_KEY, "").orEmpty()
-            private set(value) = preferences.edit().putString(REFRESH_TOKEN_KEY, value).apply()
+            get() = authStorage.getString(REFRESH_TOKEN_KEY, "").orEmpty()
+            private set(value) = authStorage.edit().putString(REFRESH_TOKEN_KEY, value).apply()
 
         var isAutoLogin: Boolean
-            get() = preferences.getBoolean(AUTO_LOGIN_KEY, false)
-            private set(value) = preferences.edit().putBoolean(AUTO_LOGIN_KEY, value).apply()
+            get() = authStorage.getBoolean(AUTO_LOGIN_KEY, false)
+            private set(value) = authStorage.edit().putBoolean(AUTO_LOGIN_KEY, value).apply()
 
         suspend fun loginWithKakao(accessToken: String): LoginEntity {
             val response = authApi.loginWithKakao(accessToken)
@@ -82,7 +82,7 @@ class AuthRepository
         }
 
         fun clearTokens() {
-            preferences.edit().apply {
+            authStorage.edit().apply {
                 remove(ACCESS_TOKEN_KEY)
                 remove(REFRESH_TOKEN_KEY)
                 apply()

--- a/app/src/main/java/com/into/websoso/data/repository/PushMessageRepository.kt
+++ b/app/src/main/java/com/into/websoso/data/repository/PushMessageRepository.kt
@@ -64,6 +64,12 @@ class PushMessageRepository
             )
         }
 
+        suspend fun clearFCMToken() {
+            userStorage.edit { preferences ->
+                preferences.remove(USER_FCM_TOKEN_KEY)
+            }
+        }
+
         companion object {
             val USER_FCM_TOKEN_KEY = stringPreferencesKey("USER_FCM_TOKEN")
             val NOTIFICATION_PERMISSION_FIRST_LAUNCHED_KEY =

--- a/app/src/main/java/com/into/websoso/ui/accountInfo/AccountInfoViewModel.kt
+++ b/app/src/main/java/com/into/websoso/ui/accountInfo/AccountInfoViewModel.kt
@@ -35,7 +35,6 @@ class AccountInfoViewModel
                     userRepository.fetchUserInfoDetail()
                 }.onSuccess { userInfo ->
                     _userEmail.value = userInfo.email
-                }.onFailure {
                 }
             }
         }

--- a/app/src/main/java/com/into/websoso/ui/accountInfo/AccountInfoViewModel.kt
+++ b/app/src/main/java/com/into/websoso/ui/accountInfo/AccountInfoViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.into.websoso.data.repository.AuthRepository
+import com.into.websoso.data.repository.PushMessageRepository
 import com.into.websoso.data.repository.UserRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
@@ -16,6 +17,7 @@ class AccountInfoViewModel
     constructor(
         private val userRepository: UserRepository,
         private val authRepository: AuthRepository,
+        private val pushMessageRepository: PushMessageRepository,
     ) : ViewModel() {
         private val _userEmail: MutableLiveData<String> = MutableLiveData()
         val userEmail: LiveData<String> get() = _userEmail
@@ -46,6 +48,7 @@ class AccountInfoViewModel
                 }.onSuccess {
                     _isLogoutSuccess.value = true
                     authRepository.updateIsAutoLogin(false)
+                    pushMessageRepository.clearFCMToken()
                 }.onFailure {
                     _isLogoutSuccess.value = false
                 }

--- a/app/src/main/java/com/into/websoso/ui/main/home/HomeFragment.kt
+++ b/app/src/main/java/com/into/websoso/ui/main/home/HomeFragment.kt
@@ -74,7 +74,11 @@ class HomeFragment : BaseFragment<FragmentHomeBinding>(R.layout.fragment_home) {
     }
 
     private val requestPermissionLauncher =
-        registerForActivityResult(ActivityResultContracts.RequestPermission()) { updateFCMToken(true) }
+        registerForActivityResult(ActivityResultContracts.RequestPermission()) {
+            updateFCMToken(
+                isFirstLaunch = true,
+            )
+        }
 
     override fun onViewCreated(
         view: View,
@@ -211,7 +215,7 @@ class HomeFragment : BaseFragment<FragmentHomeBinding>(R.layout.fragment_home) {
             homeViewModel.updateIsNotificationPermissionFirstLaunched(false)
             return
         }
-        updateFCMToken(true)
+        updateFCMToken(isFirstLaunch = true)
         homeViewModel.updateIsNotificationPermissionFirstLaunched(false)
     }
 

--- a/app/src/main/java/com/into/websoso/ui/main/home/HomeViewModel.kt
+++ b/app/src/main/java/com/into/websoso/ui/main/home/HomeViewModel.kt
@@ -211,10 +211,18 @@ class HomeViewModel
                 else -> true
             }
 
-        fun updateFCMToken(token: String) {
+        fun saveFCMToken(token: String) {
             viewModelScope.launch {
                 runCatching {
                     pushMessageRepository.saveUserFCMToken(token)
+                }
+            }
+        }
+
+        fun updateFCMToken(token: String) {
+            viewModelScope.launch {
+                runCatching {
+                    pushMessageRepository.updateUserFCMToken(token)
                 }
             }
         }


### PR DESCRIPTION
## 📌𝘐𝘴𝘴𝘶𝘦𝘴
- closed #573

## 📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯
- 로그아웃 시 fcm 토큰을 서버 및 로컬에서 제거합니다.
- 서버에 제거하기 위해서 `logout API` 에서 `DevicedIdentifier` 디바이스 식별 번호를 추가로 받습니다.
- 로컬에서는 로그아웃 성공 시 `DataStore`에 저장된 fcm 토큰을 제거합니다.
- 그 이후, 홈화면 진입 시마다 토큰 발행해 `pushMessageRepository` 내의 하단 코드를 통해 발급한 토큰과 로컬에 저장된 토큰을 비교합니다.
<img width="470" alt="스크린샷 2025-02-15 오후 5 16 45" src="https://github.com/user-attachments/assets/4949a840-b9aa-4a3a-8f19-d93aa8056d74" />

- 홈화면에서 토큰 발행해 **업데이트 하는 분기가 두 가지**가 있습니다.
1. 첫 권한 요청을 받아서 무조건 서버에 저장해야 할 경우엔 하단의 함수를 호출해 무조건 서버로 저장할 수 있도록 합니다.
<img width="636" alt="스크린샷 2025-02-15 오후 5 18 02" src="https://github.com/user-attachments/assets/294b94aa-4691-4eeb-9aaf-2cbbc27d6f2b" />

2. 첫 권한 요청이 아닐 경우엔 위 로컬에 저장된 토큰과 발급한 토큰 비교 로직을 탑니다.
=> 무조건 서버로 api 쏘는 게 아니라는 뜻

## 📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵

https://github.com/user-attachments/assets/5054fa35-573b-4d7c-8b8b-90ee6d5bc8c3



## 💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴
서버에서 요구한 내용: 로그아웃 시에 `userIdentifier` 추가해주고, 로그인 후 fcm 토큰 post 해달라