### PR TITLE
build: 프로젝트 버전 개선

### DIFF
--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -6,4 +6,5 @@ dependencies {
     implementation(libs.android.gradle.plugin)
     implementation(libs.kotlin.gradle.plugin)
     implementation(libs.hilt.gradle.plugin)
+    implementation(libs.kotlin.compose.compiler.gradle.plugin)
 }

--- a/build-logic/src/main/kotlin/com/into/websoso/BuildConfigExtensions.kt
+++ b/build-logic/src/main/kotlin/com/into/websoso/BuildConfigExtensions.kt
@@ -2,17 +2,31 @@ package com.into.websoso
 
 import com.android.build.api.dsl.ApplicationDefaultConfig
 import com.android.build.api.dsl.BuildType
-import com.android.build.gradle.internal.cxx.configure.gradleLocalProperties
 import java.io.File
+import java.util.Properties
+
+/**
+ * local.properties를 읽는 함수
+ */
+fun getLocalProperties(rootDir: File): Properties {
+    val properties = Properties()
+    val localPropertiesFile = File(rootDir, "local.properties")
+    if (localPropertiesFile.exists()) {
+        localPropertiesFile.inputStream().use { properties.load(it) }
+    }
+    return properties
+}
 
 fun ApplicationDefaultConfig.buildConfigs(
     rootDir: File,
     block: BuildConfigScope.() -> Unit,
 ) {
-    val properties = gradleLocalProperties(rootDir)
+    val properties = getLocalProperties(rootDir)
     BuildConfigScope { name, key ->
-        val value = properties.getProperty(key)
-        buildConfigField("String", name, value)
+        val rawValue = properties.getProperty(key) ?: ""
+        val cleanedValue = rawValue.removeSurrounding("\"")
+
+        buildConfigField("String", name, "\"$cleanedValue\"")
     }.apply(block)
 }
 
@@ -20,17 +34,19 @@ fun BuildType.buildConfigs(
     rootDir: File,
     block: BuildConfigScope.() -> Unit,
 ) {
-    val properties = gradleLocalProperties(rootDir)
+    val properties = getLocalProperties(rootDir)
     BuildConfigScope { name, key ->
-        val value = properties.getProperty(key)
-        buildConfigField("String", name, value)
+        val rawValue = properties.getProperty(key) ?: ""
+        val cleanedValue = rawValue.removeSurrounding("\"")
+
+        buildConfigField("String", name, "\"$cleanedValue\"")
     }.apply(block)
 }
 
 fun getLocalProperty(
     rootDir: File,
     key: String,
-): String = gradleLocalProperties(rootDir).getProperty(key).trim('"')
+): String = getLocalProperties(rootDir).getProperty(key).trim('"')
 
 fun interface BuildConfigScope {
     fun string(

--- a/build-logic/src/main/kotlin/com/into/websoso/ProjectExtensions.kt
+++ b/build-logic/src/main/kotlin/com/into/websoso/ProjectExtensions.kt
@@ -12,13 +12,13 @@ fun Project.setNamespace(name: String) {
     }
 }
 
-internal val Project.applicationExtension: CommonExtension<*, *, *, *, *>
+internal val Project.applicationExtension: CommonExtension<*, *, *, *, *, *>
     get() = extensions.getByType<ApplicationExtension>()
 
-internal val Project.libraryExtension: CommonExtension<*, *, *, *, *>
+internal val Project.libraryExtension: CommonExtension<*, *, *, *, *, *>
     get() = extensions.getByType<LibraryExtension>()
 
-internal val Project.androidExtension: CommonExtension<*, *, *, *, *>
+internal val Project.androidExtension: CommonExtension<*, *, *, *, *, *>
     get() = runCatching { libraryExtension }
         .recoverCatching { applicationExtension }
         .onFailure { println("Could not find Library or Application extension from this project") }

--- a/build-logic/src/main/kotlin/websoso.android.compose.gradle.kts
+++ b/build-logic/src/main/kotlin/websoso.android.compose.gradle.kts
@@ -1,9 +1,12 @@
 import com.into.websoso.androidExtension
 import com.into.websoso.websosoDependencies
 
+plugins {
+    id("org.jetbrains.kotlin.plugin.compose")
+}
+
 androidExtension.apply {
     buildFeatures.compose = true
-    composeOptions.kotlinCompilerExtensionVersion = "1.5.2"
 }
 
 websosoDependencies {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,4 +8,5 @@ plugins {
     alias(libs.plugins.kotlin.kapt) apply false
     alias(libs.plugins.ktlint)
     alias(libs.plugins.android.library) apply false
+    alias(libs.plugins.compose.compiler) apply false
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,72 +4,72 @@ versionCode = "10041"
 versionName = "1.4.0"
 
 # Gradle Plugin & Kotlin
-android-gradle-plugin = "8.1.3"
-kotlin = "1.9.0"
-serialization = "1.5.1"
+android-gradle-plugin = "8.13.2"
+kotlin = "2.2.0"
+serialization = "1.9.0"
 
 # Dependency Injection
-hilt = "2.48"
-hilt-navigation-compose = "1.2.0"
-dagger = "2.56.1"
+hilt = "2.57.2"
+hilt-navigation-compose = "1.3.0"
+dagger = "2.57.2"
 javax-inject = "1"
 
 # Firebase
-google-services = "4.4.2"
-firebase-bom = "33.7.0"
+google-services = "4.4.4"
+firebase-bom = "34.7.0"
 
 # Analytics
 amplitude = "1.+"
 
 # AndroidX Libraries
-androidx = "1.9.0"
-appcompat = "1.6.1"
-material = "1.11.0"
-constraintlayout = "2.1.4"
-viewpager2 = "1.0.0"
-fragment-ktx = "1.6.1"
+androidx = "1.15.0"
+appcompat = "1.7.1"
+material = "1.13.0"
+constraintlayout = "2.2.1"
+viewpager2 = "1.1.0"
+fragment-ktx = "1.8.5"
 lifecycle-extensions = "2.2.0"
-datastore-preferences = "1.1.1"
-security-crypto = "1.1.0-alpha06"
-room = "2.6.1"
+datastore-preferences = "1.2.0"
+security-crypto = "1.1.0"
+room = "2.8.4"
 paging = "3.3.6"
 
 # Testing Libraries
 junit = "4.13.2"
-androidx-test-junit = "1.1.5"
-espresso-core = "3.5.1"
+androidx-test-junit = "1.3.0"
+espresso-core = "3.7.0"
 
 # Networking Libraries
-retrofit = "2.11.0"
+retrofit = "3.0.0"
 retrofit-kotlinx-serialization = "1.0.0"
-okhttp = "4.11.0"
-okhttp-logging-interceptor = "4.10.0"
+okhttp = "5.3.2"
+okhttp-logging-interceptor = "5.3.2"
 
 # Coroutines
-coroutines = "1.6.4"
+coroutines = "1.10.2"
 
 # Image Loading Libraries
 coil = "2.7.0"
 coil-transformers = "1.0.6"
 
 # Misc UI Libraries
-dots-indicator = "5.0"
-lottie = "5.0.2"
+dots-indicator = "5.1.0"
+lottie = "6.7.1"
 pull-to-refresh = "1.5.2"
 
 # Social Login Libraries
-kakao = "2.15.0"
+kakao = "2.23.1"
 
 # Ktlint
-ktlint = "12.1.0"
+ktlint = "14.0.1"
 
 # Jetpack Compose Libraries
-compose-bom = "2024.12.01"
-compose-compiler = "1.5.2"
-compose-ui = "1.7.6"
+compose-bom = "2025.12.01"
+compose-ui = "1.10.0"
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "android-gradle-plugin" }
+compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kotlin-kapt = { id = "org.jetbrains.kotlin.kapt", version.ref = "kotlin" }
@@ -85,6 +85,7 @@ android-library = { id = "com.android.library", version.ref = "android-gradle-pl
 android-gradle-plugin = { group = "com.android.tools.build", name = "gradle", version.ref = "android-gradle-plugin" }
 kotlin-gradle-plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 hilt-gradle-Plugin = { group = "com.google.dagger", name = "hilt-android-gradle-plugin", version.ref = "hilt" }
+kotlin-compose-compiler-gradle-plugin = { group = "org.jetbrains.kotlin", name = "compose-compiler-gradle-plugin", version.ref = "kotlin" }
 
 # AndroidX Libraries
 androidx-core-ktx = { module = "androidx.core:core-ktx", version.ref = "androidx" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Sun Mar 10 17:48:02 KST 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
## 📌𝘐𝘴𝘴𝘶𝘦𝘴
- closed #756 

## 📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯
### 주요 변경 사항 요약
#### 🚀 Build Environment (Kotlin & Gradle)
Android Gradle Plugin (AGP): 8.1.3 → 8.13.2
Kotlin: 1.9.0 → 2.2.0
Compose Compiler: Kotlin 2.0+ 통합에 따라 별도 플러그인 방식으로 전환  

#### 📱 AndroidX & UI
Core-KTX: 1.9.0 → 1.15.0 (SDK 36 강제 방지를 위한 1.15.0 고정)
Fragment-KTX: 1.6.1 → 1.8.5
AppCompat: 1.6.1 → 1.7.1
Material: 1.11.0 → 1.13.0
ConstraintLayout: 2.1.4 → 2.2.1
Room: 2.6.1 → 2.8.4  

#### 🔗 Networking & Coroutines  
Retrofit: 2.11.0 → 3.0.0
OkHttp: 4.11.0 → 5.3.2
Coroutines: 1.6.4 → 1.10.2
Serialization: 1.5.1 → 1.9.0  

#### 💉 Dependency Injection (Hilt)
Hilt/Dagger: 2.48 → 2.57.2
Hilt Navigation Compose: 1.2.0 → 1.3.0  

#### ✨ Jetpack Compose
Compose BOM: 2024.12.01 → 2025.12.01
Compose UI: 1.7.6 → 1.10.0  

#### 📊 Firebase & Analytics & Etc
Firebase BOM: 33.7.0 → 34.7.0
Kakao SDK: 2.15.0 → 2.23.1
Lottie: 5.0.2 → 6.7.1
Ktlint: 12.1.0 → 14.0.1

### 체크리스트

- [x] Compile SDK 35 환경에서 빌드 성공 여부 확인
- [x] Kotlin 2.2.0 컴파일러 및 Compose Compiler 플러그인 정상 작동 확인
- [x] local.properties 기반의 BuildField 생성 로직(따옴표 중복 이슈) 수정 완료
- [x] Hilt 컴파일 및 의존성 주입 테스트 완료

### 주의 사항
androidx.core:core-ktx를 1.17.0으로 올릴 경우 Compile SDK 36이 강제되므로, 차후 SDK 업데이트 전까지는 1.15.0 버전을 유지해야 합니다.