### PR TITLE
fix: 타유저 서재 뷰 상태바 패딩 적용

### DIFF
--- a/app/src/main/java/com/into/websoso/ui/userStorage/UserStorageActivity.kt
+++ b/app/src/main/java/com/into/websoso/ui/userStorage/UserStorageActivity.kt
@@ -5,6 +5,7 @@ import android.content.Intent
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.activity.viewModels
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.WindowInsets
@@ -29,7 +30,7 @@ class UserStorageActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-
+        enableEdgeToEdge()
         setContent {
             WebsosoTheme {
                 Scaffold(

--- a/app/src/main/java/com/into/websoso/ui/userStorage/UserStorageActivity.kt
+++ b/app/src/main/java/com/into/websoso/ui/userStorage/UserStorageActivity.kt
@@ -14,7 +14,6 @@ import androidx.compose.foundation.layout.systemBars
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.material3.Scaffold
 import androidx.compose.ui.Modifier
-import com.into.websoso.R
 import com.into.websoso.core.common.navigator.NavigatorProvider
 import com.into.websoso.core.designsystem.theme.WebsosoTheme
 import com.into.websoso.feature.library.LibraryScreen
@@ -23,7 +22,7 @@ import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 
 @AndroidEntryPoint
-class UserStorageActivity : ComponentActivity(R.layout.activity_storage) {
+class UserStorageActivity : ComponentActivity() {
     @Inject
     lateinit var websosoNavigator: NavigatorProvider
     private val libraryViewModel: LibraryViewModel by viewModels()

--- a/app/src/main/java/com/into/websoso/ui/userStorage/UserStorageActivity.kt
+++ b/app/src/main/java/com/into/websoso/ui/userStorage/UserStorageActivity.kt
@@ -3,10 +3,17 @@ package com.into.websoso.ui.userStorage
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
+import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
-import androidx.activity.enableEdgeToEdge
 import androidx.activity.viewModels
-import androidx.appcompat.app.AppCompatActivity
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.systemBars
+import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.material3.Scaffold
+import androidx.compose.ui.Modifier
 import com.into.websoso.R
 import com.into.websoso.core.common.navigator.NavigatorProvider
 import com.into.websoso.core.designsystem.theme.WebsosoTheme
@@ -16,7 +23,7 @@ import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 
 @AndroidEntryPoint
-class UserStorageActivity : AppCompatActivity(R.layout.activity_storage) {
+class UserStorageActivity : ComponentActivity(R.layout.activity_storage) {
     @Inject
     lateinit var websosoNavigator: NavigatorProvider
     private val libraryViewModel: LibraryViewModel by viewModels()
@@ -24,18 +31,28 @@ class UserStorageActivity : AppCompatActivity(R.layout.activity_storage) {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        enableEdgeToEdge()
         setContent {
             WebsosoTheme {
-                LibraryScreen(
-                    libraryViewModel = libraryViewModel,
-                    navigateToNormalExploreActivity = {
-                        websosoNavigator.navigateToNormalExploreActivity(::startActivity)
-                    },
-                    navigateToNovelDetailActivity = { novelId ->
-                        websosoNavigator.navigateToNovelDetailActivity(novelId, ::startActivity)
-                    },
-                )
+                Scaffold(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .windowInsetsPadding(WindowInsets.systemBars),
+                ) { inner ->
+                    Box(modifier = Modifier.padding(inner)) {
+                        LibraryScreen(
+                            libraryViewModel = libraryViewModel,
+                            navigateToNormalExploreActivity = {
+                                websosoNavigator.navigateToNormalExploreActivity(::startActivity)
+                            },
+                            navigateToNovelDetailActivity = { novelId ->
+                                websosoNavigator.navigateToNovelDetailActivity(
+                                    novelId,
+                                    ::startActivity,
+                                )
+                            },
+                        )
+                    }
+                }
             }
         }
     }

--- a/app/src/main/res/layout/activity_storage.xml
+++ b/app/src/main/res/layout/activity_storage.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    tools:context=".ui.userStorage.UserStorageActivity">
-
-</androidx.constraintlayout.widget.ConstraintLayout>

--- a/data/library/src/main/java/com/into/websoso/data/library/paging/LibraryPagingSource.kt
+++ b/data/library/src/main/java/com/into/websoso/data/library/paging/LibraryPagingSource.kt
@@ -33,7 +33,7 @@ class LibraryPagingSource(
         )
     }
 
-    override fun getRefreshKey(state: PagingState<Long, NovelEntity>): Long = DEFAULT_LAST_USER_NOVEL_ID
+    override fun getRefreshKey(state: PagingState<Long, NovelEntity>): Long? = DEFAULT_LAST_USER_NOVEL_ID
 
     companion object {
         private const val DEFAULT_LAST_USER_NOVEL_ID = 0L

--- a/data/library/src/main/java/com/into/websoso/data/library/paging/LibraryPagingSource.kt
+++ b/data/library/src/main/java/com/into/websoso/data/library/paging/LibraryPagingSource.kt
@@ -33,10 +33,7 @@ class LibraryPagingSource(
         )
     }
 
-    override fun getRefreshKey(state: PagingState<Long, NovelEntity>): Long? =
-        state.anchorPosition?.let { position ->
-            state.closestItemToPosition(position)?.userNovelId
-        }
+    override fun getRefreshKey(state: PagingState<Long, NovelEntity>): Long = DEFAULT_LAST_USER_NOVEL_ID
 
     companion object {
         private const val DEFAULT_LAST_USER_NOVEL_ID = 0L

--- a/domain/library/src/main/java/com/into/websoso/domain/library/model/Rating.kt
+++ b/domain/library/src/main/java/com/into/websoso/domain/library/model/Rating.kt
@@ -6,6 +6,12 @@ enum class Rating(
     val value: Float,
 ) {
     DEFAULT(0.0f),
+    POINT_FIVE(0.5f),
+    ONE(1.0f),
+    ONE_POINT_FIVE(1.5f),
+    TWO(2.0f),
+    TWO_POINT_FIVE(2.5f),
+    THREE(3.0f),
     THREE_POINT_FIVE(3.5f),
     FOUR(4.0f),
     FOUR_POINT_FIVE(4.5f),
@@ -13,6 +19,9 @@ enum class Rating(
     ;
 
     companion object {
-        fun from(value: Float): Rating = entries.find { it.value.isCloseTo(value) } ?: DEFAULT
+        fun from(value: Float): Rating =
+            entries.find {
+                it.value.isCloseTo(value)
+            } ?: DEFAULT
     }
 }


### PR DESCRIPTION
## 📌𝘐𝘴𝘴𝘶𝘦𝘴
- closed #744 

## 📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯
- 해당 뷰는 BaseActivity를 사용하지 않으므로, Scaffold로 감싸고, `.windowInsetsPadding(WindowInsets.systemBars)` 지정해줬습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 새로운 기능
  - 평점에 0.5 단위 세분화(0.5~3.0 추가)로 보다 정밀한 평가 및 표시가 가능해졌습니다.
- 버그 수정
  - 목록 새로고침 시 고정 시작점으로 로드되어 일관된 새로고침 동작을 제공합니다.
- 리팩터링
  - 사용자 저장소 화면을 Compose 기반으로 전환하고 시스템바 여백을 반영한 Scaffold 구성으로 UI가 재구성되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->