### PR TITLE
fix: 피드 디테일에서 뒤로 갔을 때 위치 수정

### DIFF
--- a/app/src/main/java/com/into/websoso/ui/feedDetail/FeedDetailActivity.kt
+++ b/app/src/main/java/com/into/websoso/ui/feedDetail/FeedDetailActivity.kt
@@ -118,7 +118,8 @@ class FeedDetailActivity : BaseActivity<ActivityFeedDetailBinding>(activity_feed
                     false -> likeCount + 1
                 }
 
-                view.findViewById<TextView>(tv_feed_thumb_up_count).text = updatedLikeCount.toString()
+                view.findViewById<TextView>(tv_feed_thumb_up_count).text =
+                    updatedLikeCount.toString()
                 view.isSelected = !view.isSelected
 
                 singleEventHandler.debounce(coroutineScope = lifecycleScope) {
@@ -367,6 +368,7 @@ class FeedDetailActivity : BaseActivity<ActivityFeedDetailBinding>(activity_feed
                         val nickname = result.data?.getStringExtra(USER_NICKNAME).orEmpty()
                         val intent = Intent().apply {
                             putExtra(USER_NICKNAME, nickname)
+                            putExtra(FEED_ID, feedId)
                         }
                         setResult(BlockUser.RESULT_OK, intent)
                         if (!isFinishing) finish()
@@ -467,14 +469,16 @@ class FeedDetailActivity : BaseActivity<ActivityFeedDetailBinding>(activity_feed
                                 }.show(supportFragmentManager, RemovedFeedDialogFragment.TAG)
 
                         else -> {
-                            setResult(FeedDetailRemoved.RESULT_OK)
+                            val extraIntent = Intent().apply { putExtra(FEED_ID, feedId) }
+                            setResult(FeedDetailRemoved.RESULT_OK, extraIntent)
                             if (!isFinishing) finish()
                         }
                     }
                 }
 
                 feedDetailUiState.isServerError -> {
-                    setResult(FeedDetailError.RESULT_OK)
+                    val extraIntent = Intent().apply { putExtra(FEED_ID, feedId) }
+                    setResult(FeedDetailError.RESULT_OK, extraIntent)
                     if (!isFinishing) finish()
                 }
 
@@ -537,7 +541,7 @@ class FeedDetailActivity : BaseActivity<ActivityFeedDetailBinding>(activity_feed
     }
 
     companion object {
-        private const val FEED_ID: String = "FEED_ID"
+        const val FEED_ID: String = "FEED_ID"
         private const val DEFAULT_FEED_ID: Long = -1
         private const val NOTIFICATION_ID: String = "NOTIFICATION_ID"
         private const val LOTTIE_IMAGE = "lottie_websoso_loading.json"

--- a/app/src/main/java/com/into/websoso/ui/main/feed/FeedFragment.kt
+++ b/app/src/main/java/com/into/websoso/ui/main/feed/FeedFragment.kt
@@ -87,7 +87,7 @@ class FeedFragment : BaseFragment<FragmentFeedBinding>(fragment_feed) {
         when (result.resultCode) {
             CreateFeed.RESULT_OK -> {
                 feedViewModel.updateRefreshedFeeds(true)
-                // 피드 아예 초기화
+                // TODO: 피드 아예 초기화
 
                 showWebsosoSnackBar(
                     view = binding.root,
@@ -430,9 +430,8 @@ class FeedFragment : BaseFragment<FragmentFeedBinding>(fragment_feed) {
                 val chip = it as Chip
                 chip.isSelected = chip.text == selectedCategory.category.krTitle
             }
-
-            // 최초로 init할 때 전체상태로 updateFeeds 호출함 -> 리프레시되어야하기 때문에 true 설정
-            // 뷰모델 init으로 옮기기, isRefreshed 상태 없애기
+            // TODO: 최초로 init할 때 전체상태로 updateFeeds 호출함 -> 리프레시되어야하기 때문에 true 설정
+            // TODO: 뷰모델 init으로 옮기기, isRefreshed 상태 없애기
             feedViewModel.updateFeeds(true)
         }
     }

--- a/app/src/main/java/com/into/websoso/ui/main/feed/FeedFragment.kt
+++ b/app/src/main/java/com/into/websoso/ui/main/feed/FeedFragment.kt
@@ -1,7 +1,6 @@
 package com.into.websoso.ui.main.feed
 
 import android.annotation.SuppressLint
-import android.content.Intent
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -9,7 +8,7 @@ import android.view.ViewGroup
 import android.view.WindowManager
 import android.widget.PopupWindow
 import android.widget.TextView
-import androidx.activity.result.ActivityResultLauncher
+import androidx.activity.result.ActivityResult
 import androidx.activity.result.contract.ActivityResultContracts.StartActivityForResult
 import androidx.core.view.children
 import androidx.core.view.isVisible
@@ -32,11 +31,8 @@ import com.into.websoso.core.common.ui.base.BaseFragment
 import com.into.websoso.core.common.ui.custom.WebsosoChip
 import com.into.websoso.core.common.ui.model.ResultFrom.BlockUser
 import com.into.websoso.core.common.ui.model.ResultFrom.CreateFeed
-import com.into.websoso.core.common.ui.model.ResultFrom.FeedDetailBack
 import com.into.websoso.core.common.ui.model.ResultFrom.FeedDetailError
 import com.into.websoso.core.common.ui.model.ResultFrom.FeedDetailRemoved
-import com.into.websoso.core.common.ui.model.ResultFrom.NovelDetailBack
-import com.into.websoso.core.common.ui.model.ResultFrom.OtherUserProfileBack
 import com.into.websoso.core.common.ui.model.ResultFrom.WithdrawUser
 import com.into.websoso.core.common.util.InfiniteScrollListener
 import com.into.websoso.core.common.util.SingleEventHandler
@@ -50,6 +46,7 @@ import com.into.websoso.databinding.FragmentFeedBinding
 import com.into.websoso.databinding.MenuFeedPopupBinding
 import com.into.websoso.ui.createFeed.CreateFeedActivity
 import com.into.websoso.ui.feedDetail.FeedDetailActivity
+import com.into.websoso.ui.feedDetail.FeedDetailActivity.Companion.FEED_ID
 import com.into.websoso.ui.feedDetail.model.EditFeedModel
 import com.into.websoso.ui.main.feed.adapter.FeedAdapter
 import com.into.websoso.ui.main.feed.adapter.FeedType.Feed
@@ -80,7 +77,69 @@ class FeedFragment : BaseFragment<FragmentFeedBinding>(fragment_feed) {
     private val feedViewModel: FeedViewModel by viewModels()
     private val feedAdapter: FeedAdapter by lazy { FeedAdapter(onClickFeedItem()) }
     private val singleEventHandler: SingleEventHandler by lazy { SingleEventHandler.from() }
-    private lateinit var activityResultCallback: ActivityResultLauncher<Intent>
+    private val activityResultCallback by lazy {
+        registerForActivityResult(StartActivityForResult()) { result ->
+            handleActivityResult(result)
+        }
+    }
+
+    private fun handleActivityResult(result: ActivityResult) {
+        when (result.resultCode) {
+            CreateFeed.RESULT_OK -> {
+                feedViewModel.updateRefreshedFeeds(true)
+                // 피드 아예 초기화
+
+                showWebsosoSnackBar(
+                    view = binding.root,
+                    message = getString(feed_create_done),
+                    icon = ic_novel_detail_check,
+                )
+            }
+
+            FeedDetailRemoved.RESULT_OK -> {
+                val removedFeedId = result.data?.getLongExtra(FEED_ID, -1) ?: -1
+                feedViewModel.updateRefreshedFeeds(removedFeedId)
+
+                showWebsosoSnackBar(
+                    view = binding.root,
+                    message = getString(feed_removed_feed_snackbar),
+                    icon = ic_blocked_user_snack_bar,
+                )
+            }
+
+            FeedDetailError.RESULT_OK -> {
+                val removedFeedId = result.data?.getLongExtra(FEED_ID, -1) ?: -1
+                feedViewModel.updateRefreshedFeeds(removedFeedId)
+
+                showWebsosoSnackBar(
+                    view = binding.root,
+                    message = getString(feed_server_error),
+                    icon = ic_blocked_user_snack_bar,
+                )
+            }
+
+            BlockUser.RESULT_OK -> {
+                val nickname = result.data?.getStringExtra(USER_NICKNAME).orEmpty()
+                val removedFeedId = result.data?.getLongExtra(FEED_ID, -1) ?: -1
+
+                feedViewModel.updateRefreshedFeeds(removedFeedId)
+
+                showWebsosoSnackBar(
+                    view = binding.root,
+                    message = getString(block_user_success_message, nickname),
+                    icon = ic_novel_detail_check,
+                )
+            }
+
+            WithdrawUser.RESULT_OK -> {
+                showWebsosoSnackBar(
+                    view = binding.root,
+                    message = getString(R.string.other_user_page_withdraw_user),
+                    icon = ic_blocked_user_snack_bar,
+                )
+            }
+        }
+    }
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -134,7 +193,8 @@ class FeedFragment : BaseFragment<FragmentFeedBinding>(fragment_feed) {
                     false -> likeCount + 1
                 }
 
-                view.findViewById<TextView>(tv_feed_thumb_up_count).text = updatedLikeCount.toString()
+                view.findViewById<TextView>(tv_feed_thumb_up_count).text =
+                    updatedLikeCount.toString()
                 view.isSelected = !view.isSelected
 
                 singleEventHandler.debounce(coroutineScope = lifecycleScope) {
@@ -296,71 +356,8 @@ class FeedFragment : BaseFragment<FragmentFeedBinding>(fragment_feed) {
 
         initView()
         setupObserver()
-        refreshView()
+        activityResultCallback
         tracker.trackEvent("feed_all")
-    }
-
-    private fun refreshView() {
-        if (::activityResultCallback.isInitialized.not()) {
-            activityResultCallback = registerForActivityResult(StartActivityForResult()) { result ->
-                when (result.resultCode) {
-                    FeedDetailBack.RESULT_OK,
-                    NovelDetailBack.RESULT_OK,
-                    OtherUserProfileBack.RESULT_OK,
-                    -> feedViewModel.updateRefreshedFeeds(false)
-
-                    CreateFeed.RESULT_OK -> {
-                        feedViewModel.updateRefreshedFeeds(true)
-
-                        showWebsosoSnackBar(
-                            view = binding.root,
-                            message = getString(feed_create_done),
-                            icon = ic_novel_detail_check,
-                        )
-                    }
-
-                    FeedDetailRemoved.RESULT_OK -> {
-                        feedViewModel.updateRefreshedFeeds(false)
-
-                        showWebsosoSnackBar(
-                            view = binding.root,
-                            message = getString(feed_removed_feed_snackbar),
-                            icon = ic_blocked_user_snack_bar,
-                        )
-                    }
-
-                    FeedDetailError.RESULT_OK -> {
-                        feedViewModel.updateRefreshedFeeds(false)
-
-                        showWebsosoSnackBar(
-                            view = binding.root,
-                            message = getString(feed_server_error),
-                            icon = ic_blocked_user_snack_bar,
-                        )
-                    }
-
-                    BlockUser.RESULT_OK -> {
-                        feedViewModel.updateRefreshedFeeds(false)
-
-                        val nickname = result.data?.getStringExtra(USER_NICKNAME).orEmpty()
-
-                        showWebsosoSnackBar(
-                            view = binding.root,
-                            message = getString(block_user_success_message, nickname),
-                            icon = ic_novel_detail_check,
-                        )
-                    }
-
-                    WithdrawUser.RESULT_OK -> {
-                        showWebsosoSnackBar(
-                            view = binding.root,
-                            message = getString(R.string.other_user_page_withdraw_user),
-                            icon = ic_blocked_user_snack_bar,
-                        )
-                    }
-                }
-            }
-        }
     }
 
     private fun initView() {
@@ -434,6 +431,8 @@ class FeedFragment : BaseFragment<FragmentFeedBinding>(fragment_feed) {
                 chip.isSelected = chip.text == selectedCategory.category.krTitle
             }
 
+            // 최초로 init할 때 전체상태로 updateFeeds 호출함 -> 리프레시되어야하기 때문에 true 설정
+            // 뷰모델 init으로 옮기기, isRefreshed 상태 없애기
             feedViewModel.updateFeeds(true)
         }
     }

--- a/app/src/main/java/com/into/websoso/ui/main/feed/FeedViewModel.kt
+++ b/app/src/main/java/com/into/websoso/ui/main/feed/FeedViewModel.kt
@@ -51,6 +51,10 @@ class FeedViewModel @Inject constructor(
     }
 
     fun updateFeeds(isRefreshed: Boolean = false) {
+        // 피드 아이템 더 불러오기 함수
+        // 카테고리 누를 시 init 함수
+        // 새로고침 함수
+        // 모두 분리하기
         feedUiState.value?.let { feedUiState ->
             if (!feedUiState.isLoadable) return
 
@@ -63,7 +67,7 @@ class FeedViewModel @Inject constructor(
                     when (feedUiState.feeds.isNotEmpty()) {
                         true -> getFeedsUseCase(
                             selectedCategory.enTitle,
-                            feedUiState.feeds.minOf { it.id }
+                            feedUiState.feeds.minOf { it.id },
                         )
 
                         false -> getFeedsUseCase(selectedCategory.enTitle)
@@ -147,6 +151,14 @@ class FeedViewModel @Inject constructor(
         }
     }
 
+    fun updateRefreshedFeeds(feedId: Long) {
+        feedUiState.value?.let { feedUiState ->
+            _feedUiState.value = feedUiState.copy(
+                feeds = feedUiState.feeds.filterNot { it.id == feedId },
+            )
+        }
+    }
+
     fun updateLike(selectedFeedId: Long, isLiked: Boolean, updatedLikeCount: Int) {
         feedUiState.value?.let { feedUiState ->
             val selectedFeed = feedUiState.feeds.find { feedModel ->
@@ -227,7 +239,7 @@ class FeedViewModel @Inject constructor(
                 }.onSuccess {
                     _feedUiState.value = feedUiState.copy(
                         loading = false,
-                        feeds = feedUiState.feeds.filter { it.id != feedId }
+                        feeds = feedUiState.feeds.filter { it.id != feedId },
                     )
                 }.onFailure {
                     _feedUiState.value = feedUiState.copy(

--- a/app/src/main/java/com/into/websoso/ui/main/feed/FeedViewModel.kt
+++ b/app/src/main/java/com/into/websoso/ui/main/feed/FeedViewModel.kt
@@ -51,10 +51,10 @@ class FeedViewModel @Inject constructor(
     }
 
     fun updateFeeds(isRefreshed: Boolean = false) {
-        // 피드 아이템 더 불러오기 함수
-        // 카테고리 누를 시 init 함수
-        // 새로고침 함수
-        // 모두 분리하기
+        // TODO: 피드 아이템 더 불러오기 함수
+        // TODO: 카테고리 누를 시 init 함수
+        // TODO: 새로고침 함수
+        // TODO: 모두 분리하기
         feedUiState.value?.let { feedUiState ->
             if (!feedUiState.isLoadable) return
 


### PR DESCRIPTION
## 📌𝘐𝘴𝘴𝘶𝘦𝘴
- closed #603 

## 📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯
- [ 피드 탭 -> 피드 스크롤, 피드 더 불러오기 -> 피드 클릭 후 피드 상세보기 진입 -> 뒤로가기 ] 해당 플로우일 경우, 피드탭이 초기화 되는 버그를 수정했습니다.

## 📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵


## 💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴
피드 디테일에서 뒤로가기 하는 경우 뿐만 아니라, 피드 탭에서 다른 뷰를 다녀오면 어떤 경우든 발생하는 버그였습니다.
원인은 다른뷰에 다녀올 때, 기존에 캐싱된 피드를 새롭게 호출한 피드들로 덮어쓰기하여 기존에 추가된 피드(더 불러오기로 추가된 피드)들이 다 날아가는 문제였습니다.
결과적으로, 피드탭에서 UI/UX로 제공하는 새로고침 기능을 제외하곤 더 이상 피드를 새로고침하지 않으며, 
1. 삭제된 피드
2. 차단된 피드
3. 신고누적된 피드
4. 그 외 접근 불가한 피드

다음과 같은 경우엔 해당 피드만 UI에서 숨김처리 해놓도록 구현해놓았습니다.

추가로 뷰모델 로직개선 작업이 이어질 예정입니다 .. 
여러분은 항상 DRY 원칙을 경계해야 합니다...
작년엔 한참 고민중이었고, 지금은 나름 깨우쳤는데.. 작년의 스노우볼이 이렇게 크군요 :(