### PR TITLE
fix: 내 피드 필터 설정 시 새로고침

### DIFF
--- a/feature/feed/src/main/java/com/into/websoso/feature/feed/UpdatedFeedViewModel.kt
+++ b/feature/feed/src/main/java/com/into/websoso/feature/feed/UpdatedFeedViewModel.kt
@@ -19,160 +19,196 @@ import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
-class UpdatedFeedViewModel @Inject constructor(
-    private val getFeedsUseCase: UpdatedGetFeedsUseCase,
-    private val getMyFeedsUseCase: UpdatedGetMyFeedsUseCase,
-    private val feedRepository: UpdatedFeedRepository,
-) : ViewModel() {
+class UpdatedFeedViewModel
+    @Inject
+    constructor(
+        private val getFeedsUseCase: UpdatedGetFeedsUseCase,
+        private val getMyFeedsUseCase: UpdatedGetMyFeedsUseCase,
+        private val feedRepository: UpdatedFeedRepository,
+    ) : ViewModel() {
+        private val _uiState = MutableStateFlow(FeedUiState())
+        val uiState = _uiState.asStateFlow()
 
-    private val _uiState = MutableStateFlow(FeedUiState())
-    val uiState = _uiState.asStateFlow()
+        init {
+            collectFeedFlows()
+            fetchNextPage()
+        }
 
-    init {
-        collectFeedFlows()
-        fetchNextPage()
-    }
-
-    private fun collectFeedFlows() {
-        viewModelScope.launch {
-            getFeedsUseCase.sosoAllFlow.collect { feeds ->
-                val uiFeeds = feeds.map { it.toFeedUiModel() }.toImmutableList()
-                _uiState.update { state ->
-                    val updatedAllData = state.sosoAllData.copy(feeds = uiFeeds)
-                    if (state.selectedTab == FeedTab.SOSO_FEED && state.sosoCategory == SosoFeedType.ALL) {
-                        state.copy(sosoAllData = updatedAllData).updateCurrentSource(updatedAllData)
-                    } else {
-                        state.copy(sosoAllData = updatedAllData)
+        private fun collectFeedFlows() {
+            viewModelScope.launch {
+                getFeedsUseCase.sosoAllFlow.collect { feeds ->
+                    val uiFeeds = feeds.map { it.toFeedUiModel() }.toImmutableList()
+                    _uiState.update { state ->
+                        val updatedAllData = state.sosoAllData.copy(feeds = uiFeeds)
+                        if (state.selectedTab == FeedTab.SOSO_FEED && state.sosoCategory == SosoFeedType.ALL) {
+                            state.copy(sosoAllData = updatedAllData).updateCurrentSource(updatedAllData)
+                        } else {
+                            state.copy(sosoAllData = updatedAllData)
+                        }
+                    }
+                }
+            }
+            viewModelScope.launch {
+                getFeedsUseCase.sosoRecommendedFlow.collect { feeds ->
+                    val uiFeeds = feeds.map { it.toFeedUiModel() }.toImmutableList()
+                    _uiState.update { state ->
+                        val updatedRecData = state.sosoRecommendationData.copy(feeds = uiFeeds)
+                        if (state.selectedTab == FeedTab.SOSO_FEED && state.sosoCategory == SosoFeedType.RECOMMENDED) {
+                            state
+                                .copy(sosoRecommendationData = updatedRecData)
+                                .updateCurrentSource(updatedRecData)
+                        } else {
+                            state.copy(sosoRecommendationData = updatedRecData)
+                        }
+                    }
+                }
+            }
+            viewModelScope.launch {
+                getMyFeedsUseCase.myFeedsFlow.collect { feeds ->
+                    val uiFeeds = feeds.map { it.toFeedUiModel() }.toImmutableList()
+                    _uiState.update { state ->
+                        val updatedMyData = state.myFeedData.copy(feeds = uiFeeds)
+                        if (state.selectedTab == FeedTab.MY_FEED) {
+                            state.copy(myFeedData = updatedMyData).updateCurrentSource(updatedMyData)
+                        } else {
+                            state.copy(myFeedData = updatedMyData)
+                        }
                     }
                 }
             }
         }
-        viewModelScope.launch {
-            getFeedsUseCase.sosoRecommendedFlow.collect { feeds ->
-                val uiFeeds = feeds.map { it.toFeedUiModel() }.toImmutableList()
-                _uiState.update { state ->
-                    val updatedRecData = state.sosoRecommendationData.copy(feeds = uiFeeds)
-                    if (state.selectedTab == FeedTab.SOSO_FEED && state.sosoCategory == SosoFeedType.RECOMMENDED) {
-                        state.copy(sosoRecommendationData = updatedRecData)
-                            .updateCurrentSource(updatedRecData)
-                    } else {
-                        state.copy(sosoRecommendationData = updatedRecData)
+
+        fun fetchNextPage(feedId: Long? = null) {
+            val state = uiState.value
+            val current = state.currentData
+            val lastFeedId = feedId ?: current.lastId
+
+            if (state.loading || (!current.isLoadable && lastFeedId != 0L)) return
+
+            _uiState.update { it.copy(loading = true) }
+
+            viewModelScope.launch {
+                runCatching {
+                    when (state.selectedTab) {
+                        FeedTab.MY_FEED -> {
+                            getMyFeedsUseCase(
+                                lastFeedId = lastFeedId,
+                                genres = state.currentFilter.selectedGenres.map { it.tag },
+                                isVisible = state.currentFilter.isVisible,
+                                sortCriteria = state.myFeedData.sort.name
+                                    .uppercase(),
+                                isUnVisible = state.currentFilter.isUnVisible,
+                            )
+                        }
+
+                        FeedTab.SOSO_FEED -> {
+                            getFeedsUseCase(
+                                feedsOption = state.sosoCategory.name.uppercase(),
+                                lastFeedId = lastFeedId,
+                            )
+                        }
                     }
-                }
-            }
-        }
-        viewModelScope.launch {
-            getMyFeedsUseCase.myFeedsFlow.collect { feeds ->
-                val uiFeeds = feeds.map { it.toFeedUiModel() }.toImmutableList()
-                _uiState.update { state ->
-                    val updatedMyData = state.myFeedData.copy(feeds = uiFeeds)
-                    if (state.selectedTab == FeedTab.MY_FEED) {
-                        state.copy(myFeedData = updatedMyData).updateCurrentSource(updatedMyData)
-                    } else {
-                        state.copy(myFeedData = updatedMyData)
-                    }
-                }
-            }
-        }
-    }
-
-    fun fetchNextPage(feedId: Long? = null) {
-        val state = uiState.value
-        val current = state.currentData
-        val lastFeedId = feedId ?: current.lastId
-
-        if (state.loading || (!current.isLoadable && lastFeedId != 0L)) return
-
-        _uiState.update { it.copy(loading = true) }
-
-        viewModelScope.launch {
-            runCatching {
-                when (state.selectedTab) {
-
-                    FeedTab.MY_FEED -> {
-                        getMyFeedsUseCase(
-                            lastFeedId = lastFeedId,
-                            genres = state.currentFilter.selectedGenres.map { it.tag },
-                            isVisible = state.currentFilter.isVisible,
-                            sortCriteria = state.myFeedData.sort.name.uppercase(),
-                            isUnVisible = state.currentFilter.isUnVisible,
+                }.onSuccess { result ->
+                    _uiState.update { currentState ->
+                        val updatedSource = currentState.currentData.copy(
+                            lastId = result.isLoadable.let {
+                                if (it) result.feeds.lastOrNull()?.id ?: 0 else 0
+                            },
+                            isLoadable = result.isLoadable,
                         )
+                        currentState
+                            .updateCurrentSource(updatedSource)
+                            .copy(loading = false, isRefreshing = false)
                     }
-
-                    FeedTab.SOSO_FEED -> getFeedsUseCase(
-                        feedsOption = state.sosoCategory.name.uppercase(),
-                        lastFeedId = lastFeedId,
-                    )
+                }.onFailure {
+                    _uiState.update { it.copy(loading = false, isRefreshing = false, error = true) }
                 }
-            }.onSuccess { result ->
-                _uiState.update { currentState ->
-                    val updatedSource = currentState.currentData.copy(
-                        lastId = result.isLoadable.let {
-                            if (it) result.feeds.lastOrNull()?.id ?: 0 else 0
-                        },
-                        isLoadable = result.isLoadable,
-                    )
-                    currentState.updateCurrentSource(updatedSource)
-                        .copy(loading = false, isRefreshing = false)
-                }
-            }.onFailure {
-                _uiState.update { it.copy(loading = false, isRefreshing = false, error = true) }
             }
         }
-    }
 
-    /**
-     * [새로고침] 기존 데이터를 지우지 않고 isRefreshing만 켠 후 재요청
-     * 데이터 교체는 Repository가 Flow를 방출할 때 자연스럽게 이루어짐
-     */
-    fun refresh() {
-        _uiState.update { it.copy(isRefreshing = true) }
-        fetchNextPage(feedId = 0L)
-    }
+        /**
+         * [새로고침] 기존 데이터를 지우지 않고 isRefreshing만 켠 후 재요청
+         * 데이터 교체는 Repository가 Flow를 방출할 때 자연스럽게 이루어짐
+         */
+        fun refresh() {
+            _uiState.update { it.copy(isRefreshing = true) }
+            fetchNextPage(feedId = 0L)
+        }
 
-    fun updateLike(selectedFeedId: Long) = feedRepository.toggleLikeLocal(selectedFeedId)
+        fun updateLike(selectedFeedId: Long) = feedRepository.toggleLikeLocal(selectedFeedId)
 
-    fun updateRemovedFeed(feedId: Long) {
-        _uiState.update { it.copy(loading = true) }
-        viewModelScope.launch {
-            feedRepository.saveRemovedFeed(feedId)
-            _uiState.update { it.copy(loading = false) }
+        fun updateRemovedFeed(feedId: Long) {
+            _uiState.update { it.copy(loading = true) }
+            viewModelScope.launch {
+                feedRepository.saveRemovedFeed(feedId)
+                _uiState.update { it.copy(loading = false) }
+            }
+        }
+
+        fun updateReportedSpoilerFeed(feedId: Long) {
+            viewModelScope.launch { feedRepository.saveSpoilerFeed(feedId) }
+        }
+
+        fun updateReportedImpertinenceFeed(feedId: Long) {
+            viewModelScope.launch { feedRepository.saveImpertinenceFeed(feedId) }
+        }
+
+        override fun onCleared() {
+            super.onCleared()
+            feedRepository.syncDirtyFeeds()
+        }
+
+        // --- 기타 탭/필터 로직 ---
+        fun updateMyFeedSort(sort: FeedOrder) {
+            if (uiState.value.myFeedData.sort == sort) return
+
+            _uiState.update { state ->
+                val resetMyData = state.myFeedData.copy(
+                    lastId = 0L,
+                    isLoadable = true,
+                    sort = sort,
+                )
+                state.copy(
+                    myFeedData = resetMyData,
+                    isRefreshing = true,
+                    error = false,
+                )
+            }
+            fetchNextPage(feedId = 0L)
+        }
+
+        fun updateTab(tab: FeedTab) {
+            _uiState.update { it.copy(selectedTab = tab) }
+            if (uiState.value.currentData.feeds
+                    .isEmpty()
+            ) {
+                fetchNextPage(feedId = 0L)
+            }
+        }
+
+        fun updateSosoCategory(category: SosoFeedType) {
+            if (uiState.value.sosoCategory == category) return
+            _uiState.update { it.copy(sosoCategory = category) }
+            if (uiState.value.currentData.feeds
+                    .isEmpty()
+            ) {
+                fetchNextPage(feedId = 0L)
+            }
+        }
+
+        fun applyMyFilter(filter: MyFeedFilter) {
+            _uiState.update { state ->
+                val resetMyData = state.myFeedData.copy(
+                    lastId = 0L,
+                    isLoadable = true,
+                )
+                state.copy(
+                    currentFilter = filter,
+                    myFeedData = resetMyData,
+                    isRefreshing = true,
+                    error = false,
+                )
+            }
+            fetchNextPage(feedId = 0L)
         }
     }
-
-    fun updateReportedSpoilerFeed(feedId: Long) {
-        viewModelScope.launch { feedRepository.saveSpoilerFeed(feedId) }
-    }
-
-    fun updateReportedImpertinenceFeed(feedId: Long) {
-        viewModelScope.launch { feedRepository.saveImpertinenceFeed(feedId) }
-    }
-
-    override fun onCleared() {
-        super.onCleared()
-        feedRepository.syncDirtyFeeds()
-    }
-
-    // --- 기타 탭/필터 로직 ---
-    fun updateMyFeedSort(sort: FeedOrder) {
-        if (uiState.value.myFeedData.sort == sort) return
-        _uiState.update { it.copy(myFeedData = FeedSourceData(sort = sort)) }
-        fetchNextPage(feedId = 0L)
-    }
-
-    fun updateTab(tab: FeedTab) {
-        _uiState.update { it.copy(selectedTab = tab) }
-        if (uiState.value.currentData.feeds.isEmpty()) fetchNextPage(feedId = 0L)
-    }
-
-    fun updateSosoCategory(category: SosoFeedType) {
-        if (uiState.value.sosoCategory == category) return
-        _uiState.update { it.copy(sosoCategory = category) }
-        if (uiState.value.currentData.feeds.isEmpty()) fetchNextPage(feedId = 0L)
-    }
-
-    fun applyMyFilter(filter: MyFeedFilter) {
-        _uiState.update { it.copy(currentFilter = filter, myFeedData = FeedSourceData()) }
-        fetchNextPage(feedId = 0L)
-    }
-}


### PR DESCRIPTION
## 📌𝘐𝘴𝘴𝘶𝘦𝘴
- closed #809

## 📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯
- 내 피드에서 필터/정렬 변경 시 동일 결과이면 빈 화면이 고정되는 문제 수정

## 📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵

**[수정 전]**

https://github.com/user-attachments/assets/a2e7c434-b547-4438-b075-4a847714d971


**[수정 후]**

https://github.com/user-attachments/assets/5e1bebfc-c032-403e-bea7-7ba3d615cade



## 💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴

### **문제 상황**
1. 내 피드 탭 진입 후 피드 리스트가 정상 노출된 상태에서
2. 필터를 변경했다가, 결과에 영향이 없는 필터를 다시 해제(또는 원복)했을 때
3. 실제 데이터(피드 목록)는 동일한데도 UI가 Empty 화면으로 전환되고, 이후에도 리스트가 다시 표시되지 않음

요약: 필터 변경 결과가 “사실상 동일”한 케이스에서 빈 화면으로 고정되는 문제

### **원인 분석**
**1) ViewModel에서 필터/정렬 변경 시 UI 데이터를 선제적으로 초기화**

기존 코드에서 필터/정렬 변경 시 아래처럼 myFeedData를 새 객체로 교체하여 feeds가 즉시 empty가 되었습니다.

- `applyMyFilter()에서 myFeedData = FeedSourceData()`

- `updateMyFeedSort()에서 myFeedData = FeedSourceData(sort = sort)`

이로 인해 필터/정렬 버튼을 누르는 순간 UI가 Empty 화면으로 전환될 수 있는 구조였습니다.


**2) Repository(StateFlow)가 “동일 값”이면 emit하지 않아 UI 복구 트리거가 사라짐**

Repository의 MutableStateFlow는 새로운 값이 이전 값과 equals로 동일하면 emit을 하지 않습니다.

실제 로그에서도 아래와 같이 changed=false(동일) 인 케이스가 발생했습니다.
- changed=true: emit 발생 가능(데이터 변경)
- changed=false: 데이터가 동일하여 emit이 발생하지 않음 → UI를 다시 채울 이벤트가 없음

> `current=2, next=2, changed=false`

- 이 경우 `myFeedsFlow.collect { ... }` 가 실행되지 않아 UI를 다시 채우는 로직이 동작하지 않았습니다.
- 결과적으로 ViewModel이 미리 비워둔 `myFeedData.feeds = []` 상태가 유지되어 Empty 화면에서 복구되지 않았습니다.

> 결론: “UI를 먼저 비움” + “동일 결과면 Flow emit 없음” 조합으로 Empty 화면 고정이 발생


### **해결방법**

필터/정렬 변경 시 **기존 리스트(feeds)를 비우지 않고 유지**하며, 다음 요청을 위해 필요한 값만 리셋하도록 수정했습니다.

- feeds는 유지 (Empty 전환 방지)
- 페이지네이션을 위한 lastId=0, isLoadable=true만 초기화
- isRefreshing=true로 UI에 갱신 중 상태만 표시
- 서버/Repository에서 실제로 다른 데이터가 emit되면 기존처럼 collect에서 자연스럽게 교체됨

### **변경 사항 요약**

- `applyMyFilter()`: `myFeedData = FeedSourceData()`로 초기화하던 로직 제거 → feeds 유지 + refreshing 처리
- `updateMyFeedSort()`: 동일하게 feeds 유지 + paging reset + refreshing 처리
- 페이징을 위해 lastId=0, isLoadable=true만 리셋하여 재조회는 수행하되, 결과가 동일하여 emit이 없더라도 UI가 빈 화면으로 전환되지 않도록 수정
-  결과적으로 동일 데이터로 인해 emit이 발생하지 않는 상황에서도 UI가 Empty로 고정되지 않음

**비고(동기화 전략과의 관계)**

본 이슈는 "dirty를 언제 서버에 반영할지(동기화 타이밍)"의 문제가 아니라,
UI 상태를 선제적으로 비운 뒤, 동일 결과에서는 Flow emit이 없어 복구되지 않는 UI 상태 관리 문제였습니다!
따라서 데이터가 동일해 emit이 없더라도 UI가 안정적으로 유지되도록 UI 상태 관리를 개선하였습니다.