### PR TITLE
bugfix: 회원탈퇴 후 회원가입 시 푸시알림이 오지 않는 현상

### DIFF
--- a/app/src/main/java/com/into/websoso/ui/withdraw/second/WithdrawSecondActivity.kt
+++ b/app/src/main/java/com/into/websoso/ui/withdraw/second/WithdrawSecondActivity.kt
@@ -59,7 +59,7 @@ class WithdrawSecondActivity : BaseActivity<ActivityWithdrawSecondBinding>(R.lay
             }
 
             override fun onWithdrawCheckAgreeButtonClick() {
-                withdrawSecondViewModel.updateIsWithdrawCheckAgreement()
+                withdrawSecondViewModel.updateIsWithdrawAgreementChecked()
             }
 
             override fun onWithdrawButtonClick() {

--- a/app/src/main/java/com/into/websoso/ui/withdraw/second/WithdrawSecondActivity.kt
+++ b/app/src/main/java/com/into/websoso/ui/withdraw/second/WithdrawSecondActivity.kt
@@ -59,7 +59,7 @@ class WithdrawSecondActivity : BaseActivity<ActivityWithdrawSecondBinding>(R.lay
             }
 
             override fun onWithdrawCheckAgreeButtonClick() {
-                withdrawSecondViewModel.updateIsWithdrawCheckAgree()
+                withdrawSecondViewModel.updateIsWithdrawCheckAgreement()
             }
 
             override fun onWithdrawButtonClick() {
@@ -78,7 +78,7 @@ class WithdrawSecondActivity : BaseActivity<ActivityWithdrawSecondBinding>(R.lay
     }
 
     private fun setupObserver() {
-        withdrawSecondViewModel.isWithdrawCheckAgree.observe(this) { isAgree ->
+        withdrawSecondViewModel.isWithdrawAgreementChecked.observe(this) { isAgree ->
             updateWithdrawCheckAgreeButtonImage(isAgree)
         }
 

--- a/app/src/main/java/com/into/websoso/ui/withdraw/second/WithdrawSecondViewModel.kt
+++ b/app/src/main/java/com/into/websoso/ui/withdraw/second/WithdrawSecondViewModel.kt
@@ -21,8 +21,8 @@ class WithdrawSecondViewModel
         private val _withdrawReason: MutableLiveData<String> = MutableLiveData("")
         val withdrawReason: LiveData<String> get() = _withdrawReason
 
-        private val _isWithdrawCheckAgree: MutableLiveData<Boolean> = MutableLiveData(false)
-        val isWithdrawCheckAgree: LiveData<Boolean> get() = _isWithdrawCheckAgree
+        private val _isWithdrawAgreementChecked: MutableLiveData<Boolean> = MutableLiveData(false)
+        val isWithdrawAgreementChecked: LiveData<Boolean> get() = _isWithdrawAgreementChecked
 
         private val _isWithdrawButtonEnabled: MediatorLiveData<Boolean> = MediatorLiveData(false)
         val isWithdrawButtonEnabled: LiveData<Boolean> get() = _isWithdrawButtonEnabled
@@ -42,7 +42,7 @@ class WithdrawSecondViewModel
             _isWithdrawButtonEnabled.addSource(withdrawReason) {
                 _isWithdrawButtonEnabled.value = isEnabled()
             }
-            _isWithdrawButtonEnabled.addSource(isWithdrawCheckAgree) {
+            _isWithdrawButtonEnabled.addSource(isWithdrawAgreementChecked) {
                 _isWithdrawButtonEnabled.value = isEnabled()
             }
             _isWithdrawButtonEnabled.addSource(withdrawEtcReason) {
@@ -52,13 +52,13 @@ class WithdrawSecondViewModel
 
         private fun isEnabled(): Boolean {
             val isReasonNotBlank: Boolean = _withdrawReason.value?.isNotBlank() == true
-            val isWithdrawAgree: Boolean = _isWithdrawCheckAgree.value == true
+            val isWithdrawAgreement: Boolean = _isWithdrawAgreementChecked.value == true
             val isEtcReasonValid =
                 _withdrawReason.value == ETC_INPUT_REASON && withdrawEtcReason.value?.isNotBlank() == true
 
             return when {
-                _withdrawReason.value == ETC_INPUT_REASON -> isEtcReasonValid && isWithdrawAgree
-                isReasonNotBlank && isWithdrawAgree -> true
+                _withdrawReason.value == ETC_INPUT_REASON -> isEtcReasonValid && isWithdrawAgreement
+                isReasonNotBlank && isWithdrawAgreement -> true
                 else -> false
             }
         }
@@ -67,8 +67,8 @@ class WithdrawSecondViewModel
             _withdrawReason.value = reason
         }
 
-        fun updateIsWithdrawCheckAgree() {
-            _isWithdrawCheckAgree.value = isWithdrawCheckAgree.value?.not()
+        fun updateIsWithdrawCheckAgreement() {
+            _isWithdrawAgreementChecked.value = isWithdrawAgreementChecked.value?.not()
         }
 
         fun withdraw() {

--- a/app/src/main/java/com/into/websoso/ui/withdraw/second/WithdrawSecondViewModel.kt
+++ b/app/src/main/java/com/into/websoso/ui/withdraw/second/WithdrawSecondViewModel.kt
@@ -67,7 +67,7 @@ class WithdrawSecondViewModel
             _withdrawReason.value = reason
         }
 
-        fun updateIsWithdrawCheckAgreement() {
+        fun updateIsWithdrawAgreementChecked() {
             _isWithdrawAgreementChecked.value = isWithdrawAgreementChecked.value?.not()
         }
 

--- a/app/src/main/java/com/into/websoso/ui/withdraw/second/WithdrawSecondViewModel.kt
+++ b/app/src/main/java/com/into/websoso/ui/withdraw/second/WithdrawSecondViewModel.kt
@@ -26,20 +26,20 @@ class WithdrawSecondViewModel
         private val _isWithdrawAgreementChecked: MutableLiveData<Boolean> = MutableLiveData(false)
         val isWithdrawAgreementChecked: LiveData<Boolean> get() = _isWithdrawAgreementChecked
 
-    private val _isWithdrawButtonEnabled: MediatorLiveData<Boolean> = MediatorLiveData(false)
-    val isWithdrawButtonEnabled: LiveData<Boolean> get() = _isWithdrawButtonEnabled
+        private val _isWithdrawButtonEnabled: MediatorLiveData<Boolean> = MediatorLiveData(false)
+        val isWithdrawButtonEnabled: LiveData<Boolean> get() = _isWithdrawButtonEnabled
 
-    private val _isWithDrawSuccess: MutableLiveData<Boolean> = MutableLiveData(false)
-    val isWithDrawSuccess: LiveData<Boolean> get() = _isWithDrawSuccess
+        private val _isWithDrawSuccess: MutableLiveData<Boolean> = MutableLiveData(false)
+        val isWithDrawSuccess: LiveData<Boolean> get() = _isWithDrawSuccess
 
-    val withdrawEtcReason: MutableLiveData<String> = MutableLiveData()
+        val withdrawEtcReason: MutableLiveData<String> = MutableLiveData()
 
-    val withdrawEtcReasonCount: MediatorLiveData<Int> = MediatorLiveData()
+        val withdrawEtcReasonCount: MediatorLiveData<Int> = MediatorLiveData()
 
-    init {
-        withdrawEtcReasonCount.addSource(withdrawEtcReason) { reason ->
-            withdrawEtcReasonCount.value = reason.length
-        }
+        init {
+            withdrawEtcReasonCount.addSource(withdrawEtcReason) { reason ->
+                withdrawEtcReasonCount.value = reason.length
+            }
 
             _isWithdrawButtonEnabled.addSource(withdrawReason) {
                 _isWithdrawButtonEnabled.value = isEnabled()
@@ -65,9 +65,9 @@ class WithdrawSecondViewModel
             }
         }
 
-    fun updateWithdrawReason(reason: String) {
-        _withdrawReason.value = reason
-    }
+        fun updateWithdrawReason(reason: String) {
+            _withdrawReason.value = reason
+        }
 
         fun updateIsWithdrawAgreementChecked() {
             _isWithdrawAgreementChecked.value = isWithdrawAgreementChecked.value?.not()
@@ -92,7 +92,7 @@ class WithdrawSecondViewModel
             }
         }
 
-    companion object {
-        private const val ETC_INPUT_REASON = "직접입력"
+        companion object {
+            private const val ETC_INPUT_REASON = "직접입력"
+        }
     }
-}

--- a/app/src/main/java/com/into/websoso/ui/withdraw/second/WithdrawSecondViewModel.kt
+++ b/app/src/main/java/com/into/websoso/ui/withdraw/second/WithdrawSecondViewModel.kt
@@ -6,85 +6,90 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.into.websoso.data.repository.AuthRepository
+import com.into.websoso.data.repository.PushMessageRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
-class WithdrawSecondViewModel @Inject constructor(
-    private val authRepository: AuthRepository,
-) : ViewModel() {
-    private val _withdrawReason: MutableLiveData<String> = MutableLiveData("")
-    val withdrawReason: LiveData<String> get() = _withdrawReason
+class WithdrawSecondViewModel
+    @Inject
+    constructor(
+        private val authRepository: AuthRepository,
+        private val pushMessageRepository: PushMessageRepository,
+    ) : ViewModel() {
+        private val _withdrawReason: MutableLiveData<String> = MutableLiveData("")
+        val withdrawReason: LiveData<String> get() = _withdrawReason
 
-    private val _isWithdrawCheckAgree: MutableLiveData<Boolean> = MutableLiveData(false)
-    val isWithdrawCheckAgree: LiveData<Boolean> get() = _isWithdrawCheckAgree
+        private val _isWithdrawCheckAgree: MutableLiveData<Boolean> = MutableLiveData(false)
+        val isWithdrawCheckAgree: LiveData<Boolean> get() = _isWithdrawCheckAgree
 
-    private val _isWithdrawButtonEnabled: MediatorLiveData<Boolean> = MediatorLiveData(false)
-    val isWithdrawButtonEnabled: LiveData<Boolean> get() = _isWithdrawButtonEnabled
+        private val _isWithdrawButtonEnabled: MediatorLiveData<Boolean> = MediatorLiveData(false)
+        val isWithdrawButtonEnabled: LiveData<Boolean> get() = _isWithdrawButtonEnabled
 
-    private val _isWithDrawSuccess: MutableLiveData<Boolean> = MutableLiveData(false)
-    val isWithDrawSuccess: LiveData<Boolean> get() = _isWithDrawSuccess
+        private val _isWithDrawSuccess: MutableLiveData<Boolean> = MutableLiveData(false)
+        val isWithDrawSuccess: LiveData<Boolean> get() = _isWithDrawSuccess
 
-    val withdrawEtcReason: MutableLiveData<String> = MutableLiveData()
+        val withdrawEtcReason: MutableLiveData<String> = MutableLiveData()
 
-    val withdrawEtcReasonCount: MediatorLiveData<Int> = MediatorLiveData()
+        val withdrawEtcReasonCount: MediatorLiveData<Int> = MediatorLiveData()
 
-    init {
-        withdrawEtcReasonCount.addSource(withdrawEtcReason) { reason ->
-            withdrawEtcReasonCount.value = reason.length
-        }
+        init {
+            withdrawEtcReasonCount.addSource(withdrawEtcReason) { reason ->
+                withdrawEtcReasonCount.value = reason.length
+            }
 
-        _isWithdrawButtonEnabled.addSource(withdrawReason) {
-            _isWithdrawButtonEnabled.value = isEnabled()
-        }
-        _isWithdrawButtonEnabled.addSource(isWithdrawCheckAgree) {
-            _isWithdrawButtonEnabled.value = isEnabled()
-        }
-        _isWithdrawButtonEnabled.addSource(withdrawEtcReason) {
-            _isWithdrawButtonEnabled.value = isEnabled()
-        }
-    }
-
-    private fun isEnabled(): Boolean {
-        val isReasonNotBlank: Boolean = _withdrawReason.value?.isNotBlank() == true
-        val isWithdrawAgree: Boolean = _isWithdrawCheckAgree.value == true
-        val isEtcReasonValid =
-            _withdrawReason.value == ETC_INPUT_REASON && withdrawEtcReason.value?.isNotBlank() == true
-
-        return when {
-            _withdrawReason.value == ETC_INPUT_REASON -> isEtcReasonValid && isWithdrawAgree
-            isReasonNotBlank && isWithdrawAgree -> true
-            else -> false
-        }
-    }
-
-    fun updateWithdrawReason(reason: String) {
-        _withdrawReason.value = reason
-    }
-
-    fun updateIsWithdrawCheckAgree() {
-        _isWithdrawCheckAgree.value = isWithdrawCheckAgree.value?.not()
-    }
-
-    fun withdraw() {
-        viewModelScope.launch {
-            runCatching {
-                val withdrawReason = when (withdrawReason.value) {
-                    ETC_INPUT_REASON -> withdrawEtcReason.value
-                    else -> withdrawReason.value
-                } ?: ""
-                authRepository.withdraw(withdrawReason)
-            }.onSuccess {
-                _isWithDrawSuccess.value = true
-                authRepository.updateIsAutoLogin(false)
-            }.onFailure {
-                _isWithDrawSuccess.value = false
+            _isWithdrawButtonEnabled.addSource(withdrawReason) {
+                _isWithdrawButtonEnabled.value = isEnabled()
+            }
+            _isWithdrawButtonEnabled.addSource(isWithdrawCheckAgree) {
+                _isWithdrawButtonEnabled.value = isEnabled()
+            }
+            _isWithdrawButtonEnabled.addSource(withdrawEtcReason) {
+                _isWithdrawButtonEnabled.value = isEnabled()
             }
         }
-    }
 
-    companion object {
-        private const val ETC_INPUT_REASON = "직접입력"
+        private fun isEnabled(): Boolean {
+            val isReasonNotBlank: Boolean = _withdrawReason.value?.isNotBlank() == true
+            val isWithdrawAgree: Boolean = _isWithdrawCheckAgree.value == true
+            val isEtcReasonValid =
+                _withdrawReason.value == ETC_INPUT_REASON && withdrawEtcReason.value?.isNotBlank() == true
+
+            return when {
+                _withdrawReason.value == ETC_INPUT_REASON -> isEtcReasonValid && isWithdrawAgree
+                isReasonNotBlank && isWithdrawAgree -> true
+                else -> false
+            }
+        }
+
+        fun updateWithdrawReason(reason: String) {
+            _withdrawReason.value = reason
+        }
+
+        fun updateIsWithdrawCheckAgree() {
+            _isWithdrawCheckAgree.value = isWithdrawCheckAgree.value?.not()
+        }
+
+        fun withdraw() {
+            viewModelScope.launch {
+                runCatching {
+                    val withdrawReason = when (withdrawReason.value) {
+                        ETC_INPUT_REASON -> withdrawEtcReason.value
+                        else -> withdrawReason.value
+                    } ?: ""
+                    authRepository.withdraw(withdrawReason)
+                }.onSuccess {
+                    _isWithDrawSuccess.value = true
+                    authRepository.updateIsAutoLogin(false)
+                    pushMessageRepository.clearFCMToken()
+                }.onFailure {
+                    _isWithDrawSuccess.value = false
+                }
+            }
+        }
+
+        companion object {
+            private const val ETC_INPUT_REASON = "직접입력"
+        }
     }
-}


### PR DESCRIPTION
## 📌𝘐𝘴𝘴𝘶𝘦𝘴
- closed #583

## 📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯
- 앱 내에서 fcm 토큰을 서버로 업데이트 하는 로직은 로컬에 저장된 fcm 토큰과 파이어베이스에서 받아온 토큰을 비교합니다.
- 이 과정에서 로그아웃 시에는 로컬의 토큰 지우는 로직을 추가했는데, 회원탈퇴에는 안 적어둬서 기존 로컬 토큰이 파베에서 받아온 토큰과 같아 업데이트 하지 못하는 현상이었습니다.
- 따라서 하단의 코드 한 줄로 해결했습니다. (로컬 fcm 토큰 제거 메서드 호출)
- android 13 이상, 미만 전부 확인 완료했습니다.

<img width="542" alt="스크린샷 2025-02-21 오전 12 44 56" src="https://github.com/user-attachments/assets/aff55c56-67c4-416a-8270-f77f2e71321d" />


## 📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵
https://github.com/user-attachments/assets/c0065f8d-ae4f-4d6c-8027-e5def4b04675



## 💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴
N/A