### PR TITLE
feat: 프로필 비공개 여부 버튼 > 토글 버튼으로 수정

### DIFF
--- a/app/src/main/java/com/into/websoso/data/mapper/UserMapper.kt
+++ b/app/src/main/java/com/into/websoso/data/mapper/UserMapper.kt
@@ -12,7 +12,6 @@ import com.into.websoso.data.model.UserFeedsEntity.UserFeedEntity
 import com.into.websoso.data.model.UserInfoDetailEntity
 import com.into.websoso.data.model.UserInfoEntity
 import com.into.websoso.data.model.UserNovelStatsEntity
-import com.into.websoso.data.model.UserProfileStatusEntity
 import com.into.websoso.data.model.UserStorageEntity
 import com.into.websoso.data.model.UserStorageEntity.StorageNovelEntity
 import com.into.websoso.data.remote.response.BlockedUsersResponseDto
@@ -26,7 +25,6 @@ import com.into.websoso.data.remote.response.UserFeedsResponseDto.UserFeedRespon
 import com.into.websoso.data.remote.response.UserInfoDetailResponseDto
 import com.into.websoso.data.remote.response.UserInfoResponseDto
 import com.into.websoso.data.remote.response.UserNovelStatsResponseDto
-import com.into.websoso.data.remote.response.UserProfileStatusResponseDto
 import com.into.websoso.data.remote.response.UserStorageResponseDto
 import com.into.websoso.data.remote.response.UserStorageResponseDto.StorageNovelDto
 import com.into.websoso.ui.main.myPage.myActivity.model.Genres
@@ -63,11 +61,6 @@ fun UserNovelStatsResponseDto.toData(): UserNovelStatsEntity =
         watchingNovelCount = watchingNovelCount,
         watchedNovelCount = watchedNovelCount,
         quitNovelCount = quitNovelCount,
-    )
-
-fun UserProfileStatusResponseDto.toData(): UserProfileStatusEntity =
-    UserProfileStatusEntity(
-        isProfilePublic = isProfilePublic,
     )
 
 fun MyProfileResponseDto.toData(): MyProfileEntity =

--- a/app/src/main/java/com/into/websoso/data/model/UserProfileStatusEntity.kt
+++ b/app/src/main/java/com/into/websoso/data/model/UserProfileStatusEntity.kt
@@ -1,5 +1,0 @@
-package com.into.websoso.data.model
-
-data class UserProfileStatusEntity(
-    val isProfilePublic: Boolean,
-)

--- a/app/src/main/java/com/into/websoso/data/repository/UserRepository.kt
+++ b/app/src/main/java/com/into/websoso/data/repository/UserRepository.kt
@@ -16,7 +16,6 @@ import com.into.websoso.data.model.UserFeedsEntity
 import com.into.websoso.data.model.UserInfoDetailEntity
 import com.into.websoso.data.model.UserInfoEntity
 import com.into.websoso.data.model.UserNovelStatsEntity
-import com.into.websoso.data.model.UserProfileStatusEntity
 import com.into.websoso.data.model.UserStorageEntity
 import com.into.websoso.data.remote.api.UserApi
 import com.into.websoso.data.remote.request.TermsAgreementRequestDto
@@ -69,7 +68,7 @@ class UserRepository
 
         suspend fun fetchUserNovelStats(userId: Long): UserNovelStatsEntity = userApi.getUserNovelStats(userId).toData()
 
-        suspend fun fetchUserProfileStatus(): UserProfileStatusEntity = userApi.getProfileStatus().toData()
+        suspend fun fetchUserProfileStatus(): Boolean = userApi.getProfileStatus().isProfilePublic
 
         suspend fun saveUserProfileStatus(isProfilePublic: Boolean) {
             userApi.patchProfileStatus(UserProfileStatusRequestDto(isProfilePublic))

--- a/app/src/main/java/com/into/websoso/ui/profileDisclosure/ProfileDisclosureActivity.kt
+++ b/app/src/main/java/com/into/websoso/ui/profileDisclosure/ProfileDisclosureActivity.kt
@@ -39,7 +39,6 @@ class ProfileDisclosureActivity : BaseActivity<ActivityProfileDisclosureBinding>
                     profileDisclosureViewModel.isProfilePrivate.value?.not() ?: true,
                 )
                 setResult(ChangeProfileDisclosure.RESULT_OK, intent)
-                finish()
             }
             finish()
         }

--- a/app/src/main/java/com/into/websoso/ui/profileDisclosure/ProfileDisclosureActivity.kt
+++ b/app/src/main/java/com/into/websoso/ui/profileDisclosure/ProfileDisclosureActivity.kt
@@ -4,100 +4,60 @@ import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import androidx.activity.viewModels
+import androidx.lifecycle.lifecycleScope
 import com.into.websoso.R
 import com.into.websoso.core.common.ui.base.BaseActivity
 import com.into.websoso.core.common.ui.model.ResultFrom.ChangeProfileDisclosure
+import com.into.websoso.core.common.util.SingleEventHandler
 import com.into.websoso.databinding.ActivityProfileDisclosureBinding
 import com.into.websoso.ui.setting.SettingActivity
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
-class ProfileDisclosureActivity :
-    BaseActivity<ActivityProfileDisclosureBinding>(R.layout.activity_profile_disclosure) {
+class ProfileDisclosureActivity : BaseActivity<ActivityProfileDisclosureBinding>(R.layout.activity_profile_disclosure) {
     private val profileDisclosureViewModel: ProfileDisclosureViewModel by viewModels()
+    private val singleEventHandler: SingleEventHandler by lazy { SingleEventHandler.from() }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
         bindViewModel()
         onBackButtonClick()
-        onProfileDisclosureButtonClick()
-        onCompleteButtonClick()
-        setupObserver()
     }
 
     private fun bindViewModel() {
         binding.profileDisclosureViewModel = profileDisclosureViewModel
         binding.lifecycleOwner = this
+        binding.onToggleClick = ::updateProfileDisclosureStatus
     }
 
     private fun onBackButtonClick() {
         binding.ivProfileDisclosureBackButton.setOnClickListener {
+            if (profileDisclosureViewModel.isChangedStatus.value == true) {
+                val intent = SettingActivity.getIntent(
+                    this,
+                    profileDisclosureViewModel.isProfilePrivate.value?.not() ?: true,
+                )
+                setResult(ChangeProfileDisclosure.RESULT_OK, intent)
+                finish()
+                return@setOnClickListener
+            }
             finish()
         }
     }
 
-    private fun onProfileDisclosureButtonClick() {
-        binding.clProfileDisclosureButton.setOnClickListener {
-            profileDisclosureViewModel.updateProfileStatus()
+    private fun updateProfileDisclosureStatus() {
+        val newCheckedState: Boolean = !binding.scProfileDisclosureToggle.isChecked
+        binding.scProfileDisclosureToggle.isChecked = newCheckedState
+
+        singleEventHandler.debounce(coroutineScope = lifecycleScope) {
+            profileDisclosureViewModel.updateProfileStatus(newCheckedState)
         }
-    }
-
-    private fun onCompleteButtonClick() {
-        binding.tvProfileDisclosureCompleteButton.setOnClickListener {
-            profileDisclosureViewModel.saveProfileDisclosureStatus()
-        }
-    }
-
-    private fun setupObserver() {
-        profileDisclosureViewModel.uiState.observe(this) { uiState ->
-            when {
-                uiState.loading -> {
-                    binding.wllProfileDisclosure.setWebsosoLoadingVisibility(true)
-                    binding.wllProfileDisclosure.setErrorLayoutVisibility(false)
-                }
-
-                uiState.error -> {
-                    binding.wllProfileDisclosure.setWebsosoLoadingVisibility(false)
-                    binding.wllProfileDisclosure.setErrorLayoutVisibility(true)
-                }
-
-                else -> {
-                    binding.wllProfileDisclosure.setWebsosoLoadingVisibility(false)
-                    binding.wllProfileDisclosure.setErrorLayoutVisibility(false)
-                }
-            }
-        }
-
-        profileDisclosureViewModel.isProfilePublic.observe(this) { isProfilePublic ->
-            updateProfileDisclosureStatusButton(isProfilePublic)
-        }
-
-        profileDisclosureViewModel.isSaveStatusComplete.observe(this) { isSaveStatus ->
-            if (isSaveStatus) {
-                val intent = SettingActivity.getIntent(
-                    this,
-                    profileDisclosureViewModel.isProfilePublic.value ?: true,
-                )
-                setResult(ChangeProfileDisclosure.RESULT_OK, intent)
-                finish()
-            }
-        }
-    }
-
-    private fun updateProfileDisclosureStatusButton(isProfilePublic: Boolean) {
-        val buttonImage = when (isProfilePublic) {
-            true -> R.drawable.img_account_info_check_unselected
-            false -> R.drawable.img_account_info_check_selected
-        }
-        binding.ivProfileDisclosureStatusButton.setImageResource(buttonImage)
     }
 
     companion object {
         const val IS_PROFILE_PUBLIC = "isProfilePublic"
 
-        fun getIntent(context: Context): Intent {
-            return Intent(context, ProfileDisclosureActivity::class.java)
-        }
+        fun getIntent(context: Context): Intent = Intent(context, ProfileDisclosureActivity::class.java)
     }
 }

--- a/app/src/main/java/com/into/websoso/ui/profileDisclosure/ProfileDisclosureActivity.kt
+++ b/app/src/main/java/com/into/websoso/ui/profileDisclosure/ProfileDisclosureActivity.kt
@@ -40,7 +40,6 @@ class ProfileDisclosureActivity : BaseActivity<ActivityProfileDisclosureBinding>
                 )
                 setResult(ChangeProfileDisclosure.RESULT_OK, intent)
                 finish()
-                return@setOnClickListener
             }
             finish()
         }

--- a/app/src/main/java/com/into/websoso/ui/profileDisclosure/model/ProfileDisclosureUiState.kt
+++ b/app/src/main/java/com/into/websoso/ui/profileDisclosure/model/ProfileDisclosureUiState.kt
@@ -1,6 +1,0 @@
-package com.into.websoso.ui.profileDisclosure.model
-
-data class ProfileDisclosureUiState(
-    val loading: Boolean = true,
-    val error: Boolean = false,
-)

--- a/app/src/main/res/layout/activity_profile_disclosure.xml
+++ b/app/src/main/res/layout/activity_profile_disclosure.xml
@@ -1,13 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools">
+    xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <data>
 
         <variable
             name="profileDisclosureViewModel"
             type="com.into.websoso.ui.profileDisclosure.ProfileDisclosureViewModel" />
+
+        <variable
+            name="onToggleClick"
+            type="kotlin.jvm.functions.Function0" />
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
@@ -40,24 +43,11 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
 
-        <TextView
-            android:id="@+id/tv_profile_disclosure_complete_button"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginEnd="12dp"
-            android:enabled="@{profileDisclosureViewModel.isCompleteButtonEnabled}"
-            android:padding="10dp"
-            android:text="@string/profile_disclosure_complete"
-            android:textAppearance="@style/title2"
-            android:textColor="@color/bg_profile_disclosure_text_selector"
-            app:layout_constraintBottom_toBottomOf="@id/tv_profile_disclosure_title"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintTop_toTopOf="@id/tv_profile_disclosure_title" />
-
         <androidx.constraintlayout.widget.ConstraintLayout
             android:id="@+id/cl_profile_disclosure_button"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
+            android:onClick="@{() -> onToggleClick.invoke()}"
             android:paddingHorizontal="20dp"
             android:paddingVertical="10dp"
             app:layout_constraintEnd_toEndOf="parent"
@@ -67,6 +57,7 @@
             <TextView
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
+                android:paddingVertical="10dp"
                 android:text="@string/profile_disclosure_private"
                 android:textAppearance="@style/body1"
                 android:textColor="@color/black"
@@ -74,25 +65,18 @@
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toTopOf="parent" />
 
-            <ImageView
-                android:id="@+id/iv_profile_disclosure_status_button"
+            <androidx.appcompat.widget.SwitchCompat
+                android:id="@+id/sc_profile_disclosure_toggle"
                 android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:padding="10dp"
-                android:src="@drawable/img_account_info_check_unselected"
+                android:layout_height="0dp"
+                android:background="@null"
+                android:checked="@{profileDisclosureViewModel.isProfilePrivate}"
+                android:clickable="false"
+                android:thumb="@drawable/bg_notification_setting_toggle_thumb"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintTop_toTopOf="parent" />
+                app:layout_constraintTop_toTopOf="parent"
+                app:track="@drawable/bg_notification_setting_toggle" />
         </androidx.constraintlayout.widget.ConstraintLayout>
-
-        <com.into.websoso.core.common.ui.custom.WebsosoLoadingLayout
-            android:id="@+id/wll_profile_disclosure"
-            android:layout_width="0dp"
-            android:layout_height="0dp"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent"
-            tools:visibility="gone" />
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -284,7 +284,6 @@
 
     <!-- 프로필 공개여부 뷰 -->
     <string name="profile_disclosure_title">프로필 공개 설정</string>
-    <string name="profile_disclosure_complete">완료</string>
     <string name="profile_disclosure_private">비공개</string>
     <string name="profile_disclosure_public">전체 공개</string>
     <string name="profile_disclosure_message">프로필이 %s로 전환되었어요</string>


### PR DESCRIPTION
## 📌𝘐𝘴𝘴𝘶𝘦𝘴
- closed #632

## 📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯
- 기존 프로필 공개 여부 버튼이 활/비활성화 이미지에서 토글 버튼으로 수정되었습니다. (알림 설정뷰와 얼라인을 위해서)
- `isChangedStatus` 로 상태 초기값과 저장된 값이 다른지 파악해 뒤로가기 버튼을 눌렀을 때 스낵바가 뜰 수 있도록 했습니다.

## 📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵

https://github.com/user-attachments/assets/a980fc9e-7d3e-4d8d-bf02-362067d71c91

## 💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴