### PR TITLE
fix: 글자 커서 색상 변경

### DIFF
--- a/app/src/main/res/layout/activity_create_feed.xml
+++ b/app/src/main/res/layout/activity_create_feed.xml
@@ -149,6 +149,8 @@
                     android:textAppearance="@style/body2"
                     android:textColor="@color/black"
                     android:textColorHint="@color/gray_200_949399"
+                    android:textColorHighlight="@color/primary_50_F1EFFF"
+                    android:theme="@style/Theme.Websoso.EditText"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toBottomOf="@id/wcg_detail_explore_info_genre" />

--- a/app/src/main/res/layout/activity_feed_detail.xml
+++ b/app/src/main/res/layout/activity_feed_detail.xml
@@ -108,6 +108,8 @@
                 android:textAppearance="@style/body3"
                 android:textColor="@color/black"
                 android:textColorHint="@color/gray_200_949399"
+                android:textColorHighlight="@color/primary_50_F1EFFF"
+                android:theme="@style/Theme.Websoso.EditText"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toStartOf="@+id/iv_feed_detail_comment_register"
                 app:layout_constraintStart_toEndOf="@id/iv_feed_detail_my_profile_image"

--- a/app/src/main/res/layout/activity_normal_explore.xml
+++ b/app/src/main/res/layout/activity_normal_explore.xml
@@ -82,6 +82,8 @@
                             android:text="@={normalExploreViewModel.searchWord}"
                             android:textAppearance="@style/label1"
                             android:textColor="@color/black"
+                            android:textColorHighlight="@color/primary_50_F1EFFF"
+                            android:theme="@style/Theme.Websoso.EditText"
                             app:layout_constraintBottom_toBottomOf="parent"
                             app:layout_constraintEnd_toStartOf="@id/iv_normal_explore_cancel_button"
                             app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -16,4 +16,8 @@
         <item name="android:textColor">@color/bg_detail_explore_chip_text_selector</item>
         <item name="chipCornerRadius">8dp</item>
     </style>
+
+    <style name="Theme.Websoso.EditText" parent="">
+        <item name="colorControlActivated">@color/primary_100_6A5DFD</item>
+    </style>
 </resources>


### PR DESCRIPTION
## 📌𝘐𝘴𝘴𝘶𝘦𝘴
- closed #821

## 📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯
- 검색, 게시글 댓글, 피드 작성 부분 색상 변경
-

## 📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵
<img width="1440" height="3088" alt="image" src="https://github.com/user-attachments/assets/e65d9ed6-b050-4dd2-baf2-c435044d5894" />


## 💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴
UI가 xml 형태로 되어있어 전체 적용이 불가능합니다. 추후 compose로 변경되면 MaterialTheme에서 적용하면 될듯 합니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 변경 사항

* **Style (스타일)**
  * 텍스트 입력 필드의 선택 하이라이트 색상이 업데이트되어 선택 시 가시성이 향상되었습니다.
  * 여러 화면의 입력 필드에 새로운 커스텀 EditText 테마가 적용되어 시각적 일관성과 디자인 경험이 개선되었습니다.
  * 새로운 EditText 테마 리소스가 추가되어 입력 관련 스타일 일관성 유지에 기여합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->