### PR TITLE
fix: 카카오 로그인 웹뷰 콜백되지 않는 현상 해결

### DIFF
--- a/build-logic/src/main/kotlin/com/into/websoso/BuildConfigExtensions.kt
+++ b/build-logic/src/main/kotlin/com/into/websoso/BuildConfigExtensions.kt
@@ -30,7 +30,10 @@ fun BuildType.buildConfigs(
 fun getLocalProperty(
     rootDir: File,
     key: String,
-): String = gradleLocalProperties(rootDir).getProperty(key)
+): String {
+    val value = gradleLocalProperties(rootDir).getProperty(key)
+    return value.trim('"')
+}
 
 fun interface BuildConfigScope {
     fun string(

--- a/build-logic/src/main/kotlin/com/into/websoso/BuildConfigExtensions.kt
+++ b/build-logic/src/main/kotlin/com/into/websoso/BuildConfigExtensions.kt
@@ -30,10 +30,7 @@ fun BuildType.buildConfigs(
 fun getLocalProperty(
     rootDir: File,
     key: String,
-): String {
-    val value = gradleLocalProperties(rootDir).getProperty(key)
-    return value.trim('"')
-}
+): String = gradleLocalProperties(rootDir).getProperty(key).trim('"')
 
 fun interface BuildConfigScope {
     fun string(


### PR DESCRIPTION
## 📌𝘐𝘴𝘴𝘶𝘦𝘴
- closed #671

## 📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯
- 카카오 로그인 웹 뷰 콜백되지 않는 현상 해결했습니다.
- 로컬 프로퍼티 내의 큰 따옴표까지 같이 들어가서 안 되는 거였습니다.
- 하단 사진이 build 된 manifest 파일 (`&quot;` 가 큰 따옴표)
> 카카오 앱 키 보여서 카톡에 올린 사진 봐주세요

## 📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵

[Screen_recording_20250505_153307.webm](https://github.com/user-attachments/assets/4edf2760-d5ad-4f98-a673-7457c3155555)

## 💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴
+ 추가로 이전에는 왜 될까 ? 라고 master 브랜치를 봤는데 요기 app 단의 build.gradle 에서 큰 따옴표 제거해주고 있었습니다. 참고 차 작성해둠!
<img width="586" alt="스크린샷 2025-05-05 오후 3 39 07" src="https://github.com/user-attachments/assets/5b1db356-3670-4b0e-9f30-4049323b48fe" />
