### PR TITLE
feat: 작가 모아보기 기능

### DIFF
--- a/app/src/main/java/com/into/websoso/ui/normalExplore/NormalExploreActivity.kt
+++ b/app/src/main/java/com/into/websoso/ui/normalExplore/NormalExploreActivity.kt
@@ -47,7 +47,6 @@ class NormalExploreActivity : BaseActivity<ActivityNormalExploreBinding>(activit
         setupUI()
         onSearchTextEditorActionListener()
         setupObserver()
-        setupInitialSearchAuthor()
         handleBackPressed()
     }
 
@@ -72,20 +71,16 @@ class NormalExploreActivity : BaseActivity<ActivityNormalExploreBinding>(activit
         }
     }
 
-    private fun setupInitialSearchAuthor() {
-        val searchAuthor = intent.getStringExtra(SEARCH_AUTHOR).orEmpty()
-        if (searchAuthor.isBlank()) return
-
-        normalExploreViewModel.searchWord.value = searchAuthor
-        normalExploreViewModel.updateSearchResult(isSearchButtonClick = true)
-    }
-
     private fun onSearchTextEditorActionListener() {
         binding.apply {
             etNormalExploreSearchContent.setOnEditorActionListener { _, actionId, _ ->
                 if (actionId == IME_ACTION_SEARCH) {
+                    normalExploreViewModel?.updateSearchWord(
+                        binding.etNormalExploreSearchContent.text
+                            ?.toString()
+                            .orEmpty(),
+                    )
                     normalExploreViewModel?.updateSearchResult(isSearchButtonClick = true)
-                        ?: throw IllegalStateException()
                     binding.etNormalExploreSearchContent.clearFocus()
                     hideKeyboard()
                     true
@@ -115,6 +110,11 @@ class NormalExploreActivity : BaseActivity<ActivityNormalExploreBinding>(activit
             override fun onSearchButtonClick() {
                 singleEventHandler.throttleFirst {
                     tracker.trackEvent("click_search_result")
+                    normalExploreViewModel.updateSearchWord(
+                        binding.etNormalExploreSearchContent.text
+                            ?.toString()
+                            .orEmpty(),
+                    )
                     normalExploreViewModel.updateSearchResult(isSearchButtonClick = true)
                     binding.etNormalExploreSearchContent.clearFocus()
                     hideKeyboard()
@@ -205,7 +205,7 @@ class NormalExploreActivity : BaseActivity<ActivityNormalExploreBinding>(activit
     }
 
     companion object {
-        private const val SEARCH_AUTHOR = "SEARCH_AUTHOR"
+        const val SEARCH_AUTHOR = "SEARCH_AUTHOR"
 
         fun getIntent(
             context: Context,

--- a/app/src/main/java/com/into/websoso/ui/normalExplore/NormalExploreActivity.kt
+++ b/app/src/main/java/com/into/websoso/ui/normalExplore/NormalExploreActivity.kt
@@ -47,6 +47,7 @@ class NormalExploreActivity : BaseActivity<ActivityNormalExploreBinding>(activit
         setupUI()
         onSearchTextEditorActionListener()
         setupObserver()
+        setupInitialSearchAuthor()
         handleBackPressed()
     }
 
@@ -69,6 +70,14 @@ class NormalExploreActivity : BaseActivity<ActivityNormalExploreBinding>(activit
             }
             onClick = onNormalExploreButtonClick()
         }
+    }
+
+    private fun setupInitialSearchAuthor() {
+        val searchAuthor = intent.getStringExtra(SEARCH_AUTHOR).orEmpty()
+        if (searchAuthor.isBlank()) return
+
+        normalExploreViewModel.searchWord.value = searchAuthor
+        normalExploreViewModel.updateSearchResult(isSearchButtonClick = true)
     }
 
     private fun onSearchTextEditorActionListener() {
@@ -196,6 +205,14 @@ class NormalExploreActivity : BaseActivity<ActivityNormalExploreBinding>(activit
     }
 
     companion object {
-        fun getIntent(context: Context): Intent = Intent(context, NormalExploreActivity::class.java)
+        private const val SEARCH_AUTHOR = "SEARCH_AUTHOR"
+
+        fun getIntent(
+            context: Context,
+            searchAuthor: String = "",
+        ): Intent =
+            Intent(context, NormalExploreActivity::class.java).apply {
+                putExtra(SEARCH_AUTHOR, searchAuthor)
+            }
     }
 }

--- a/app/src/main/java/com/into/websoso/ui/normalExplore/NormalExploreViewModel.kt
+++ b/app/src/main/java/com/into/websoso/ui/normalExplore/NormalExploreViewModel.kt
@@ -2,10 +2,12 @@ package com.into.websoso.ui.normalExplore
 
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.into.websoso.domain.usecase.GetNormalExploreResultUseCase
 import com.into.websoso.ui.mapper.toUi
+import com.into.websoso.ui.normalExplore.NormalExploreActivity.Companion.SEARCH_AUTHOR
 import com.into.websoso.ui.normalExplore.model.NormalExploreUiState
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
@@ -16,12 +18,16 @@ class NormalExploreViewModel
     @Inject
     constructor(
         private val getNormalExploreResultUseCase: GetNormalExploreResultUseCase,
+        private val savedStateHandle: SavedStateHandle,
     ) : ViewModel() {
         private val _uiState: MutableLiveData<NormalExploreUiState> =
             MutableLiveData(NormalExploreUiState())
         val uiState: LiveData<NormalExploreUiState> get() = _uiState
 
-        private val _searchWord: MutableLiveData<String> = MutableLiveData()
+        private val initialSearchWord: String =
+            savedStateHandle.get<String>(SEARCH_AUTHOR).orEmpty()
+
+        private val _searchWord = MutableLiveData(initialSearchWord)
         val searchWord: MutableLiveData<String> get() = _searchWord
 
         private val _isSearchCancelButtonVisibility: MutableLiveData<Boolean> = MutableLiveData(false)
@@ -29,6 +35,17 @@ class NormalExploreViewModel
 
         private val _isNovelResultEmptyBoxVisibility: MutableLiveData<Boolean> = MutableLiveData(false)
         val isNovelResultEmptyBoxVisibility: LiveData<Boolean> get() = _isNovelResultEmptyBoxVisibility
+
+        init {
+            if (initialSearchWord.isNotBlank()) {
+                updateSearchResult(isSearchButtonClick = true)
+            }
+        }
+
+        fun updateSearchWord(searchWord: String) {
+            _searchWord.value = searchWord
+            savedStateHandle[SEARCH_AUTHOR] = searchWord
+        }
 
         fun updateSearchResult(isSearchButtonClick: Boolean) {
             if (_uiState.value?.isLoadable == false && !isSearchButtonClick) {
@@ -72,5 +89,6 @@ class NormalExploreViewModel
 
         fun updateSearchWordEmpty() {
             _searchWord.value = ""
+            savedStateHandle[SEARCH_AUTHOR] = ""
         }
     }

--- a/app/src/main/java/com/into/websoso/ui/novelDetail/NovelDetailActivity.kt
+++ b/app/src/main/java/com/into/websoso/ui/novelDetail/NovelDetailActivity.kt
@@ -2,6 +2,7 @@ package com.into.websoso.ui.novelDetail
 
 import android.content.Context
 import android.content.Intent
+import android.graphics.Paint
 import android.net.Uri
 import android.os.Bundle
 import android.util.Patterns
@@ -102,6 +103,7 @@ class NovelDetailActivity : BaseActivity<ActivityNovelDetailBinding>(activity_no
 
         binding.onClick = onNovelDetailButtonClick()
         bindViewModel()
+        setupAuthorUnderline()
         setupPopupBinding()
         setupObserver()
         setupWebsosoLoadingLayout()
@@ -114,6 +116,11 @@ class NovelDetailActivity : BaseActivity<ActivityNovelDetailBinding>(activity_no
     private fun bindViewModel() {
         binding.novelDetailViewModel = novelDetailViewModel
         binding.lifecycleOwner = this
+    }
+
+    private fun setupAuthorUnderline() {
+        binding.tvNovelDetailAuthor.paintFlags =
+            binding.tvNovelDetailAuthor.paintFlags or Paint.UNDERLINE_TEXT_FLAG
     }
 
     private fun setupPopupBinding() {
@@ -204,7 +211,9 @@ class NovelDetailActivity : BaseActivity<ActivityNovelDetailBinding>(activity_no
                     updateGenreImage(novelDetail.novel.novelGenreImage)
                 }
 
-                false -> binding.wllNovelDetail.setWebsosoLoadingVisibility(true)
+                false -> {
+                    binding.wllNovelDetail.setWebsosoLoadingVisibility(true)
+                }
             }
         }
         novelDetailViewModel.loading.observe(this) { isLoading ->
@@ -346,6 +355,10 @@ class NovelDetailActivity : BaseActivity<ActivityNovelDetailBinding>(activity_no
                 }
                 tracker.trackEvent("rate_love")
                 novelDetailViewModel.updateUserInterest(novelId)
+            }
+
+            override fun onAuthorClick(author: String) {
+                TODO("Not yet implemented")
             }
         }
 

--- a/app/src/main/java/com/into/websoso/ui/novelDetail/NovelDetailActivity.kt
+++ b/app/src/main/java/com/into/websoso/ui/novelDetail/NovelDetailActivity.kt
@@ -11,7 +11,6 @@ import android.view.View.GONE
 import android.view.View.MeasureSpec.UNSPECIFIED
 import android.view.View.VISIBLE
 import android.view.ViewTreeObserver.OnPreDrawListener
-import android.view.WindowManager
 import android.view.WindowManager.LayoutParams.WRAP_CONTENT
 import android.widget.PopupWindow
 import androidx.activity.addCallback
@@ -47,6 +46,7 @@ import com.into.websoso.databinding.MenuNovelDetailPopupBinding
 import com.into.websoso.ui.common.dialog.LoginRequestDialogFragment
 import com.into.websoso.ui.createFeed.CreateFeedActivity
 import com.into.websoso.ui.feedDetail.model.EditFeedModel
+import com.into.websoso.ui.normalExplore.NormalExploreActivity
 import com.into.websoso.ui.novelDetail.adapter.NovelDetailPagerAdapter
 import com.into.websoso.ui.novelDetail.model.NovelAlertModel
 import com.into.websoso.ui.novelFeed.NovelFeedViewModel
@@ -289,8 +289,8 @@ class NovelDetailActivity : BaseActivity<ActivityNovelDetailBinding>(activity_no
     private fun showPopupWindow() {
         menuPopupWindow = PopupWindow(
             novelDetailMenuPopupBinding.root,
-            WindowManager.LayoutParams.WRAP_CONTENT,
-            WindowManager.LayoutParams.WRAP_CONTENT,
+            WRAP_CONTENT,
+            WRAP_CONTENT,
             true,
         ).apply {
             this.elevation = 14f.toFloatPxFromDp()
@@ -358,7 +358,11 @@ class NovelDetailActivity : BaseActivity<ActivityNovelDetailBinding>(activity_no
             }
 
             override fun onAuthorClick(author: String) {
-                TODO("Not yet implemented")
+                val intent = NormalExploreActivity.getIntent(
+                    context = this@NovelDetailActivity,
+                    searchAuthor = author,
+                )
+                startActivity(intent)
             }
         }
 

--- a/app/src/main/java/com/into/websoso/ui/novelDetail/NovelDetailClickListener.kt
+++ b/app/src/main/java/com/into/websoso/ui/novelDetail/NovelDetailClickListener.kt
@@ -14,4 +14,6 @@ interface NovelDetailClickListener {
     fun onNovelFeedWriteClick()
 
     fun onNovelInterestClick()
+
+    fun onAuthorClick(author: String)
 }

--- a/app/src/main/java/com/into/websoso/ui/novelDetail/model/NovelDetailModel.kt
+++ b/app/src/main/java/com/into/websoso/ui/novelDetail/model/NovelDetailModel.kt
@@ -33,7 +33,7 @@ data class NovelDetailModel(
         val isNovelCompleted: Boolean = false,
         val isNovelCompletedText: String = if (isNovelCompleted) "완결작" else "연재중",
         val author: String = "",
-        val formattedNovelDetailSummary: String = "$novelGenres ・ $isNovelCompletedText ・ $author",
+        val formattedNovelDetailSummary: String = "$novelGenres ・ $isNovelCompletedText ・ ",
         val isNovelNotBlank: Boolean = novelTitle.isNotBlank() && novelImage.isNotBlank() && author.isNotBlank(),
     ) : Serializable {
         val getGenres: List<String>
@@ -66,7 +66,9 @@ data class NovelDetailModel(
                 }"
 
                 start != null -> outputFormat.format(start)
+
                 end != null -> outputFormat.format(end)
+
                 else -> ""
             }
         }

--- a/app/src/main/res/layout/activity_novel_detail.xml
+++ b/app/src/main/res/layout/activity_novel_detail.xml
@@ -136,17 +136,35 @@
                             app:layout_constraintTop_toBottomOf="@id/cv_novel_detail_cover"
                             tools:text="철혈검가 사냥개의 회귀" />
 
-                        <TextView
-                            android:id="@+id/tv_novel_detail_character_info"
+                        <LinearLayout
+                            android:id="@+id/ll_novel_detail_character_info"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:layout_marginTop="6dp"
-                            android:text="@{novelDetailViewModel.novelDetailModel.novel.formattedNovelDetailSummary}"
-                            android:textAppearance="@style/body2"
+                            android:orientation="horizontal"
                             app:layout_constraintEnd_toEndOf="parent"
                             app:layout_constraintStart_toStartOf="parent"
-                            app:layout_constraintTop_toBottomOf="@id/tv_novel_detail_title"
-                            tools:text="로판/로맨스 ・ 완결작 ・ 이보라" />
+                            app:layout_constraintTop_toBottomOf="@id/tv_novel_detail_title">
+
+                            <TextView
+                                android:id="@+id/tv_novel_detail_summary"
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:text="@{novelDetailViewModel.novelDetailModel.novel.formattedNovelDetailSummary}"
+                                android:textAppearance="@style/body2"
+                                android:textColor="@color/gray_200_949399"
+                                tools:text="로판/로맨스 ・ 완결작" />
+
+                            <TextView
+                                android:id="@+id/tv_novel_detail_author"
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:onClick="@{() -> onClick.onAuthorClick(novelDetailViewModel.novelDetailModel.novel.author)}"
+                                android:text='@{novelDetailViewModel.novelDetailModel.novel.author}'
+                                android:textAppearance="@style/body2"
+                                android:textColor="@color/gray_200_949399"
+                                tools:text=" ・ 이보라" />
+                        </LinearLayout>
 
                         <LinearLayout
                             android:id="@+id/ll_novel_detail_numeric_info"
@@ -156,7 +174,7 @@
                             android:gravity="center_vertical"
                             app:layout_constraintEnd_toEndOf="parent"
                             app:layout_constraintStart_toStartOf="parent"
-                            app:layout_constraintTop_toBottomOf="@id/tv_novel_detail_character_info">
+                            app:layout_constraintTop_toBottomOf="@id/ll_novel_detail_character_info">
 
                             <ImageView
                                 android:layout_width="12dp"


### PR DESCRIPTION
## 📌𝘐𝘴𝘴𝘶𝘦𝘴
- closed #825

## 📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯
- 작가명 TextView에 밑줄 스타일 적용
- 작가명 클릭 시 해당 작가명 기반 탐색 검색 화면 이동
- 탐색 화면 진입 시 전달받은 작가명으로 초기 검색 수행
- 뒤로가기 시, 원래 작품 정보 화면으로 이동

## 📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵

https://github.com/user-attachments/assets/b125bb67-eed0-4578-a3aa-bbdaa0268190



## 💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴

### 변경사항

- 작품 상세 요약 문구에서 작가명을 별도 TextView로 분리
- 작가명 밑줄 스타일 및 클릭 이벤트 추가
- 작가명 클릭 시 NormalExploreActivity로 이동
- 전달받은 작가명으로 초기 검색 수행

#### 구현 이유

기존 UI 배치를 유지하면서 작가명에만 링크 스타일/클릭을 적용하기 위해 요약 정보와 작가명을 분리했습니다.
별도 검색 화면을 추가하지 않고 기존 NormalExploreActivity를 재사용하기 위해 Intent extra로 작가명을 전달해 초기 검색이 실행되도록 구현했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 신규 기능
- 저자별 검색 기능 추가로 특정 저자의 작품 검색 가능
- 소설 상세 페이지에서 저자명을 클릭하면 해당 저자의 검색 결과로 이동
- 저자명에 밑줄 표시로 상호작용 가능한 요소임을 표시

## 버그 수정
- 검색 버튼 클릭 및 엔터 키 입력 시 검색 키워드 업데이트 로직 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->