### PR TITLE
feat: 서재UI/UX 개편 (11) - 탭 변경 시에도 스크롤 유지되도록 기능 구현

### DIFF
--- a/app/src/main/java/com/into/websoso/ui/main/MainActivity.kt
+++ b/app/src/main/java/com/into/websoso/ui/main/MainActivity.kt
@@ -42,11 +42,11 @@ class MainActivity : BaseActivity<ActivityMainBinding>(activity_main) {
     private var currentSelectedItemId: Int = menu_home
 
     private val fragmentTags = mapOf(
-        menu_home to HomeFragment::class.java.name,
-        menu_explore to ExploreFragment::class.java.name,
-        menu_feed to FeedFragment::class.java.name,
-        menu_library to LibraryFragment::class.java.name,
-        menu_my_page to MyPageFragment::class.java.name,
+        menu_home to HomeFragment.TAG,
+        menu_explore to ExploreFragment.TAG,
+        menu_feed to FeedFragment.TAG,
+        menu_library to LibraryFragment.TAG,
+        menu_my_page to MyPageFragment.TAG,
     )
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -141,15 +141,14 @@ class MainActivity : BaseActivity<ActivityMainBinding>(activity_main) {
     }
 
     private fun findOrCreateFragment(tag: String): Fragment =
-        supportFragmentManager.findFragmentByTag(tag)
-            ?: when (tag) {
-                HomeFragment::class.java.name -> HomeFragment()
-                ExploreFragment::class.java.name -> ExploreFragment()
-                FeedFragment::class.java.name -> FeedFragment()
-                LibraryFragment::class.java.name -> LibraryFragment()
-                MyPageFragment::class.java.name -> MyPageFragment()
-                else -> throw IllegalArgumentException("Unknown fragment tag: $tag")
-            }
+        supportFragmentManager.findFragmentByTag(tag) ?: when (tag) {
+            HomeFragment.TAG -> HomeFragment()
+            ExploreFragment.TAG -> ExploreFragment()
+            FeedFragment.TAG -> FeedFragment()
+            LibraryFragment.TAG -> LibraryFragment()
+            MyPageFragment.TAG -> MyPageFragment()
+            else -> throw IllegalArgumentException("Unknown fragment tag: $tag")
+        }
 
     private fun setupObserver() {
         mainViewModel.isLogin.observe(this) { isLogin ->

--- a/app/src/main/java/com/into/websoso/ui/main/MainActivity.kt
+++ b/app/src/main/java/com/into/websoso/ui/main/MainActivity.kt
@@ -9,6 +9,7 @@ import androidx.activity.OnBackPressedCallback
 import androidx.activity.viewModels
 import androidx.annotation.IntegerRes
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.commit
 import com.into.websoso.R.id.fcv_main
 import com.into.websoso.R.id.menu_explore
 import com.into.websoso.R.id.menu_feed
@@ -93,16 +94,18 @@ class MainActivity : BaseActivity<ActivityMainBinding>(activity_main) {
     private fun setupInitialFragment() {
         val initialItemId = menu_home
         val initialTag = fragmentTags[initialItemId]!!
-        val initialFragment = findOrCreateFragment(initialTag)
 
-        if (!initialFragment.isAdded) {
-            supportFragmentManager
-                .beginTransaction()
-                .add(fcv_main, initialFragment, initialTag)
-                .commit()
+        val existingFragment = supportFragmentManager.findFragmentByTag(initialTag)
+        val fragment = existingFragment ?: findOrCreateFragment(initialTag)
+
+        supportFragmentManager.commit {
+            setReorderingAllowed(true)
+            if (existingFragment == null) {
+                add(fcv_main, fragment, initialTag)
+            } else {
+                show(existingFragment)
+            }
         }
-
-        currentFragment = initialFragment
     }
 
     private fun setupBottomNavListener() {

--- a/app/src/main/java/com/into/websoso/ui/main/explore/ExploreFragment.kt
+++ b/app/src/main/java/com/into/websoso/ui/main/explore/ExploreFragment.kt
@@ -95,5 +95,6 @@ class ExploreFragment : BaseFragment<FragmentExploreBinding>(R.layout.fragment_e
 
     companion object {
         private const val DETAIL_BOTTOM_SHEET_TAG = "DetailExploreDialogBottomSheet"
+        const val TAG = "ExploreFragment"
     }
 }

--- a/app/src/main/java/com/into/websoso/ui/main/feed/FeedFragment.kt
+++ b/app/src/main/java/com/into/websoso/ui/main/feed/FeedFragment.kt
@@ -499,4 +499,8 @@ class FeedFragment : BaseFragment<FragmentFeedBinding>(fragment_feed) {
         _popupBinding = null
         super.onDestroyView()
     }
+
+    companion object {
+        const val TAG = "FeedFragment"
+    }
 }

--- a/app/src/main/java/com/into/websoso/ui/main/home/HomeFragment.kt
+++ b/app/src/main/java/com/into/websoso/ui/main/home/HomeFragment.kt
@@ -332,5 +332,6 @@ class HomeFragment : BaseFragment<FragmentHomeBinding>(fragment_home) {
     companion object {
         private const val TODAY_POPULAR_NOVEL_MARGIN = 15
         private const val USER_INTEREST_MARGIN = 14
+        const val TAG = "HomeFragment"
     }
 }

--- a/app/src/main/java/com/into/websoso/ui/main/library/LibraryFragment.kt
+++ b/app/src/main/java/com/into/websoso/ui/main/library/LibraryFragment.kt
@@ -28,6 +28,9 @@ class LibraryFragment : Fragment() {
     ): View {
         val view = inflater.inflate(R.layout.fragment_library, container, false)
         val composeView = view.findViewById<ComposeView>(R.id.cv_library)
+        parentFragmentManager.setFragmentResultListener("scroll_to_top", viewLifecycleOwner) { _, _ ->
+            resetScrollPosition()
+        }
         composeView.apply {
             setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
             setContent {
@@ -49,5 +52,9 @@ class LibraryFragment : Fragment() {
     fun resetScrollPosition() {
         val viewModel: LibraryViewModel by viewModels()
         viewModel.resetScrollPosition()
+    }
+
+    companion object {
+        const val TAG = "LibraryFragment"
     }
 }

--- a/app/src/main/java/com/into/websoso/ui/main/library/LibraryFragment.kt
+++ b/app/src/main/java/com/into/websoso/ui/main/library/LibraryFragment.kt
@@ -20,6 +20,7 @@ import javax.inject.Inject
 class LibraryFragment : Fragment() {
     @Inject
     lateinit var websosoNavigator: NavigatorProvider
+    private val libraryViewModel: LibraryViewModel by viewModels()
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -28,7 +29,7 @@ class LibraryFragment : Fragment() {
     ): View {
         val view = inflater.inflate(R.layout.fragment_library, container, false)
         val composeView = view.findViewById<ComposeView>(R.id.cv_library)
-        parentFragmentManager.setFragmentResultListener("scroll_to_top", viewLifecycleOwner) { _, _ ->
+        parentFragmentManager.setFragmentResultListener("scrollToTop", viewLifecycleOwner) { _, _ ->
             resetScrollPosition()
         }
         composeView.apply {
@@ -36,6 +37,7 @@ class LibraryFragment : Fragment() {
             setContent {
                 WebsosoTheme {
                     LibraryScreen(
+                        libraryViewModel = libraryViewModel,
                         navigateToNormalExploreActivity = {
                             websosoNavigator.navigateToNormalExploreActivity(::startActivity)
                         },
@@ -49,9 +51,8 @@ class LibraryFragment : Fragment() {
         return view
     }
 
-    fun resetScrollPosition() {
-        val viewModel: LibraryViewModel by viewModels()
-        viewModel.resetScrollPosition()
+    private fun resetScrollPosition() {
+        libraryViewModel.resetScrollPosition()
     }
 
     companion object {

--- a/app/src/main/java/com/into/websoso/ui/main/library/LibraryFragment.kt
+++ b/app/src/main/java/com/into/websoso/ui/main/library/LibraryFragment.kt
@@ -7,10 +7,12 @@ import android.view.ViewGroup
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
 import com.into.websoso.R
 import com.into.websoso.core.common.navigator.NavigatorProvider
 import com.into.websoso.core.designsystem.theme.WebsosoTheme
 import com.into.websoso.feature.library.LibraryScreen
+import com.into.websoso.feature.library.LibraryViewModel
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 
@@ -42,5 +44,10 @@ class LibraryFragment : Fragment() {
             }
         }
         return view
+    }
+
+    fun resetScrollPosition() {
+        val viewModel: LibraryViewModel by viewModels()
+        viewModel.resetScrollPosition()
     }
 }

--- a/app/src/main/java/com/into/websoso/ui/main/myPage/MyPageFragment.kt
+++ b/app/src/main/java/com/into/websoso/ui/main/myPage/MyPageFragment.kt
@@ -147,5 +147,6 @@ class MyPageFragment : BaseFragment<FragmentMyPageBinding>(fragment_my_page) {
 
     companion object {
         private const val TOOLBAR_COLLAPSE_THRESHOLD = 0
+        const val TAG = "MyPageFragment"
     }
 }

--- a/app/src/main/res/layout/fragment_explore.xml
+++ b/app/src/main/res/layout/fragment_explore.xml
@@ -9,7 +9,8 @@
 
     <ScrollView
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
+        android:layout_height="match_parent"
+        android:background="@color/white"
         android:overScrollMode="never"
         android:scrollbars="none">
 

--- a/app/src/main/res/layout/fragment_feed.xml
+++ b/app/src/main/res/layout/fragment_feed.xml
@@ -13,6 +13,7 @@
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
+        android:background="@color/white"
         tools:context=".ui.main.feed.FeedFragment">
 
         <androidx.constraintlayout.widget.ConstraintLayout

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -13,6 +13,7 @@
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
+        android:background="@color/white"
         tools:context=".ui.main.home.HomeFragment">
 
         <ImageView

--- a/feature/library/src/main/java/com/into/websoso/feature/library/LibraryScreen.kt
+++ b/feature/library/src/main/java/com/into/websoso/feature/library/LibraryScreen.kt
@@ -13,7 +13,6 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.SheetState
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -22,14 +21,12 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
-import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import androidx.lifecycle.repeatOnLifecycle
 import androidx.paging.LoadState
 import androidx.paging.compose.LazyPagingItems
 import androidx.paging.compose.collectAsLazyPagingItems
 import androidx.paging.map
+import com.into.websoso.core.common.extensions.collectAsEventWithLifecycle
 import com.into.websoso.core.designsystem.theme.White
 import com.into.websoso.domain.library.model.AttractivePoints
 import com.into.websoso.domain.library.model.ReadStatus
@@ -70,19 +67,15 @@ fun LibraryScreen(
         skipPartiallyExpanded = true,
         confirmValueChange = { false },
     )
-    val lifecycleOwner = LocalLifecycleOwner.current
-
-    LaunchedEffect(Unit) {
-        lifecycleOwner.lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
-            libraryViewModel.scrollToTopEvent.collect {
-                if (uiState.isGrid) {
-                    gridState.scrollToItem(SCROLL_POSITION_TOP)
-                } else {
-                    listState.scrollToItem(SCROLL_POSITION_TOP)
-                }
+    libraryViewModel.scrollToTopEvent.collectAsEventWithLifecycle(
+        onEvent = {
+            if (uiState.isGrid) {
+                gridState.scrollToItem(SCROLL_POSITION_TOP)
+            } else {
+                listState.scrollToItem(SCROLL_POSITION_TOP)
             }
-        }
-    }
+        },
+    )
 
     LibraryScreen(
         uiState = uiState,

--- a/feature/library/src/main/java/com/into/websoso/feature/library/LibraryScreen.kt
+++ b/feature/library/src/main/java/com/into/websoso/feature/library/LibraryScreen.kt
@@ -1,5 +1,6 @@
 package com.into.websoso.feature.library
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -23,6 +24,7 @@ import androidx.paging.LoadState
 import androidx.paging.compose.LazyPagingItems
 import androidx.paging.compose.collectAsLazyPagingItems
 import androidx.paging.map
+import com.into.websoso.core.designsystem.theme.White
 import com.into.websoso.domain.library.model.AttractivePoints
 import com.into.websoso.domain.library.model.ReadStatus
 import com.into.websoso.feature.library.component.LibraryEmptyView
@@ -130,7 +132,11 @@ private fun LibraryScreen(
     onFilterSearchClick: () -> Unit,
     onInterestClick: () -> Unit,
 ) {
-    Column(modifier = Modifier.fillMaxSize()) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(White),
+    ) {
         LibraryTopBar(onSearchClick = onSearchClick)
 
         LibraryFilterTopBar(

--- a/feature/library/src/main/java/com/into/websoso/feature/library/LibraryScreen.kt
+++ b/feature/library/src/main/java/com/into/websoso/feature/library/LibraryScreen.kt
@@ -6,8 +6,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.grid.LazyGridState
-import androidx.compose.foundation.lazy.grid.rememberLazyGridState
-import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.SheetState
 import androidx.compose.material3.rememberModalBottomSheetState
@@ -56,8 +54,8 @@ fun LibraryScreen(
         .map { it.map { novel -> novel.toUiModel() } }
         .collectAsLazyPagingItems()
     var isShowBottomSheet by remember { mutableStateOf(false) }
-    val listState = rememberLazyListState()
-    val gridState = rememberLazyGridState()
+    val listState = libraryViewModel.listState
+    val gridState = libraryViewModel.gridState
     val bottomSheetState = rememberModalBottomSheetState(
         skipPartiallyExpanded = true,
         confirmValueChange = { false },

--- a/feature/library/src/main/java/com/into/websoso/feature/library/LibraryScreen.kt
+++ b/feature/library/src/main/java/com/into/websoso/feature/library/LibraryScreen.kt
@@ -7,10 +7,13 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.grid.LazyGridState
+import androidx.compose.foundation.lazy.grid.rememberLazyGridState
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.SheetState
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -56,12 +59,22 @@ fun LibraryScreen(
         .map { it.map { novel -> novel.toUiModel() } }
         .collectAsLazyPagingItems()
     var isShowBottomSheet by remember { mutableStateOf(false) }
-    val listState = libraryViewModel.listState
-    val gridState = libraryViewModel.gridState
+    val listState = rememberLazyListState()
+    val gridState = rememberLazyGridState()
     val bottomSheetState = rememberModalBottomSheetState(
         skipPartiallyExpanded = true,
         confirmValueChange = { false },
     )
+
+    LaunchedEffect(Unit) {
+        libraryViewModel.scrollToTopEvent.collect {
+            if (uiState.isGrid) {
+                gridState.scrollToItem(0)
+            } else {
+                listState.scrollToItem(0)
+            }
+        }
+    }
 
     LibraryScreen(
         uiState = uiState,

--- a/feature/library/src/main/java/com/into/websoso/feature/library/LibraryScreen.kt
+++ b/feature/library/src/main/java/com/into/websoso/feature/library/LibraryScreen.kt
@@ -22,7 +22,10 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.repeatOnLifecycle
 import androidx.paging.LoadState
 import androidx.paging.compose.LazyPagingItems
 import androidx.paging.compose.collectAsLazyPagingItems
@@ -43,6 +46,8 @@ import com.into.websoso.feature.library.model.LibraryUiState
 import com.into.websoso.feature.library.model.SortTypeUiModel
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
+
+private const val SCROLL_POSITION_TOP = 0
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -65,13 +70,16 @@ fun LibraryScreen(
         skipPartiallyExpanded = true,
         confirmValueChange = { false },
     )
+    val lifecycleOwner = LocalLifecycleOwner.current
 
     LaunchedEffect(Unit) {
-        libraryViewModel.scrollToTopEvent.collect {
-            if (uiState.isGrid) {
-                gridState.scrollToItem(0)
-            } else {
-                listState.scrollToItem(0)
+        lifecycleOwner.lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
+            libraryViewModel.scrollToTopEvent.collect {
+                if (uiState.isGrid) {
+                    gridState.scrollToItem(SCROLL_POSITION_TOP)
+                } else {
+                    listState.scrollToItem(SCROLL_POSITION_TOP)
+                }
             }
         }
     }

--- a/feature/library/src/main/java/com/into/websoso/feature/library/LibraryViewModel.kt
+++ b/feature/library/src/main/java/com/into/websoso/feature/library/LibraryViewModel.kt
@@ -100,7 +100,7 @@ class LibraryViewModel
             }
         }
 
-        fun scrollToTop() {
+        fun resetScrollPosition() {
             viewModelScope.launch {
                 if (uiState.value.isGrid) {
                     gridState.scrollToItem(0)

--- a/feature/library/src/main/java/com/into/websoso/feature/library/LibraryViewModel.kt
+++ b/feature/library/src/main/java/com/into/websoso/feature/library/LibraryViewModel.kt
@@ -1,10 +1,5 @@
 package com.into.websoso.feature.library
 
-import androidx.compose.foundation.lazy.LazyListState
-import androidx.compose.foundation.lazy.grid.LazyGridState
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.paging.PagingData
@@ -19,7 +14,9 @@ import com.into.websoso.feature.library.model.LibraryUiState
 import com.into.websoso.feature.library.model.SortTypeUiModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
@@ -40,11 +37,8 @@ class LibraryViewModel
         private val _uiState = MutableStateFlow(LibraryUiState())
         val uiState: StateFlow<LibraryUiState> = _uiState.asStateFlow()
 
-        var listState by mutableStateOf(LazyListState())
-            private set
-
-        var gridState by mutableStateOf(LazyGridState())
-            private set
+        private val _scrollToTopEvent = MutableSharedFlow<Unit>()
+        val scrollToTopEvent: SharedFlow<Unit> = _scrollToTopEvent
 
         init {
             updateMyLibraryFilter()
@@ -102,11 +96,7 @@ class LibraryViewModel
 
         fun resetScrollPosition() {
             viewModelScope.launch {
-                if (uiState.value.isGrid) {
-                    gridState.scrollToItem(0)
-                } else {
-                    listState.scrollToItem(0)
-                }
+                _scrollToTopEvent.emit(Unit)
             }
         }
     }

--- a/feature/library/src/main/java/com/into/websoso/feature/library/LibraryViewModel.kt
+++ b/feature/library/src/main/java/com/into/websoso/feature/library/LibraryViewModel.kt
@@ -1,5 +1,10 @@
 package com.into.websoso.feature.library
 
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.lazy.grid.LazyGridState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.paging.PagingData
@@ -34,6 +39,12 @@ class LibraryViewModel
 
         private val _uiState = MutableStateFlow(LibraryUiState())
         val uiState: StateFlow<LibraryUiState> = _uiState.asStateFlow()
+
+        var listState by mutableStateOf(LazyListState())
+            private set
+
+        var gridState by mutableStateOf(LazyGridState())
+            private set
 
         init {
             updateMyLibraryFilter()
@@ -86,6 +97,16 @@ class LibraryViewModel
         fun updateInterestedNovels() {
             _uiState.update {
                 it.copy(isInterested = !it.isInterested)
+            }
+        }
+
+        fun scrollToTop() {
+            viewModelScope.launch {
+                if (uiState.value.isGrid) {
+                    gridState.scrollToItem(0)
+                } else {
+                    listState.scrollToItem(0)
+                }
             }
         }
     }

--- a/feature/library/src/main/java/com/into/websoso/feature/library/LibraryViewModel.kt
+++ b/feature/library/src/main/java/com/into/websoso/feature/library/LibraryViewModel.kt
@@ -13,12 +13,12 @@ import com.into.websoso.domain.library.model.SortType
 import com.into.websoso.feature.library.model.LibraryUiState
 import com.into.websoso.feature.library.model.SortTypeUiModel
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -37,8 +37,8 @@ class LibraryViewModel
         private val _uiState = MutableStateFlow(LibraryUiState())
         val uiState: StateFlow<LibraryUiState> = _uiState.asStateFlow()
 
-        private val _scrollToTopEvent = MutableSharedFlow<Unit>()
-        val scrollToTopEvent: SharedFlow<Unit> = _scrollToTopEvent
+        private val _scrollToTopEvent = Channel<Unit>(Channel.BUFFERED)
+        val scrollToTopEvent: Flow<Unit> = _scrollToTopEvent.receiveAsFlow()
 
         init {
             updateMyLibraryFilter()
@@ -96,7 +96,7 @@ class LibraryViewModel
 
         fun resetScrollPosition() {
             viewModelScope.launch {
-                _scrollToTopEvent.emit(Unit)
+                _scrollToTopEvent.send(Unit)
             }
         }
     }

--- a/feature/library/src/main/java/com/into/websoso/feature/library/component/LibraryListItem.kt
+++ b/feature/library/src/main/java/com/into/websoso/feature/library/component/LibraryListItem.kt
@@ -166,8 +166,7 @@ private fun ReadStatusBadge(
                 .background(
                     color = readStatus.backgroundColor,
                     shape = RoundedCornerShape(8.dp),
-                )
-                .padding(vertical = 4.dp),
+                ).padding(vertical = 4.dp),
             contentAlignment = Alignment.Center,
         ) {
             Text(

--- a/feature/library/src/main/java/com/into/websoso/feature/library/mapper/AttractivePointsMapper.kt
+++ b/feature/library/src/main/java/com/into/websoso/feature/library/mapper/AttractivePointsMapper.kt
@@ -3,10 +3,9 @@ package com.into.websoso.feature.library.mapper
 import com.into.websoso.domain.library.model.AttractivePoints
 import com.into.websoso.feature.library.model.AttractivePointUiModel
 
-internal fun AttractivePoints.toUiModel(): AttractivePointUiModel {
-    return AttractivePointUiModel(
+internal fun AttractivePoints.toUiModel(): AttractivePointUiModel =
+    AttractivePointUiModel(
         type = this,
         label = this.label,
         key = this.key,
     )
-}


### PR DESCRIPTION
## 📌𝘐𝘴𝘴𝘶𝘦𝘴
- closed #725 

## 📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯
- 서재 탭 스크롤 상태 유지: 서재 탭 전환 시 기존 스크롤 위치를 유지하도록 상태 관리 (LazyListState, LazyGridState)
- 서재 탭 재클릭 시 스크롤 최상단 이동: 유저가 서재 탭을 다시 클릭하면 리스트가 최상단으로 스크롤되도록 기능 추가

## 📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵

https://github.com/user-attachments/assets/04255194-b2b2-478d-b475-572aa3e69914


## 💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 라이브러리(서재) 기능이 Jetpack Compose 기반의 새로운 UI 및 화면 구조로 전면 개편되었습니다.
  * 필터 및 정렬, 관심 작품/읽기 상태/별점/매력포인트 등 다양한 조건으로 소설 목록을 탐색할 수 있습니다.
  * 그리드/리스트 보기 전환, 페이징(무한 스크롤) 지원, 비어있는 상태 안내 및 탐색 버튼 제공.
  * 라이브러리 필터를 위한 바텀시트 및 필터 토글, 초기화, 적용 기능 추가.
  * 새로운 네비게이션 경로 추가 및 기존 네비게이션 방식 개선.
  * Room 기반 로컬 DB 및 Paging 3 연동 추가로 데이터 계층 확장.
  * 내부 데이터 저장소에 라이브러리 필터 상태 관리 기능 추가.
  * 신규 도메인 계층 및 UseCase 도입으로 페이징 및 필터링 로직 분리.
  * 라이브러리 관련 신규 아이콘 및 벡터 리소스 다수 추가.

* **버그 수정**
  * 네비게이션 및 화면 전환 방식 개선으로 중복 생성/불필요한 새로고침 방지.

* **리팩터/구조 개선**
  * 기존 뷰 기반 라이브러리 및 유저 서재 관련 화면, ViewModel, 어댑터, 데이터 모델 등 대거 삭제 및 Compose 기반으로 일원화.
  * 데이터 계층 및 도메인 계층에 페이징, 필터, 정렬 등 확장성 높은 구조 도입.
  * 내부 데이터 저장소 및 토큰 관리 함수 네이밍 명확화.
  * 의존성 및 모듈 구조 확장(코어/도메인/데이터/피처).
  * 레이아웃 XML 단순화 및 ComposeView로 대체.
  * Fragment 및 Activity 내 네비게이션 로직 개선 및 재구성.

* **리소스/디자인**
  * 라이브러리 관련 신규 아이콘 및 벡터 리소스 다수 추가.
  * 레이아웃 XML 단순화 및 ComposeView로 대체.

* **기타**
  * 내부 데이터 저장소 및 토큰 관리 함수 네이밍 명확화.
  * 의존성 및 모듈 구조 확장(코어/도메인/데이터/피처).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->