### PR TITLE
feat: targetSdk35 로 수정

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -23,6 +23,8 @@ android {
         versionName = libs.versions.versionName.get()
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 
+        targetSdk = 35
+
         buildConfigs(rootDir) {
             string(name = "S3_BASE_URL", key = "s3.url")
             string(name = "KAKAO_APP_KEY", key = "kakao.app.key")

--- a/build-logic/src/main/kotlin/websoso.android.kotlin.gradle.kts
+++ b/build-logic/src/main/kotlin/websoso.android.kotlin.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 androidExtension.apply {
-    compileSdk = 34
+    compileSdk = 35
 
     defaultConfig {
         minSdk = 30

--- a/core/resource/build.gradle.kts
+++ b/core/resource/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 
 android {
     namespace = "com.into.websoso.core.resource"
-    compileSdk = 34
+    compileSdk = 35
 
     defaultConfig {
         minSdk = 30


### PR DESCRIPTION
## 📌𝘐𝘴𝘴𝘶𝘦𝘴
- closed #738

## 📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯
- targetSdk 를 app 단에 추가했습니다. (원래 없었음)
   -> build-logic 의 `websoso.android.kotlin.gradle.kts` 에 추가하지 않은 이유는 `compileSdk`는 CommonExtension에 공통 속성이라 바로 쓸 수 있지만, `targetSdk`는 앱 전용 ApplicationExtension에만 있어 CommonExtension에서는 접근할 수 없기 때문입니다.
   -> 분기처리 하는 함수 써서 할 수는 있지만, `websoso.android.kotlin.gradle.kts` 요 파일은 모두 사용되는 것이고 굳이 사용처가 아닌 곳에서 알 필요가 없다고 판단에 사용하는 곳인 app의 `build.gradle.kts` 에만 추가했습니다.

## 📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵
N/A


## 💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Android의 targetSdk 및 compileSdk 버전을 35로 업데이트했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->