### PR TITLE
bugfix: 약관동의 확인 다이얼로그 외부터치 금지 구현

### DIFF
--- a/app/src/main/java/com/into/websoso/ui/main/home/dialog/TermsAgreementDialogFragment.kt
+++ b/app/src/main/java/com/into/websoso/ui/main/home/dialog/TermsAgreementDialogFragment.kt
@@ -14,8 +14,13 @@ class TermsAgreementDialogFragment :
         savedInstanceState: Bundle?,
     ) {
         super.onViewCreated(view, savedInstanceState)
-        isCancelable = false
+        setupDialog()
         onTermsAgreementPopupMenuUpdateClick()
+    }
+
+    private fun setupDialog() {
+        isCancelable = false
+        setCancelable(false)
     }
 
     private fun onTermsAgreementPopupMenuUpdateClick() {


### PR DESCRIPTION
## 📌𝘐𝘴𝘴𝘶𝘦𝘴
- closed #596 

## 📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯
- 약관동의 확인 다이얼로그 외부터치 or 뒤로가기 막아두기

## 📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵
[Screen_recording_20250222_205248.webm](https://github.com/user-attachments/assets/dd2d7c11-57dd-4e13-8417-86c28a1042f5)

## 💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴