### PR TITLE
fix: 프로필 설명 글이 짤린 현상

### DIFF
--- a/app/src/main/res/layout/activity_other_user_page.xml
+++ b/app/src/main/res/layout/activity_other_user_page.xml
@@ -29,7 +29,7 @@
 
                 <com.google.android.material.appbar.CollapsingToolbarLayout
                     android:layout_width="match_parent"
-                    android:layout_height="260dp"
+                    android:layout_height="272dp"
                     android:background="@color/transparent"
                     app:collapsedTitleGravity="center"
                     app:layout_scrollFlags="scroll|exitUntilCollapsed">
@@ -41,6 +41,7 @@
                         android:adjustViewBounds="true"
                         android:background="@color/primary_20_F5F7FF"
                         android:paddingTop="36dp"
+                        android:paddingBottom="12dp"
                         app:layout_collapseMode="parallax">
 
                         <ImageView
@@ -70,10 +71,11 @@
                             android:id="@+id/tv_other_user_page_user_description"
                             android:layout_width="0dp"
                             android:layout_height="wrap_content"
-                            android:layout_marginTop="4dp"
                             android:layout_marginHorizontal="20dp"
-                            android:paddingBottom="30dp"
+                            android:layout_marginTop="6dp"
                             android:gravity="center"
+                            android:maxLines="2"
+                            android:paddingBottom="30dp"
                             android:text='@{otherUserPageViewModel.uiState.otherUserProfile.intro}'
                             android:textAppearance="@style/body2"
                             android:textColor="@color/gray_200_AEADB3"
@@ -197,11 +199,11 @@
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:layout_gravity="center"
-                            android:src="@drawable/img_other_user_page_no_public"
                             android:layout_marginTop="100dp"
-                            app:layout_constraintTop_toTopOf="parent"
+                            android:src="@drawable/img_other_user_page_no_public"
+                            app:layout_constraintEnd_toEndOf="parent"
                             app:layout_constraintStart_toStartOf="parent"
-                            app:layout_constraintEnd_toEndOf="parent"/>
+                            app:layout_constraintTop_toTopOf="parent" />
 
                         <TextView
                             android:id="@+id/tv_other_user_page_no_public_message"
@@ -212,9 +214,9 @@
                             android:text='@{String.format(@string/other_user_page_no_public, otherUserPageViewModel.uiState.otherUserProfile.nickname)}'
                             android:textAppearance="@style/body2"
                             android:textColor="@color/gray_200_AEADB3"
-                            app:layout_constraintTop_toBottomOf="@id/iv_other_user_page_no_public"
+                            app:layout_constraintEnd_toEndOf="parent"
                             app:layout_constraintStart_toStartOf="parent"
-                            app:layout_constraintEnd_toEndOf="parent"/>
+                            app:layout_constraintTop_toBottomOf="@id/iv_other_user_page_no_public" />
 
                     </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/app/src/main/res/layout/fragment_my_page.xml
+++ b/app/src/main/res/layout/fragment_my_page.xml
@@ -29,7 +29,7 @@
 
                 <com.google.android.material.appbar.CollapsingToolbarLayout
                     android:layout_width="match_parent"
-                    android:layout_height="260dp"
+                    android:layout_height="272dp"
                     android:background="@color/transparent"
                     app:collapsedTitleGravity="center"
                     app:layout_scrollFlags="scroll|exitUntilCollapsed">
@@ -41,6 +41,7 @@
                         android:adjustViewBounds="true"
                         android:background="@color/primary_20_F5F7FF"
                         android:paddingTop="36dp"
+                        android:paddingBottom="12dp"
                         app:layout_collapseMode="parallax">
 
                         <ImageView
@@ -83,10 +84,11 @@
                             android:id="@+id/tv_my_page_user_description"
                             android:layout_width="0dp"
                             android:layout_height="wrap_content"
-                            android:layout_marginTop="4dp"
                             android:layout_marginHorizontal="20dp"
-                            android:paddingBottom="30dp"
+                            android:layout_marginTop="6dp"
                             android:gravity="center"
+                            android:maxLines="2"
+                            android:paddingBottom="30dp"
                             android:text='@{myPageViewModel.uiState.myProfile.intro}'
                             android:textAppearance="@style/body2"
                             android:textColor="@color/gray_200_AEADB3"


### PR DESCRIPTION
## 📌𝘐𝘴𝘴𝘶𝘦𝘴
- closed #604

## 📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯
- 프로필 설명 글 짤리는 현상 해결했습니다
- maxline 2 걸고, 다른 값들 조금씩 조정스 했어요

## 📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵


- 360*760 으로 확인함

https://github.com/user-attachments/assets/e6e3ae34-937e-4089-91e8-9ab10c0bca69


## 💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴