### PR TITLE
fix: Android CI 빌드 속도 최적화

### DIFF
--- a/.github/workflows/WSS_PR_builder.yml
+++ b/.github/workflows/WSS_PR_builder.yml
@@ -54,6 +54,7 @@ jobs:
           echo amplitude.key=\"$AMPLITUDE_KEY\" >> ./local.properties
 
       - name: Run Ktlint
+        if: github.event_name == 'pull_request'
         uses: ScaCap/action-ktlint@master
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -61,5 +62,14 @@ jobs:
           fail_on_error: true
           reporter: github-pr-review
 
-      - name: Build with Gradle
-        run: ./gradlew build
+      # 2. PR용: 모든 모듈의 로직을 검증하되, 빌드(컴파일)는 앱 중심으로 효율화
+      - name: Test & Assemble (PR)
+        if: github.event_name == 'pull_request'
+        # 1. 모든 모듈의 유닛 테스트 실행 (로직 검증)
+        # 2. 앱 모듈 디버그 빌드 실행 (의존성 모듈 자동 포함 빌드)
+        run: ./gradlew testDebugUnitTest :app:assembleDebug --scan
+
+      # 3. Merge(Push)용: 전체 검증 (안전장치)
+      - name: Full Build (Push)
+        if: github.event_name == 'push'
+        run: ./gradlew build --scan

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,3 +21,5 @@ kotlin.code.style=official
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
+org.gradle.caching=true
+org.gradle.parallel=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,3 +23,4 @@ kotlin.code.style=official
 android.nonTransitiveRClass=true
 org.gradle.caching=true
 org.gradle.parallel=true
+org.gradle.configuration-cache=true


### PR DESCRIPTION
## 📌𝘐𝘴𝘴𝘶𝘦𝘴
- closed #812

## 📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯
- debug, release 빌드가 함께 되고 있어, 경우(PR, Push)에 따라 빌드를 분리하였습니다.
- Gradle Build Cache / Parallel 활성화
- Configuration Cache 적용


## 📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵

### 1차 반영 후 결과
<img width="1286" height="162" alt="스크린샷 2026-03-03 오후 5 33 57" src="https://github.com/user-attachments/assets/4e3058a0-bf7e-4bc3-a0e7-d73dd5ff689c" />

### 2차 반영 후 결과
<img width="1278" height="84" alt="스크린샷 2026-03-07 오후 2 10 11" src="https://github.com/user-attachments/assets/bfc671a9-ca92-461b-afb1-47deebb0288e" />

### 3차 반영 후 결과
<img width="1281" height="157" alt="스크린샷 2026-03-07 오후 2 10 42" src="https://github.com/user-attachments/assets/aef6e317-a624-4fa8-9c17-89d07508d883" />


## 💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴

### 1차. PR CI 태스크 구조 최적화

기존에는 PR / Push 모두 ./gradlew build를 수행하고 있었으나, 이를 목적에 맞게 분리하였습니다.
PR에서는 아래 검증만 수행하도록 변경했습니다.
- ktlint
- testDebugUnitTest
- :app:assembleDebug

Push에서는 기존 ./gradlew build를 유지하여 전체 검증 안전장치는 남겨두었습니다.

- 의사결정 이유
기존 PR CI는 build 수행으로 인해 release/R8/release lint 등 PR 단계에서 꼭 필요하지 않은 고비용 작업까지 함께 실행되고 있었습니다.
PR 단계의 목적은 머지 전 빠른 피드백 제공이므로, PR에서는 필수 검증만 수행하고 merge 이후(push)에서 전체 검증을 유지하는 방식이 더 적절하다고 판단하였습니다.
또한 Build Scan 및 로컬 분석 결과, 기존 PR 경로에서는 minifyReleaseWithR8, lintVitalAnalyzeRelease와 같은 불필요한 무거운 태스크가 상위 병목으로 나타나고 있었습니다.

- 결과
Before: 13m 28s
After: 7m 25s
→ 6분 3초 단축, 약 45% 감소

추가로, 최신 full build 기준 run과 비교하면:
full build push run: 18분 36초
최적화 후 PR CI run: 7분 25초
→ 11분 11초 단축, 약 60.1% 감소

이 단계의 핵심 개선은 **캐시 적용 효과보다는 Work avoidance(불필요한 작업 제거) 에 있었습니다.**

### 2차. Gradle Build Cache / Parallel 활성화

gradle.properties에 아래 설정을 추가하였습니다.

```
org.gradle.caching=true
org.gradle.parallel=true
```

- 의사결정 이유
1차 최적화 이후 PR 태스크 축소를 통해 이미 큰 폭의 개선이 이루어진 상태였고, 다음으로는 Gradle 자체 실행 효율을 추가로 개선할 수 있는지 확인하고자 하였습니다.
이 단계에서는 GitHub Actions 워크플로까지 함께 변경하지 않고, Gradle 설정만 먼저 조정하여 영향 범위를 분리해 확인하였습니다.

- 결과
적용 전 PR CI: 7분 25초
적용 후 PR CI: 6분 57초
→ 28초 단축, 약 6.3% 감소

Build Scan 기준:
From cache: 0.0% → 0.1%
Tasks avoided: 75%대 유지

실제 실행된 태스크 대부분은 Not cacheable
즉, **Build Cache hit 증가보다는 병렬 실행 및 Gradle 실행 구조 최적화에 따른 소폭 개선**으로 보는 것이 더 적절했습니다.

### 3차. Configuration Cache 적용

이후 gradle.properties에 아래 설정을 추가하였습니다.

`org.gradle.configuration-cache=true`

- 의사결정 이유
2차 적용 이후에도 From cache 비율은 낮았고, 남아 있는 비용 중 하나가 설정 단계(configuration phase)라는 점을 확인하였습니다.
이에 따라 Configuration Cache를 적용하여 설정 단계 결과를 재사용할 수 있는지 확인하고자 하였습니다.

-결과
첫 실행:
6분 57초 → 6분 55초
Configuration cache: MISS
Serial configuration time: 17.949s

동일 조건으로 re-run 후: 6분 45초
Serial configuration time: 0.966s

즉, 설정 단계는 17.949초 → 0.966초로 감소하였고, 약 94.6% 개선되었습니다.
전체 CI 시간 또한 6분 55초 → 6분 45초로 추가 단축되었습니다.

이 단계에서는 **Configuration Cache가 반복 실행 시 설정 단계 비용을 유의미하게 줄이는 데 효과적**임을 확인할 수 있었습니다.

### 결론
가장 큰 성능 개선은 1차의 PR CI 태스크 구조 최적화에서 이루어졌습니다.
이후 Build Cache / Parallel 적용으로 소폭 추가 개선,
마지막으로 Configuration Cache를 통해 반복 실행 시 설정 단계 비용을 크게 줄일 수 있음을 확인하였습니다.
