### PR TITLE
fix: 서재UI/UX 개편 (13) - 바텀네비게이션 전환 문제 해결

### DIFF
--- a/app/src/main/java/com/into/websoso/ui/main/MainActivity.kt
+++ b/app/src/main/java/com/into/websoso/ui/main/MainActivity.kt
@@ -105,6 +105,8 @@ class MainActivity : BaseActivity<ActivityMainBinding>(activity_main) {
                 show(existingFragment)
             }
         }
+
+        currentFragment = fragment
     }
 
     private fun setupBottomNavListener() {


### PR DESCRIPTION
## 📌𝘐𝘴𝘴𝘶𝘦𝘴
- closed #730 

## 📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯
- 초기 프래그먼트 설정 시 currentFragment 누락 보완

## 📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵


## 💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴
[현재 바텀네비게이션 구조]
- 전환 시 replaceCurrentFragment(itemId)를 호출해 currentFragment 기준으로 기존 Fragment를 remove() 또는 hide(), 신규Fragment를 add() 또는 show() 방식으로 처리.
- 초기 진입 시 menu_home 탭을 기본 Fragment로 설정함.

[문제상황]
- 앱 실행 후 Home → Library로 전환 시 간헐적으로 화면이 전환되지 않음.
- 하지만 다른 탭을 거쳐 Library로 이동하면 이후에는 정상 동작함.

[원인]
- setupInitialFragment()에서 초기 Fragment(HomeFragment)는 화면에 추가되었지만,
해당 Fragment를 currentFragment에 명시적으로 설정하지 않아 이후 전환 시 currentFragment == null 상태가 됨.
- 이로 인해 replaceCurrentFragment() 내부 로직에서 이전 Fragment를 hide() 또는 remove()하지 못하고,
새로운 Fragment만 show()되어 두 Fragment가 겹쳐 보이는 UI 꼬임 현상 발생.

[해결방법]
- 초기 Fragment를 currentFragment로 설정

