### PR TITLE
fix: WebsosoAuthenticator 401 로직 수정

### DIFF
--- a/app/src/main/java/com/into/websoso/WebsosoApp.kt
+++ b/app/src/main/java/com/into/websoso/WebsosoApp.kt
@@ -2,16 +2,32 @@ package com.into.websoso
 
 import android.app.Application
 import androidx.appcompat.app.AppCompatDelegate
-import com.kakao.sdk.common.KakaoSdk
 import com.into.websoso.BuildConfig.KAKAO_APP_KEY
+import com.into.websoso.data.authenticator.AuthFailureHandler
+import com.into.websoso.data.repository.AuthRepository
+import com.into.websoso.ui.login.LoginActivity
+import com.kakao.sdk.common.KakaoSdk
+import com.kakao.sdk.user.UserApiClient
 import dagger.hilt.android.HiltAndroidApp
+import javax.inject.Inject
 
 @HiltAndroidApp
-class WebsosoApp : Application() {
+class WebsosoApp :
+    Application(),
+    AuthFailureHandler {
+    @Inject
+    lateinit var authRepository: AuthRepository
+
     override fun onCreate() {
         super.onCreate()
+        authRepository.authFailureHandler = this
         AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_NO)
-
         KakaoSdk.init(this, KAKAO_APP_KEY)
+    }
+
+    override fun onAuthFailed() {
+        UserApiClient.instance.logout {
+            this.startActivity(LoginActivity.getIntent(this))
+        }
     }
 }

--- a/app/src/main/java/com/into/websoso/data/authenticator/AuthFailureHandler.kt
+++ b/app/src/main/java/com/into/websoso/data/authenticator/AuthFailureHandler.kt
@@ -1,0 +1,5 @@
+package com.into.websoso.data.authenticator
+
+interface AuthFailureHandler {
+    fun onAuthFailed()
+}

--- a/app/src/main/java/com/into/websoso/data/authenticator/WebsosoAuthenticator.kt
+++ b/app/src/main/java/com/into/websoso/data/authenticator/WebsosoAuthenticator.kt
@@ -1,10 +1,6 @@
 package com.into.websoso.data.authenticator
 
-import android.content.Context
-import com.kakao.sdk.user.UserApiClient
 import com.into.websoso.data.repository.AuthRepository
-import com.into.websoso.ui.login.LoginActivity
-import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.runBlocking
 import okhttp3.Authenticator
 import okhttp3.Request
@@ -14,35 +10,32 @@ import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
-class WebsosoAuthenticator @Inject constructor(
-    private val authRepository: AuthRepository,
-    @ApplicationContext private val context: Context,
-) : Authenticator {
-
-    override fun authenticate(route: Route?, response: Response): Request? {
-        if (response.request.header("Authorization") == null) {
-            return null
-        }
-
-        if (response.code == 401) {
-            if (authRepository.refreshToken.isBlank()) {
+class WebsosoAuthenticator
+    @Inject
+    constructor(
+        private val authRepository: AuthRepository,
+    ) : Authenticator {
+        override fun authenticate(
+            route: Route?,
+            response: Response,
+        ): Request? {
+            if (response.request.header("Authorization") == null) {
                 return null
             }
 
-            val newAccessToken = runCatching {
-                runBlocking {
-                    authRepository.reissueToken()
-                }
-            }.onFailure {
-                runBlocking {
-                    authRepository.clearTokens()
-                    UserApiClient.instance.logout {
-                        context.startActivity(LoginActivity.getIntent(context))
+            if (response.code == 401) {
+                val newAccessToken = runCatching {
+                    runBlocking {
+                        authRepository.reissueToken()
                     }
+                }.onFailure {
+                    runBlocking {
+                        authRepository.clearTokens()
                 }
             }.getOrThrow()
 
-            return response.request.newBuilder()
+            return response.request
+                .newBuilder()
                 .header("Authorization", "Bearer $newAccessToken")
                 .build()
         }

--- a/app/src/main/java/com/into/websoso/data/repository/AuthRepository.kt
+++ b/app/src/main/java/com/into/websoso/data/repository/AuthRepository.kt
@@ -1,6 +1,7 @@
 package com.into.websoso.data.repository
 
 import android.content.SharedPreferences
+import com.into.websoso.data.authenticator.AuthFailureHandler
 import com.into.websoso.data.mapper.toData
 import com.into.websoso.data.model.LoginEntity
 import com.into.websoso.data.remote.api.AuthApi
@@ -17,6 +18,7 @@ class AuthRepository
         private val authApi: AuthApi,
         private val authStorage: SharedPreferences,
     ) {
+        var authFailureHandler: AuthFailureHandler? = null
         var accessToken: String
             get() = authStorage.getString(ACCESS_TOKEN_KEY, "").orEmpty()
             private set(value) = authStorage.edit().putString(ACCESS_TOKEN_KEY, value).apply()
@@ -97,6 +99,7 @@ class AuthRepository
                 response.authorization
             }.getOrElse {
                 it.printStackTrace()
+                authFailureHandler?.onAuthFailed()
                 null
             }
 


### PR DESCRIPTION
## 📌𝘐𝘴𝘴𝘶𝘦𝘴
- closed #608 

## 📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯
- data 레이어에서 context 주입 제거
- AuthFailureHandler 추가
- AuthFailureHandler 앱 단위에서 글로벌 적용

## 📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵
https://github.com/user-attachments/assets/af108e73-6ddc-4fbd-9bc7-0f49e086963b

## 💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴
context 주입을 위해 authRepository를 App 단위에서 불러왔습니다.
앱 내 글로벌 적용을 한다면 이 방법도 하나의 대안이 될 수 있다고 들어서...!

테스트는 clearTokens를 직접 앱을 시작할 때 불러오면서 진행했습니다