### PR TITLE
fix: ‘작성완료!’ 토스트 노출 버그

### DIFF
--- a/app/src/main/java/com/into/websoso/ui/feedDetail/FeedDetailActivity.kt
+++ b/app/src/main/java/com/into/websoso/ui/feedDetail/FeedDetailActivity.kt
@@ -464,7 +464,8 @@ class FeedDetailActivity : BaseActivity<ActivityFeedDetailBinding>(activity_feed
                         CreateFeed, FeedDetailRefreshed ->
                             RemovedFeedDialogFragment
                                 .newInstance {
-                                    setResult(CreateFeed.RESULT_OK)
+                                    val extraIntent = Intent().apply { putExtra(FEED_ID, feedId) }
+                                    setResult(FeedDetailRefreshed.RESULT_OK, extraIntent)
                                     if (!isFinishing) finish()
                                 }.show(supportFragmentManager, RemovedFeedDialogFragment.TAG)
 

--- a/app/src/main/java/com/into/websoso/ui/main/feed/FeedFragment.kt
+++ b/app/src/main/java/com/into/websoso/ui/main/feed/FeedFragment.kt
@@ -29,7 +29,12 @@ import com.into.websoso.R.string.feed_removed_feed_snackbar
 import com.into.websoso.R.string.feed_server_error
 import com.into.websoso.core.common.ui.base.BaseFragment
 import com.into.websoso.core.common.ui.custom.WebsosoChip
-import com.into.websoso.core.common.ui.model.ResultFrom.*
+import com.into.websoso.core.common.ui.model.ResultFrom.BlockUser
+import com.into.websoso.core.common.ui.model.ResultFrom.CreateFeed
+import com.into.websoso.core.common.ui.model.ResultFrom.FeedDetailError
+import com.into.websoso.core.common.ui.model.ResultFrom.FeedDetailRefreshed
+import com.into.websoso.core.common.ui.model.ResultFrom.FeedDetailRemoved
+import com.into.websoso.core.common.ui.model.ResultFrom.WithdrawUser
 import com.into.websoso.core.common.util.InfiniteScrollListener
 import com.into.websoso.core.common.util.SingleEventHandler
 import com.into.websoso.core.common.util.showWebsosoSnackBar

--- a/app/src/main/java/com/into/websoso/ui/main/feed/FeedFragment.kt
+++ b/app/src/main/java/com/into/websoso/ui/main/feed/FeedFragment.kt
@@ -29,11 +29,7 @@ import com.into.websoso.R.string.feed_removed_feed_snackbar
 import com.into.websoso.R.string.feed_server_error
 import com.into.websoso.core.common.ui.base.BaseFragment
 import com.into.websoso.core.common.ui.custom.WebsosoChip
-import com.into.websoso.core.common.ui.model.ResultFrom.BlockUser
-import com.into.websoso.core.common.ui.model.ResultFrom.CreateFeed
-import com.into.websoso.core.common.ui.model.ResultFrom.FeedDetailError
-import com.into.websoso.core.common.ui.model.ResultFrom.FeedDetailRemoved
-import com.into.websoso.core.common.ui.model.ResultFrom.WithdrawUser
+import com.into.websoso.core.common.ui.model.ResultFrom.*
 import com.into.websoso.core.common.util.InfiniteScrollListener
 import com.into.websoso.core.common.util.SingleEventHandler
 import com.into.websoso.core.common.util.showWebsosoSnackBar
@@ -85,6 +81,11 @@ class FeedFragment : BaseFragment<FragmentFeedBinding>(fragment_feed) {
 
     private fun handleActivityResult(result: ActivityResult) {
         when (result.resultCode) {
+            FeedDetailRefreshed.RESULT_OK -> {
+                val removedFeedId = result.data?.getLongExtra(FEED_ID, -1) ?: -1
+                feedViewModel.updateRefreshedFeeds(removedFeedId)
+            }
+
             CreateFeed.RESULT_OK -> {
                 feedViewModel.updateRefreshedFeeds(true)
                 // TODO: 피드 아예 초기화
@@ -356,8 +357,8 @@ class FeedFragment : BaseFragment<FragmentFeedBinding>(fragment_feed) {
 
         initView()
         setupObserver()
-        activityResultCallback
         tracker.trackEvent("feed_all")
+        activityResultCallback
     }
 
     private fun initView() {


### PR DESCRIPTION
## 📌𝘐𝘴𝘴𝘶𝘦𝘴
- closed #606 

## 📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯
피드 상세보기 뷰,
1. 새로고침 후 error 상태가 되었을 때 '해당 글을 찾을 수 없어요' 다이얼로그 '확인' 클릭한 경우 
2. 내 피드 수정하기 후 다시 돌아왔는 데 error 상태가 되었을 때 '해당 글을 찾을 수 없어요' 다이얼로그 '확인' 클릭한 경우
피드 뷰로 돌아왔을 때, '작성완료!' 토스트가 뜨는 버그 해결

## 💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴