### PR TITLE
fix: My -> 내서재 이동 시 백스택 쌓이는 버그

### DIFF
--- a/app/src/main/java/com/into/websoso/ui/main/MainActivity.kt
+++ b/app/src/main/java/com/into/websoso/ui/main/MainActivity.kt
@@ -4,6 +4,7 @@ import android.annotation.SuppressLint
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
+import android.util.Log
 import android.view.View
 import androidx.activity.OnBackPressedCallback
 import androidx.activity.viewModels
@@ -57,6 +58,12 @@ class MainActivity : BaseActivity<ActivityMainBinding>(activity_main) {
         setupObserver()
         onViewGuestClick()
         handleNavigation(intent.getSerializableExtra(DESTINATION_KEY) as? FragmentType)
+        supportFragmentManager.setFragmentResultListener(
+            "NAVIGATE_TO_LIBRARY_FRAGMENT",
+            this,
+        ) { _, _ ->
+            handleNavigation(LIBRARY)
+        }
     }
 
     private fun setupBackButtonListener() {
@@ -130,6 +137,7 @@ class MainActivity : BaseActivity<ActivityMainBinding>(activity_main) {
         val existingFragment = supportFragmentManager.findFragmentByTag(tag)
         val targetFragment = existingFragment ?: findOrCreateFragment(tag)
 
+        Log.d("123123", tag.toString())
         supportFragmentManager.commit {
             setReorderingAllowed(true)
 

--- a/app/src/main/java/com/into/websoso/ui/main/MainActivity.kt
+++ b/app/src/main/java/com/into/websoso/ui/main/MainActivity.kt
@@ -4,7 +4,6 @@ import android.annotation.SuppressLint
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
-import android.util.Log
 import android.view.View
 import androidx.activity.OnBackPressedCallback
 import androidx.activity.viewModels

--- a/app/src/main/java/com/into/websoso/ui/main/MainActivity.kt
+++ b/app/src/main/java/com/into/websoso/ui/main/MainActivity.kt
@@ -137,7 +137,6 @@ class MainActivity : BaseActivity<ActivityMainBinding>(activity_main) {
         val existingFragment = supportFragmentManager.findFragmentByTag(tag)
         val targetFragment = existingFragment ?: findOrCreateFragment(tag)
 
-        Log.d("123123", tag.toString())
         supportFragmentManager.commit {
             setReorderingAllowed(true)
 

--- a/app/src/main/java/com/into/websoso/ui/main/myPage/myLibrary/MyLibraryFragment.kt
+++ b/app/src/main/java/com/into/websoso/ui/main/myPage/myLibrary/MyLibraryFragment.kt
@@ -25,7 +25,6 @@ import com.into.websoso.core.resource.R.string.my_library_attractive_point_fixed
 import com.into.websoso.data.model.GenrePreferenceEntity
 import com.into.websoso.data.model.NovelPreferenceEntity
 import com.into.websoso.databinding.FragmentMyLibraryBinding
-import com.into.websoso.ui.main.MainActivity
 import com.into.websoso.ui.main.myPage.myLibrary.adapter.RestGenrePreferenceAdapter
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -198,25 +197,15 @@ class MyLibraryFragment : BaseFragment<FragmentMyLibraryBinding>(fragment_my_lib
     private fun onStorageButtonClick() {
         binding.clMyLibraryTopBar.setOnClickListener {
             singleEventHandler.throttleFirst {
-                navigateToLibraryFragment()
+                requireActivity().supportFragmentManager.setFragmentResult("NAVIGATE_TO_LIBRARY_FRAGMENT", Bundle.EMPTY)
             }
         }
 
         binding.llMyLibraryStorage.setOnClickListener {
             singleEventHandler.throttleFirst {
-                navigateToLibraryFragment()
+                requireActivity().supportFragmentManager.setFragmentResult("NAVIGATE_TO_LIBRARY_FRAGMENT", Bundle.EMPTY)
             }
         }
-    }
-
-    private fun navigateToLibraryFragment() {
-        startActivity(
-            MainActivity
-                .getIntent(
-                    context = requireContext(),
-                    destination = MainActivity.FragmentType.LIBRARY,
-                ),
-        )
     }
 
     private fun updateDominantGenres(topGenres: List<GenrePreferenceEntity>) {


### PR DESCRIPTION
## 📌𝘐𝘴𝘴𝘶𝘦𝘴
- closed #759 

## 📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯
- 보관함에서 서재로 이동 시, 백스택 쌓이는 문제 해결

## 💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 리팩터링
  - 마이페이지 상단바 및 보관함에서 라이브러리 이동 흐름을 개선했습니다. 액티비티 재시작 없이 현재 화면에서 즉시 전환되어 전환 속도와 부드러움이 향상되며 화면 깜빡임·지연이 줄어들고 상태 유지가 더 안정적입니다. 뒤로 가기 동작도 보다 일관된 탐색을 제공합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->