### PR TITLE
refactor: 로그아웃 구현

### DIFF
--- a/app/src/main/java/com/into/websoso/data/remote/api/AuthApi.kt
+++ b/app/src/main/java/com/into/websoso/data/remote/api/AuthApi.kt
@@ -1,7 +1,6 @@
 package com.into.websoso.data.remote.api
 
 import com.into.websoso.data.remote.request.FCMTokenRequestDto
-import com.into.websoso.data.remote.request.LogoutRequestDto
 import com.into.websoso.data.remote.request.UserProfileRequestDto
 import com.into.websoso.data.remote.request.WithdrawRequestDto
 import com.into.websoso.data.remote.response.UserNicknameValidityResponseDto
@@ -22,12 +21,6 @@ interface AuthApi {
     suspend fun postUserProfile(
         @Header("Authorization") authorization: String,
         @Body userProfileRequestDto: UserProfileRequestDto,
-    )
-
-    @POST("auth/logout")
-    suspend fun logout(
-        @Header("Authorization") authorization: String,
-        @Body loginResponseDto: LogoutRequestDto,
     )
 
     @POST("auth/withdraw")

--- a/app/src/main/java/com/into/websoso/data/repository/AuthRepository.kt
+++ b/app/src/main/java/com/into/websoso/data/repository/AuthRepository.kt
@@ -3,7 +3,6 @@ package com.into.websoso.data.repository
 import android.content.SharedPreferences
 import com.into.websoso.data.remote.api.AuthApi
 import com.into.websoso.data.remote.request.FCMTokenRequestDto
-import com.into.websoso.data.remote.request.LogoutRequestDto
 import com.into.websoso.data.remote.request.UserProfileRequestDto
 import com.into.websoso.data.remote.request.WithdrawRequestDto
 import javax.inject.Inject
@@ -42,21 +41,6 @@ class AuthRepository
                 "Bearer $authorization",
                 UserProfileRequestDto(nickname, gender, birth, genrePreferences),
             )
-        }
-
-        suspend fun logout(deviceIdentifier: String) {
-            runCatching {
-                if (accessToken.isNotEmpty() && refreshToken.isNotEmpty()) {
-                    authApi.logout(
-                        "Bearer $accessToken",
-                        LogoutRequestDto(refreshToken, deviceIdentifier),
-                    )
-                }
-            }.onSuccess {
-                clearTokens()
-            }.onFailure {
-                it.printStackTrace()
-            }
         }
 
         suspend fun withdraw(reason: String) {

--- a/app/src/main/java/com/into/websoso/ui/accountInfo/AccountInfoViewModel.kt
+++ b/app/src/main/java/com/into/websoso/ui/accountInfo/AccountInfoViewModel.kt
@@ -2,7 +2,6 @@ package com.into.websoso.ui.accountInfo
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.into.websoso.core.auth.AuthPlatform
 import com.into.websoso.data.account.AccountRepository
 import com.into.websoso.data.repository.PushMessageRepository
 import com.into.websoso.data.repository.UserRepository
@@ -46,10 +45,9 @@ class AccountInfoViewModel
             }
         }
 
-        fun signOut(signOutToPlatform: suspend (platform: AuthPlatform) -> Unit) {
+        fun signOut() {
             viewModelScope.launch {
                 runCatching {
-                    signOutToPlatform(AuthPlatform.KAKAO)
                     val userDeviceIdentifier = userRepository.fetchUserDeviceIdentifier()
                     accountRepository.deleteToken(userDeviceIdentifier)
                 }.onSuccess {

--- a/app/src/main/java/com/into/websoso/ui/accountInfo/AccountInfoViewModel.kt
+++ b/app/src/main/java/com/into/websoso/ui/accountInfo/AccountInfoViewModel.kt
@@ -7,7 +7,6 @@ import com.into.websoso.data.account.AccountRepository
 import com.into.websoso.data.repository.PushMessageRepository
 import com.into.websoso.data.repository.UserRepository
 import com.into.websoso.ui.accountInfo.UiEffect.NavigateToLogin
-import com.into.websoso.ui.accountInfo.UiEffect.ShowToast
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
@@ -50,14 +49,14 @@ class AccountInfoViewModel
         fun signOut(signOutToPlatform: suspend (platform: AuthPlatform) -> Unit) {
             viewModelScope.launch {
                 runCatching {
+                    signOutToPlatform(AuthPlatform.KAKAO)
                     val userDeviceIdentifier = userRepository.fetchUserDeviceIdentifier()
                     accountRepository.deleteToken(userDeviceIdentifier)
                 }.onSuccess {
-                    signOutToPlatform(AuthPlatform.KAKAO)
                     pushMessageRepository.clearFCMToken()
                     _uiEffect.send(NavigateToLogin)
                 }.onFailure {
-                    _uiEffect.send(ShowToast)
+                    _uiEffect.send(NavigateToLogin)
                 }
             }
         }
@@ -65,6 +64,4 @@ class AccountInfoViewModel
 
 sealed interface UiEffect {
     data object NavigateToLogin : UiEffect
-
-    data object ShowToast : UiEffect
 }

--- a/app/src/main/java/com/into/websoso/ui/accountInfo/AccountInfoViewModel.kt
+++ b/app/src/main/java/com/into/websoso/ui/accountInfo/AccountInfoViewModel.kt
@@ -28,7 +28,7 @@ class AccountInfoViewModel
         private val _userEmail: MutableStateFlow<String> = MutableStateFlow("")
         val userEmail: StateFlow<String> get() = _userEmail.asStateFlow()
 
-        private var _uiEffect = Channel<UiEffect>(Channel.BUFFERED)
+        private val _uiEffect = Channel<UiEffect>(Channel.BUFFERED)
         val uiEffect: Flow<UiEffect> get() = _uiEffect.receiveAsFlow()
 
         init {

--- a/app/src/main/java/com/into/websoso/ui/accountInfo/LogoutDialogFragment.kt
+++ b/app/src/main/java/com/into/websoso/ui/accountInfo/LogoutDialogFragment.kt
@@ -10,10 +10,11 @@ import com.into.websoso.core.common.navigator.NavigatorProvider
 import com.into.websoso.core.common.ui.base.BaseDialogFragment
 import com.into.websoso.core.common.util.SingleEventHandler
 import com.into.websoso.core.common.util.collectWithLifecycle
-import com.into.websoso.core.common.util.showWebsosoToast
 import com.into.websoso.databinding.DialogLogoutBinding
+import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 
+@AndroidEntryPoint
 class LogoutDialogFragment : BaseDialogFragment<DialogLogoutBinding>(R.layout.dialog_logout) {
     private val accountInfoViewModel: AccountInfoViewModel by activityViewModels()
     private val singleEventHandler: SingleEventHandler by lazy { SingleEventHandler.from() }
@@ -38,11 +39,6 @@ class LogoutDialogFragment : BaseDialogFragment<DialogLogoutBinding>(R.layout.di
         accountInfoViewModel.uiEffect.collectWithLifecycle(viewLifecycleOwner) { uiEffect ->
             when (uiEffect) {
                 UiEffect.NavigateToLogin -> websosoNavigator.navigateToLoginActivity()
-                UiEffect.ShowToast -> showWebsosoToast(
-                    requireContext(),
-                    getString(com.into.websoso.core.resource.R.string.novel_rating_save_error),
-                    com.into.websoso.core.resource.R.drawable.ic_novel_rating_alert,
-                )
             }
         }
     }

--- a/app/src/main/java/com/into/websoso/ui/accountInfo/LogoutDialogFragment.kt
+++ b/app/src/main/java/com/into/websoso/ui/accountInfo/LogoutDialogFragment.kt
@@ -4,8 +4,6 @@ import android.os.Bundle
 import android.view.View
 import androidx.fragment.app.activityViewModels
 import com.into.websoso.R
-import com.into.websoso.core.auth.AuthClient
-import com.into.websoso.core.auth.AuthPlatform
 import com.into.websoso.core.common.navigator.NavigatorProvider
 import com.into.websoso.core.common.ui.base.BaseDialogFragment
 import com.into.websoso.core.common.util.SingleEventHandler
@@ -18,9 +16,6 @@ import javax.inject.Inject
 class LogoutDialogFragment : BaseDialogFragment<DialogLogoutBinding>(R.layout.dialog_logout) {
     private val accountInfoViewModel: AccountInfoViewModel by activityViewModels()
     private val singleEventHandler: SingleEventHandler by lazy { SingleEventHandler.from() }
-
-    @Inject
-    lateinit var authClient: Map<AuthPlatform, @JvmSuppressWildcards AuthClient>
 
     @Inject
     lateinit var websosoNavigator: NavigatorProvider
@@ -49,11 +44,7 @@ class LogoutDialogFragment : BaseDialogFragment<DialogLogoutBinding>(R.layout.di
         }
 
         binding.tvLogoutButton.setOnClickListener {
-            singleEventHandler.throttleFirst {
-                accountInfoViewModel.signOut { platform ->
-                    authClient[platform]?.signOut()
-                }
-            }
+            singleEventHandler.throttleFirst(event = accountInfoViewModel::signOut)
         }
     }
 

--- a/app/src/main/java/com/into/websoso/ui/splash/SplashViewModel.kt
+++ b/app/src/main/java/com/into/websoso/ui/splash/SplashViewModel.kt
@@ -23,7 +23,7 @@ class SplashViewModel
         private val userRepository: UserRepository,
         private val accountRepository: AccountRepository,
     ) : ViewModel() {
-        private var _uiEffect = Channel<UiEffect>(Channel.BUFFERED)
+        private val _uiEffect = Channel<UiEffect>(Channel.BUFFERED)
         val uiEffect: Flow<UiEffect> get() = _uiEffect.receiveAsFlow()
 
         init {

--- a/app/src/main/java/com/into/websoso/ui/splash/SplashViewModel.kt
+++ b/app/src/main/java/com/into/websoso/ui/splash/SplashViewModel.kt
@@ -29,7 +29,6 @@ class SplashViewModel
         init {
             viewModelScope.launch {
                 val isUpdateRequired = checkMinimumVersion()
-
                 if (isUpdateRequired.not()) handleAutoLogin()
             }
         }

--- a/core/auth-kakao/src/main/java/com/into/websoso/core/auth_kakao/KakaoAuthClient.kt
+++ b/core/auth-kakao/src/main/java/com/into/websoso/core/auth_kakao/KakaoAuthClient.kt
@@ -32,18 +32,6 @@ class KakaoAuthClient
                 }
             }
 
-        override suspend fun signOut() {
-            suspendCancellableCoroutine {
-                client.logout { error ->
-                    if (error != null) {
-                        it.resumeWithException(error)
-                    } else {
-                        it.resume(Unit)
-                    }
-                }
-            }
-        }
-
         override suspend fun withdraw() {
             suspendCancellableCoroutine {
                 client.unlink { error ->

--- a/core/auth/src/main/java/com/into/websoso/core/auth/AuthClient.kt
+++ b/core/auth/src/main/java/com/into/websoso/core/auth/AuthClient.kt
@@ -3,7 +3,5 @@ package com.into.websoso.core.auth
 interface AuthClient {
     suspend fun signIn(): AuthToken
 
-    suspend fun signOut()
-
     suspend fun withdraw()
 }

--- a/core/datastore/src/main/java/com/into/websoso/core/datastore/datasource/account/DefaultAccountDataSource.kt
+++ b/core/datastore/src/main/java/com/into/websoso/core/datastore/datasource/account/DefaultAccountDataSource.kt
@@ -44,6 +44,13 @@ internal class DefaultAccountDataSource
             }
         }
 
+        override suspend fun clearTokens() {
+            accountDataStore.edit { preferences ->
+                preferences.remove(ACCESS_TOKEN)
+                preferences.remove(REFRESH_TOKEN)
+            }
+        }
+
         companion object {
             private val ACCESS_TOKEN = stringPreferencesKey("ACCESS_TOKEN")
             private val REFRESH_TOKEN = stringPreferencesKey("REFRESH_TOKEN")

--- a/core/network/src/main/java/com/into/websoso/core/network/datasource/account/AccountApi.kt
+++ b/core/network/src/main/java/com/into/websoso/core/network/datasource/account/AccountApi.kt
@@ -1,6 +1,7 @@
 package com.into.websoso.core.network.datasource.account
 
 import com.into.websoso.core.network.datasource.account.model.KakaoLoginResponseDto
+import com.into.websoso.core.network.datasource.account.model.KakaoLogoutRequestDto
 import com.into.websoso.core.network.datasource.account.model.TokenReissueRequestDto
 import com.into.websoso.core.network.datasource.account.model.TokenReissueResponseDto
 import dagger.Module
@@ -18,6 +19,11 @@ internal interface AccountApi {
     suspend fun postLoginWithKakao(
         @Header("Kakao-Access-Token") accessToken: String,
     ): KakaoLoginResponseDto
+
+    @POST("auth/logout")
+    suspend fun postLogoutWithKakao(
+        @Body kakaoLogoutRequestDto: KakaoLogoutRequestDto,
+    )
 
     @POST("reissue")
     suspend fun postReissueToken(

--- a/core/network/src/main/java/com/into/websoso/core/network/datasource/account/DefaultAccountDataSource.kt
+++ b/core/network/src/main/java/com/into/websoso/core/network/datasource/account/DefaultAccountDataSource.kt
@@ -2,6 +2,7 @@ package com.into.websoso.core.network.datasource.account
 
 import com.into.websoso.core.auth.AuthPlatform
 import com.into.websoso.core.auth.AuthToken
+import com.into.websoso.core.network.datasource.account.model.KakaoLogoutRequestDto
 import com.into.websoso.core.network.datasource.account.model.TokenReissueRequestDto
 import com.into.websoso.data.account.datasource.AccountRemoteDataSource
 import com.into.websoso.data.account.model.AccountEntity
@@ -29,6 +30,18 @@ internal class DefaultAccountDataSource
                             accessToken = authToken.accessToken,
                         ).toData()
             }
+
+        override suspend fun postLogout(
+            refreshToken: String,
+            deviceIdentifier: String,
+        ) {
+            accountApi.postLogoutWithKakao(
+                kakaoLogoutRequestDto = KakaoLogoutRequestDto(
+                    refreshToken = refreshToken,
+                    deviceIdentifier = deviceIdentifier,
+                ),
+            )
+        }
 
         override suspend fun postReissue(refreshToken: String): TokenEntity =
             accountApi

--- a/core/network/src/main/java/com/into/websoso/core/network/datasource/account/model/KakaoLogoutRequestDto.kt
+++ b/core/network/src/main/java/com/into/websoso/core/network/datasource/account/model/KakaoLogoutRequestDto.kt
@@ -1,10 +1,10 @@
-package com.into.websoso.data.remote.request
+package com.into.websoso.core.network.datasource.account.model
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class LogoutRequestDto(
+internal data class KakaoLogoutRequestDto(
     @SerialName("refreshToken")
     val refreshToken: String,
     @SerialName("deviceIdentifier")

--- a/data/account/src/main/java/com/into/websoso/data/account/AccountRepository.kt
+++ b/data/account/src/main/java/com/into/websoso/data/account/AccountRepository.kt
@@ -19,6 +19,7 @@ class AccountRepository
 
         suspend fun refreshToken(): String = accountLocalDataSource.refreshToken()
 
+        // toekns
         suspend fun saveToken(
             platform: AuthPlatform,
             authToken: AuthToken,
@@ -32,6 +33,14 @@ class AccountRepository
             accountLocalDataSource.saveRefreshToken(account.token.refreshToken)
 
             return account.isRegister
+        }
+
+        suspend fun deleteToken(deviceIdentifier: String) {
+            accountRemoteDataSource
+                .postLogout(
+                    refreshToken = refreshToken(),
+                    deviceIdentifier = deviceIdentifier,
+                ).also { accountLocalDataSource.clearTokens() }
         }
 
         suspend fun renewToken(): String {

--- a/data/account/src/main/java/com/into/websoso/data/account/AccountRepository.kt
+++ b/data/account/src/main/java/com/into/websoso/data/account/AccountRepository.kt
@@ -7,7 +7,7 @@ import com.into.websoso.data.account.datasource.AccountRemoteDataSource
 import javax.inject.Inject
 import javax.inject.Singleton
 
-// TODO: 인스턴스 싱글톤 참고하기
+// TODO: 인스턴스 싱글톤 참고하기, tokens 네이밍수정, result 객체 적용
 @Singleton
 class AccountRepository
     @Inject
@@ -19,7 +19,6 @@ class AccountRepository
 
         suspend fun refreshToken(): String = accountLocalDataSource.refreshToken()
 
-        // toekns
         suspend fun saveToken(
             platform: AuthPlatform,
             authToken: AuthToken,

--- a/data/account/src/main/java/com/into/websoso/data/account/datasource/AccountLocalDataSource.kt
+++ b/data/account/src/main/java/com/into/websoso/data/account/datasource/AccountLocalDataSource.kt
@@ -8,4 +8,6 @@ interface AccountLocalDataSource {
     suspend fun saveAccessToken(accessToken: String)
 
     suspend fun saveRefreshToken(refreshToken: String)
+
+    suspend fun clearTokens()
 }

--- a/data/account/src/main/java/com/into/websoso/data/account/datasource/AccountRemoteDataSource.kt
+++ b/data/account/src/main/java/com/into/websoso/data/account/datasource/AccountRemoteDataSource.kt
@@ -11,5 +11,10 @@ interface AccountRemoteDataSource {
         authToken: AuthToken,
     ): AccountEntity
 
+    suspend fun postLogout(
+        refreshToken: String,
+        deviceIdentifier: String,
+    )
+
     suspend fun postReissue(refreshToken: String): TokenEntity
 }

--- a/feature/signin/src/main/java/com/into/websoso/feature/signin/SignInScreen.kt
+++ b/feature/signin/src/main/java/com/into/websoso/feature/signin/SignInScreen.kt
@@ -62,7 +62,7 @@ fun SignInScreen(
         onClick = { platform ->
             signInViewModel.signIn(
                 platform = platform,
-                getToken = authClient(platform)::signIn,
+                signInToPlatform = authClient(platform)::signIn,
             )
         },
     )

--- a/feature/signin/src/main/java/com/into/websoso/feature/signin/SignInViewModel.kt
+++ b/feature/signin/src/main/java/com/into/websoso/feature/signin/SignInViewModel.kt
@@ -27,11 +27,11 @@ class SignInViewModel
 
         fun signIn(
             platform: AuthPlatform,
-            getToken: suspend () -> AuthToken,
+            signInToPlatform: suspend () -> AuthToken,
         ) {
             viewModelScope.launch {
                 runCatching {
-                    getToken()
+                    signInToPlatform()
                 }.onSuccess { authToken ->
                     signInWithSuccess(platform, authToken)
                 }.onFailure {


### PR DESCRIPTION
## 📌𝘐𝘴𝘴𝘶𝘦𝘴
- closed #683 

## 📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯
- 로그아웃 기능을 구현합니다.

## 💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴
- 카카오 로그아웃은 서버에서 진행하므로, 클라이언트에선 할 필요가 없습니다.
- 따라서 불필요한 로그아웃 코드는 제거합니다.
