### PR TITLE
fix: 서재소소 최종 QA 사항 반영

### DIFF
--- a/app/src/main/java/com/into/websoso/ui/novelRating/NovelRatingViewModel.kt
+++ b/app/src/main/java/com/into/websoso/ui/novelRating/NovelRatingViewModel.kt
@@ -307,8 +307,8 @@ class NovelRatingViewModel
                         novelRatingEntity = NovelRatingEntity(
                             userNovelId = novel?.userNovel?.userNovelId,
                             novelId = novel?.novel?.novelId ?: 0,
-                            userNovelRating = novel?.userRating?.novelRating ?: 0.0f,
-                            novelRating = novelRating,
+                            userNovelRating = novelRating,
+                            novelRating = novel?.userRating?.novelRating ?: 0.0f,
                             novelTitle = novel?.novel?.novelTitle,
                             novelImage = novel?.novel?.novelImage,
                             startDate = ratingModel

--- a/domain/library/src/main/java/com/into/websoso/domain/library/model/ReadStatus.kt
+++ b/domain/library/src/main/java/com/into/websoso/domain/library/model/ReadStatus.kt
@@ -6,7 +6,7 @@ enum class ReadStatus(
 ) {
     WATCHING("WATCHING", "보는중"),
     WATCHED("WATCHED", "봤어요"),
-    QUIT("QUIT", "하차함"),
+    QUIT("QUIT", "하차"),
     ;
 
     companion object {

--- a/feature/library/src/main/java/com/into/websoso/feature/library/component/LibraryFilterEmptyView.kt
+++ b/feature/library/src/main/java/com/into/websoso/feature/library/component/LibraryFilterEmptyView.kt
@@ -40,7 +40,7 @@ internal fun LibraryFilterEmptyView() {
             Spacer(modifier = Modifier.height(8.dp))
             Text(
                 text = "해당하는 작품이 없어요\n" +
-                    "다른 검색어를 시도해보세요",
+                    "검색의 범위를 더 넓혀보세요",
                 style = WebsosoTheme.typography.body1,
                 color = Gray200,
                 textAlign = TextAlign.Center,

--- a/feature/library/src/main/java/com/into/websoso/feature/library/component/LibraryGridListItem.kt
+++ b/feature/library/src/main/java/com/into/websoso/feature/library/component/LibraryGridListItem.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
@@ -134,7 +135,7 @@ private fun ReadStatusBadge(
 ) {
     Box(
         modifier = modifier
-            .width(48.dp)
+            .widthIn(48.dp)
             .background(
                 color = readStatusUiModel.backgroundColor,
                 shape = RoundedCornerShape(4.dp),
@@ -145,6 +146,7 @@ private fun ReadStatusBadge(
             text = readStatusUiModel.readStatus.label,
             color = White,
             style = WebsosoTheme.typography.label2,
+            maxLines = 1,
         )
     }
 }

--- a/feature/library/src/main/java/com/into/websoso/feature/library/component/LibrayFilterTopBar.kt
+++ b/feature/library/src/main/java/com/into/websoso/feature/library/component/LibrayFilterTopBar.kt
@@ -101,6 +101,7 @@ private fun NovelFilterChipSection(
                 .height(32.dp)
                 .background(color = Gray70),
         )
+
         NovelFilterChip(
             text = libraryFilterUiModel.readStatusLabelText,
             isSelected = libraryFilterUiModel.readStatuses.isSelected,
@@ -108,14 +109,14 @@ private fun NovelFilterChipSection(
         )
 
         NovelFilterChip(
-            text = libraryFilterUiModel.ratingText,
-            isSelected = libraryFilterUiModel.novelRating.isSelected,
+            text = libraryFilterUiModel.attractivePointLabelText,
+            isSelected = libraryFilterUiModel.attractivePoints.isSelected,
             onClick = onFilterClick,
         )
 
         NovelFilterChip(
-            text = libraryFilterUiModel.attractivePointLabelText,
-            isSelected = libraryFilterUiModel.attractivePoints.isSelected,
+            text = libraryFilterUiModel.ratingText,
+            isSelected = libraryFilterUiModel.novelRating.isSelected,
             onClick = onFilterClick,
         )
     }


### PR DESCRIPTION
## 📌𝘐𝘴𝘴𝘶𝘦𝘴
- closed #742 

## 📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯
- 하차함 -> 하차로 라벨 수정
- 별점 401 문제 수정
- 엠티뷰 문구 수정
- 필터 칩 순서 변경


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 버그 수정
  - 사용자 소설 평점이 올바르게 저장·표시되도록 수정
  - 라이브러리 필터 상단바에서 평점/매력포인트 칩이 뒤바뀌어 보이던 문제 수정
- 스타일
  - 목록 아이템의 상태 배지 폭을 유연하게 조정하고 라벨을 한 줄로 제한해 가독성 향상
  - 읽음 상태 라벨 ‘하차함’을 ‘하차’로 통일
  - 필터 결과 없음 메시지 문구를 더 명확하게 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->