### PR TITLE
bugfix: 컴포즈 뷰 다크모드 상단바 디자인 수정

### DIFF
--- a/app/src/main/java/com/into/websoso/core/common/util/ExtentionFuction.kt
+++ b/app/src/main/java/com/into/websoso/core/common/util/ExtentionFuction.kt
@@ -165,6 +165,7 @@ fun <T> Flow<T>.collectWithLifecycle(
 
 fun Activity.setupWhiteStatusBar() {
     this.window.statusBarColor = White.toArgb()
+
     WindowCompat.getInsetsController(this.window, this.window.decorView).apply {
         isAppearanceLightStatusBars = true
     }

--- a/app/src/main/java/com/into/websoso/core/common/util/ExtentionFuction.kt
+++ b/app/src/main/java/com/into/websoso/core/common/util/ExtentionFuction.kt
@@ -1,5 +1,6 @@
 package com.into.websoso.core.common.util
 
+import android.app.Activity
 import android.content.Context
 import android.content.Intent
 import android.content.res.Resources
@@ -14,6 +15,8 @@ import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.toArgb
+import androidx.core.view.WindowCompat
 import androidx.datastore.core.DataStore
 import androidx.datastore.core.handlers.ReplaceFileCorruptionHandler
 import androidx.datastore.preferences.SharedPreferencesMigration
@@ -28,6 +31,7 @@ import androidx.lifecycle.repeatOnLifecycle
 import com.into.websoso.BuildConfig
 import com.into.websoso.core.common.ui.custom.WebsosoCustomSnackBar
 import com.into.websoso.core.common.ui.custom.WebsosoCustomToast
+import com.into.websoso.core.designsystem.theme.White
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.launch
 import java.io.Serializable
@@ -156,5 +160,12 @@ fun <T> Flow<T>.collectWithLifecycle(
         lifecycleOwner.repeatOnLifecycle(state) {
             collect { collector(it) }
         }
+    }
+}
+
+fun Activity.setupWhiteStatusBar() {
+    this.window.statusBarColor = White.toArgb()
+    WindowCompat.getInsetsController(this.window, this.window.decorView).apply {
+        isAppearanceLightStatusBars = true
     }
 }

--- a/app/src/main/java/com/into/websoso/core/designsystem/theme/Theme.kt
+++ b/app/src/main/java/com/into/websoso/core/designsystem/theme/Theme.kt
@@ -16,34 +16,13 @@ import androidx.compose.ui.platform.LocalContext
 private val DarkColorScheme = darkColorScheme(
     primary = Primary100,
     onPrimary = White,
-    primaryContainer = Primary200,
-    onPrimaryContainer = Gray20,
-    secondary = Secondary100,
-    onSecondary = White,
-    onSecondaryContainer = Gray50,
-    tertiary = Gray300,
     onTertiary = White,
-    background = Black,
-    onBackground = Gray20,
-    onSurface = Gray200,
-    onError = White,
 )
 
 private val LightColorScheme = lightColorScheme(
     primary = Primary100,
     onPrimary = White,
-    primaryContainer = Primary50,
-    onPrimaryContainer = Gray20,
-    secondary = Secondary100,
-    onSecondary = White,
-    onSecondaryContainer = Gray50,
-    tertiary = Gray300,
     onTertiary = Black,
-    background = White,
-    onBackground = Gray300,
-    surface = Gray20,
-    onSurface = Gray70,
-    onError = White,
 )
 
 private val LocalWebsosoTypography = staticCompositionLocalOf<WebsosoTypography> {

--- a/app/src/main/java/com/into/websoso/ui/notification/NotificationActivity.kt
+++ b/app/src/main/java/com/into/websoso/ui/notification/NotificationActivity.kt
@@ -7,6 +7,7 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.viewModels
 import com.into.websoso.core.common.ui.model.ResultFrom
+import com.into.websoso.core.common.util.setupWhiteStatusBar
 import com.into.websoso.core.designsystem.theme.WebsosoTheme
 import com.into.websoso.ui.feedDetail.FeedDetailActivity
 import com.into.websoso.ui.notification.model.NotificationModel
@@ -19,6 +20,7 @@ class NotificationActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        this.setupWhiteStatusBar()
 
         setContent {
             WebsosoTheme {

--- a/app/src/main/java/com/into/websoso/ui/notification/NotificationScreen.kt
+++ b/app/src/main/java/com/into/websoso/ui/notification/NotificationScreen.kt
@@ -1,12 +1,14 @@
 package com.into.websoso.ui.notification
 
 import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.into.websoso.core.designsystem.theme.White
 import com.into.websoso.ui.notification.component.NotificationAppBar
 import com.into.websoso.ui.notification.component.NotificationsContainer
 import com.into.websoso.ui.notification.model.NotificationModel
@@ -24,7 +26,11 @@ fun NotificationScreen(
         onBackButtonClick()
     }
 
-    Column(modifier = Modifier.fillMaxSize()) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(White),
+    ) {
         NotificationAppBar(onBackButtonClick)
         NotificationsContainer(
             notifications = uiState.notifications,

--- a/app/src/main/java/com/into/websoso/ui/notification/component/NotificationAppBar.kt
+++ b/app/src/main/java/com/into/websoso/ui/notification/component/NotificationAppBar.kt
@@ -1,6 +1,7 @@
 package com.into.websoso.ui.notification.component
 
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -20,6 +21,7 @@ import com.into.websoso.R
 import com.into.websoso.core.common.util.clickableWithoutRipple
 import com.into.websoso.core.designsystem.theme.Black
 import com.into.websoso.core.designsystem.theme.WebsosoTheme
+import com.into.websoso.core.designsystem.theme.White
 
 @Composable
 fun NotificationAppBar(
@@ -28,6 +30,7 @@ fun NotificationAppBar(
 ) {
     Row(
         modifier = modifier
+            .background(White)
             .fillMaxWidth()
             .padding(horizontal = 6.dp)
             .height(44.dp),

--- a/app/src/main/java/com/into/websoso/ui/notificationDetail/NotificationDetailActivity.kt
+++ b/app/src/main/java/com/into/websoso/ui/notificationDetail/NotificationDetailActivity.kt
@@ -7,6 +7,7 @@ import androidx.activity.ComponentActivity
 import androidx.activity.addCallback
 import androidx.activity.compose.setContent
 import androidx.activity.viewModels
+import com.into.websoso.core.common.util.setupWhiteStatusBar
 import com.into.websoso.core.designsystem.theme.WebsosoTheme
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -16,7 +17,10 @@ class NotificationDetailActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        this.setupWhiteStatusBar()
+
         handleBackPressed()
+
         setContent {
             WebsosoTheme {
                 NotificationDetailScreen(

--- a/app/src/main/java/com/into/websoso/ui/notificationDetail/NotificationDetailActivity.kt
+++ b/app/src/main/java/com/into/websoso/ui/notificationDetail/NotificationDetailActivity.kt
@@ -17,7 +17,6 @@ class NotificationDetailActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         handleBackPressed()
-
         setContent {
             WebsosoTheme {
                 NotificationDetailScreen(

--- a/app/src/main/java/com/into/websoso/ui/notificationDetail/NotificationDetailScreen.kt
+++ b/app/src/main/java/com/into/websoso/ui/notificationDetail/NotificationDetailScreen.kt
@@ -1,5 +1,6 @@
 package com.into.websoso.ui.notificationDetail
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
@@ -8,6 +9,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.into.websoso.core.designsystem.theme.WebsosoTheme
+import com.into.websoso.core.designsystem.theme.White
 import com.into.websoso.data.model.NotificationDetailEntity
 import com.into.websoso.ui.notification.component.NotificationAppBar
 import com.into.websoso.ui.notificationDetail.component.NotificationDetailContent
@@ -21,7 +23,11 @@ fun NotificationDetailScreen(
 ) {
     val uiState by viewModel.notificationDetailUiState.collectAsStateWithLifecycle()
 
-    Column(modifier = modifier.fillMaxSize()) {
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .background(White),
+    ) {
         NotificationAppBar(onBackButtonClick)
         NotificationDetailContent(
             uiState = uiState,


### PR DESCRIPTION
## 📌𝘐𝘴𝘴𝘶𝘦𝘴
- closed #592

## 📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯
- 상단바 다크모드 대응 확장함수 추가
- 일부 배경이 적용되지 않은 컴포넌트 배경 추가

## 📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵
<img width="335" alt="image" src="https://github.com/user-attachments/assets/1bf653c1-3ae7-459a-bcef-4b527c4439c1" />


## 💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴