### PR TITLE
fix: 텍스트 드래그 안되는 문제 해결

### DIFF
--- a/app/src/main/java/com/into/websoso/ui/createFeed/CreateFeedActivity.kt
+++ b/app/src/main/java/com/into/websoso/ui/createFeed/CreateFeedActivity.kt
@@ -3,8 +3,8 @@ package com.into.websoso.ui.createFeed
 import android.annotation.SuppressLint
 import android.content.Context
 import android.content.Intent
+import android.graphics.Rect
 import android.os.Bundle
-import android.text.method.ScrollingMovementMethod
 import android.view.MotionEvent
 import android.view.View
 import android.view.inputmethod.InputMethodManager
@@ -57,9 +57,22 @@ class CreateFeedActivity : BaseActivity<ActivityCreateFeedBinding>(activity_crea
         createFeedImagePickerLauncher()
 
     override fun dispatchTouchEvent(ev: MotionEvent): Boolean {
-        val imm: InputMethodManager =
-            getSystemService(INPUT_METHOD_SERVICE) as InputMethodManager
-        imm.hideSoftInputFromWindow(currentFocus?.windowToken, 0)
+        if (ev.action == MotionEvent.ACTION_DOWN) {
+            val focusView = currentFocus
+            if (focusView is android.widget.EditText) {
+                val outRect = Rect()
+                focusView.getGlobalVisibleRect(outRect)
+
+                // 터치한 좌표가 EditText 영역 밖일 경우에만 키보드 숨김 및 포커스 해제
+                if (!outRect.contains(ev.rawX.toInt(), ev.rawY.toInt())) {
+                    focusView.clearFocus()
+                    val imm: InputMethodManager =
+                        getSystemService(INPUT_METHOD_SERVICE) as InputMethodManager
+                    imm.hideSoftInputFromWindow(currentFocus?.windowToken, 0)
+                }
+            }
+        }
+
         return super.dispatchTouchEvent(ev)
     }
 
@@ -99,15 +112,19 @@ class CreateFeedActivity : BaseActivity<ActivityCreateFeedBinding>(activity_crea
     @SuppressLint("ClickableViewAccessibility")
     private fun setupCustomScroll() {
         binding.etCreateFeedContent.setOnTouchListener { view, event ->
-            if (view.hasFocus()) {
-                view.parent.requestDisallowInterceptTouchEvent(true)
-                if ((event.action and MotionEvent.ACTION_MASK) == MotionEvent.ACTION_UP) {
+            when (event.action and MotionEvent.ACTION_MASK) {
+                MotionEvent.ACTION_DOWN -> {
+                    // 터치 시작 시 부모 개입 차단
+                    view.parent.requestDisallowInterceptTouchEvent(true)
+                }
+
+                MotionEvent.ACTION_UP, MotionEvent.ACTION_CANCEL -> {
                     view.parent.requestDisallowInterceptTouchEvent(false)
                 }
             }
+
             false
         }
-        binding.etCreateFeedContent.movementMethod = ScrollingMovementMethod()
     }
 
     private fun onCreateFeedClick() {
@@ -138,8 +155,11 @@ class CreateFeedActivity : BaseActivity<ActivityCreateFeedBinding>(activity_crea
 
                 when {
                     editFeedModel == null -> createFeedViewModel.createFeed()
+
                     editFeedModel.feedId == DEFAULT_FEED_ID -> createFeedViewModel.createFeed()
+
                     editFeedModel.feedCategory.isEmpty() -> createFeedViewModel.createFeed()
+
                     else -> createFeedViewModel.editFeed(
                         feedId = editFeedModel.feedId,
                     )


### PR DESCRIPTION
## 📌𝘐𝘴𝘴𝘶𝘦𝘴
- closed #820 

## 📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯
- 텍스트가 드래그가 안되던 문제 해결
- EditText 영역을 클릭 시 키보드가 내렸다가 올라오는 문제 해결

## 📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵

<img width="1440" height="3088" alt="image" src="https://github.com/user-attachments/assets/86126808-4fe5-417b-a7fa-99aafd7fdc79" />

## 💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴

둘다 dispatchTouchEvent 및 setupCustomScroll 에서 일어나는 문제들이어서 한꺼번에 수정했습니다. 
터치 이벤트 시에만 dispatchTouchEvent를 실행하도록 하여 프레임 드랍을 감소하였습니다.
또한 드래그가 안되는 문제는 movementmethod가 scroll로 되있어 기본적인 드래그가 막혔던 문제로 파악했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * EditText 외부 탭 시에만 키보드를 숨기도록 터치 감지 개선
  * 스크롤 상호작용 개선으로 더 부드러운 화면 제어 환경 제공
  * 피드 편집 시 완료 버튼이 더 많은 상황에서 올바르게 작동하도록 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->