### PR TITLE
feat: 피드 생성 이미지 컨테이너 UI 구현

### DIFF
--- a/app/src/main/java/com/into/websoso/ui/createFeed/component/CreateFeedImageContainer.kt
+++ b/app/src/main/java/com/into/websoso/ui/createFeed/component/CreateFeedImageContainer.kt
@@ -26,7 +26,7 @@ import com.into.websoso.core.resource.R.drawable.ic_feed_remove_image
 @Composable
 fun CreateFeedImageContainer(
     imageUrls: List<String>,
-    onRemoveClick: (Int) -> Unit,
+    onRemoveClick: (index: Int) -> Unit,
 ) {
     LazyRow(
         modifier = Modifier

--- a/app/src/main/java/com/into/websoso/ui/createFeed/component/CreateFeedImageContainer.kt
+++ b/app/src/main/java/com/into/websoso/ui/createFeed/component/CreateFeedImageContainer.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.into.websoso.core.common.ui.component.AdaptationImage
 import com.into.websoso.core.common.util.clickableWithoutRipple
+import com.into.websoso.core.designsystem.component.NetworkImage
 import com.into.websoso.core.designsystem.theme.WebsosoTheme
 import com.into.websoso.core.resource.R.drawable.ic_feed_remove_image
 
@@ -65,7 +66,7 @@ private fun CreateFeedImageBox(
                 .align(Alignment.TopEnd)
                 .clickableWithoutRipple { onRemoveClick() },
         )
-        AdaptationImage(
+        NetworkImage(
             imageUrl = imageUrl,
             contentScale = ContentScale.Crop,
         )

--- a/app/src/main/java/com/into/websoso/ui/createFeed/component/CreateFeedImageContainer.kt
+++ b/app/src/main/java/com/into/websoso/ui/createFeed/component/CreateFeedImageContainer.kt
@@ -1,0 +1,92 @@
+package com.into.websoso.ui.createFeed.component
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.into.websoso.core.common.ui.component.AdaptationImage
+import com.into.websoso.core.common.util.clickableWithoutRipple
+import com.into.websoso.core.designsystem.theme.WebsosoTheme
+import com.into.websoso.core.resource.R.drawable.ic_feed_remove_image
+
+@Composable
+fun CreateFeedImageContainer(
+    imageUrls: List<String> = listOf(
+        "https://github.com/user-attachments/assets/e89a02bb-549f-414d-809f-0ab1e8f72c5f",
+        "https://github.com/user-attachments/assets/e89a02bb-549f-414d-809f-0ab1e8f72c5f",
+        "https://github.com/user-attachments/assets/e89a02bb-549f-414d-809f-0ab1e8f72c5f",
+    ),
+    onRemoveClick: (Int) -> Unit,
+) {
+    LazyRow(
+        modifier = Modifier
+            .fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(10.dp),
+        contentPadding = PaddingValues(horizontal = 20.dp),
+    ) {
+        items(imageUrls.size) { index ->
+            CreateFeedImageBox(
+                imageUrl = imageUrls[index],
+                onRemoveClick = {
+                    onRemoveClick(index)
+                },
+            )
+        }
+    }
+}
+
+@Composable
+private fun CreateFeedImageBox(
+    imageUrl: String,
+    onRemoveClick: () -> Unit,
+) {
+    Box(
+        modifier = Modifier
+            .size(100.dp)
+            .aspectRatio(1f)
+            .clip(RoundedCornerShape(8.dp)),
+    ) {
+        Image(
+            painter = painterResource(ic_feed_remove_image),
+            contentDescription = null,
+            modifier = Modifier
+                .size(38.dp)
+                .padding(10.dp)
+                .align(Alignment.TopEnd)
+                .clickableWithoutRipple { onRemoveClick() },
+        )
+        AdaptationImage(
+            imageUrl = imageUrl,
+            contentScale = ContentScale.Crop,
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun CreateFeedImageContainerPreview() {
+    WebsosoTheme {
+        CreateFeedImageContainer(
+            imageUrls = listOf(
+                "https://github.com/user-attachments/assets/e89a02bb-549f-414d-809f-0ab1e8f72c5f",
+                "https://github.com/user-attachments/assets/e89a02bb-549f-414d-809f-0ab1e8f72c5f",
+                "https://github.com/user-attachments/assets/e89a02bb-549f-414d-809f-0ab1e8f72c5f",
+            ),
+            onRemoveClick = {},
+        )
+    }
+}

--- a/app/src/main/java/com/into/websoso/ui/createFeed/component/CreateFeedImageContainer.kt
+++ b/app/src/main/java/com/into/websoso/ui/createFeed/component/CreateFeedImageContainer.kt
@@ -25,11 +25,7 @@ import com.into.websoso.core.resource.R.drawable.ic_feed_remove_image
 
 @Composable
 fun CreateFeedImageContainer(
-    imageUrls: List<String> = listOf(
-        "https://github.com/user-attachments/assets/e89a02bb-549f-414d-809f-0ab1e8f72c5f",
-        "https://github.com/user-attachments/assets/e89a02bb-549f-414d-809f-0ab1e8f72c5f",
-        "https://github.com/user-attachments/assets/e89a02bb-549f-414d-809f-0ab1e8f72c5f",
-    ),
+    imageUrls: List<String>,
     onRemoveClick: (Int) -> Unit,
 ) {
     LazyRow(

--- a/app/src/main/res/layout/activity_create_feed.xml
+++ b/app/src/main/res/layout/activity_create_feed.xml
@@ -85,8 +85,8 @@
                 android:id="@+id/sc_create_feed_lock_toggle"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:checked="@={!viewModel.isPublic}"
                 android:background="@null"
+                android:checked="@={!viewModel.isPublic}"
                 android:thumb="@drawable/bg_create_feed_toggle_thumb"
                 app:track="@drawable/bg_create_feed_toggle" />
         </LinearLayout>
@@ -218,6 +218,15 @@
                         app:track="@drawable/bg_create_feed_toggle" />
                 </LinearLayout>
 
+                <androidx.compose.ui.platform.ComposeView
+                    android:id="@+id/cv_create_feed_image"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="18dp"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/ll_create_feed_spoiler" />
+
                 <TextView
                     android:id="@+id/tv_create_feed_connect_novel"
                     android:layout_width="wrap_content"
@@ -228,7 +237,7 @@
                     android:textAppearance="@style/title2"
                     android:textColor="@color/black"
                     app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toBottomOf="@id/ll_create_feed_spoiler" />
+                    app:layout_constraintTop_toBottomOf="@id/cv_create_feed_image" />
 
                 <com.into.websoso.core.common.ui.custom.WebsosoSearchEditText
                     android:id="@+id/wset_create_feed_search_novel"

--- a/core/resource/src/main/res/drawable/ic_feed_remove_image.xml
+++ b/core/resource/src/main/res/drawable/ic_feed_remove_image.xml
@@ -1,0 +1,21 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="19dp"
+    android:height="18dp"
+    android:viewportWidth="19"
+    android:viewportHeight="18">
+  <path
+      android:pathData="M9.469,9m-9,0a9,9 0,1 1,18 0a9,9 0,1 1,-18 0"
+      android:fillColor="#EEEEF2"/>
+  <path
+      android:strokeWidth="1"
+      android:pathData="M12.469,6L6.469,12"
+      android:fillColor="#00000000"
+      android:strokeColor="#949399"
+      android:strokeLineCap="round"/>
+  <path
+      android:strokeWidth="1"
+      android:pathData="M6.469,6L12.469,12"
+      android:fillColor="#00000000"
+      android:strokeColor="#949399"
+      android:strokeLineCap="round"/>
+</vector>


### PR DESCRIPTION
## 📌𝘐𝘴𝘴𝘶𝘦𝘴
- closed #706

## 📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯
- 피드 생성 이미지 컨테이너 UI 구현

## 📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵
또 카카오 로그인이 안돼서 일단 날리겠삼

## 💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴
포맷은 API 작업때 보고 변경해둘게요

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 피드 생성 화면에 이미지를 가로로 스크롤하며 표시하고, 각 이미지를 개별적으로 삭제할 수 있는 UI가 추가되었습니다.

- **버그 수정**
  - 피드 및 활동 관련 레이아웃에서 상하 마진 속성이 통합되어 레이아웃이 더욱 일관성 있게 개선되었습니다.

- **스타일**
  - 피드 삭제 아이콘이 새롭게 추가되어 이미지 삭제 버튼에 적용되었습니다.

- **문서화**
  - 일부 텍스트가 하드코딩에서 문자열 리소스 참조로 변경되고, 문구가 더 자연스럽게 수정되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->