### PR TITLE
refactor: 알림 뷰 제목의 줄바꿈 제거

### DIFF
--- a/app/src/main/java/com/into/websoso/data/model/NotificationEntity.kt
+++ b/app/src/main/java/com/into/websoso/data/model/NotificationEntity.kt
@@ -13,7 +13,7 @@ data class NotificationEntity(
     val isNotice: Boolean,
     val feedId: Long?,
 ) {
-    fun getLineChangeIgnoredTitle(): String = notificationTitle.replace(Regex(LINE_CHANGE), " ").trim()
+    fun getIgnoreLineChangeTitle(): String = notificationTitle.replace(Regex(LINE_CHANGE), " ").trim()
 
     fun getNotificationType(): NotificationType =
         NotificationType.from(

--- a/app/src/main/java/com/into/websoso/data/model/NotificationEntity.kt
+++ b/app/src/main/java/com/into/websoso/data/model/NotificationEntity.kt
@@ -13,6 +13,8 @@ data class NotificationEntity(
     val isNotice: Boolean,
     val feedId: Long?,
 ) {
+    fun getLineChangeIgnoredTitle(): String = notificationTitle.replace(Regex(LINE_CHANGE), " ").trim()
+
     fun getNotificationType(): NotificationType =
         NotificationType.from(
             when {
@@ -27,4 +29,8 @@ data class NotificationEntity(
             feedId != null -> feedId
             else -> GetNotificationListUseCase.DEFAULT_INTRINSIC_ID
         }
+
+    companion object {
+        private const val LINE_CHANGE = "[\n\r]"
+    }
 }

--- a/app/src/main/java/com/into/websoso/domain/mapper/NotificationMapper.kt
+++ b/app/src/main/java/com/into/websoso/domain/mapper/NotificationMapper.kt
@@ -16,7 +16,7 @@ fun NotificationEntity.toDomain(): Notification =
     Notification(
         id = notificationId,
         notificationIconImage = notificationImage,
-        notificationTitle = getLineChangeIgnoredTitle(),
+        notificationTitle = getIgnoreLineChangeTitle(),
         notificationType = getNotificationType(),
         notificationDescription = notificationBody,
         createdDate = createdDate,

--- a/app/src/main/java/com/into/websoso/domain/mapper/NotificationMapper.kt
+++ b/app/src/main/java/com/into/websoso/domain/mapper/NotificationMapper.kt
@@ -16,7 +16,7 @@ fun NotificationEntity.toDomain(): Notification =
     Notification(
         id = notificationId,
         notificationIconImage = notificationImage,
-        notificationTitle = notificationTitle,
+        notificationTitle = getLineChangeIgnoredTitle(),
         notificationType = getNotificationType(),
         notificationDescription = notificationBody,
         createdDate = createdDate,

--- a/app/src/main/java/com/into/websoso/ui/notification/component/NotificationCard.kt
+++ b/app/src/main/java/com/into/websoso/ui/notification/component/NotificationCard.kt
@@ -12,6 +12,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.into.websoso.core.common.ui.component.AdaptationImage
@@ -22,6 +23,8 @@ import com.into.websoso.core.designsystem.theme.WebsosoTheme
 import com.into.websoso.core.designsystem.theme.White
 import com.into.websoso.domain.model.Notification
 import com.into.websoso.domain.model.NotificationType
+
+private const val MAX_NOTIFICATION_LINES = 1
 
 @Composable
 fun NotificationCard(
@@ -48,6 +51,8 @@ fun NotificationCard(
                 text = notification.notificationTitle,
                 style = WebsosoTheme.typography.title2,
                 color = Black,
+                maxLines = MAX_NOTIFICATION_LINES,
+                overflow = TextOverflow.Ellipsis,
             )
             Text(
                 text = notification.notificationDescription,
@@ -55,6 +60,8 @@ fun NotificationCard(
                 color = Gray200,
                 modifier = Modifier
                     .padding(top = 2.dp),
+                maxLines = MAX_NOTIFICATION_LINES,
+                overflow = TextOverflow.Ellipsis,
             )
             Text(
                 text = notification.createdDate,


### PR DESCRIPTION
## 📌𝘐𝘴𝘴𝘶𝘦𝘴
- closed #585 

## 📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯
- 알림 뷰 제목의 줄바꿈 제거

## 📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵
<img width="349" alt="image" src="https://github.com/user-attachments/assets/ab5d609e-fa36-413f-9438-f8911b016bd9" />


## 💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴
해당 부분을 한 줄로 만드는 로직은 어느 계층의 역할일까요 🤔
Domain의 모델로 전환할 때 조금 지저분해져서 entity에 두고 있는데 이게 괜찮은 방법인지 고민이네요
이렇게 되면 data 가 하는 일이 아닌가? 싶다가도 로컬은 한줄짜리 제목만 받으면 되는데 굳이 우리가 알아야 할까? 이기도함