### PR TITLE
fix:스포일러 설정 시 이미지 안보임

### DIFF
--- a/feature/feed/src/main/java/com/into/websoso/feature/feed/component/FeedSection.kt
+++ b/feature/feed/src/main/java/com/into/websoso/feature/feed/component/FeedSection.kt
@@ -225,7 +225,7 @@ private fun FeedItem(
                 modifier = Modifier.debouncedClickable { onContentClick(feed.id, feed.isLiked) },
             )
 
-            Spacer(modifier = Modifier.height(height = 10.dp))
+            Spacer(modifier = Modifier.height(height = 20.dp))
             if (feed.imageUrls.isNotEmpty()) {
                 Box {
                     NetworkImage(
@@ -256,10 +256,10 @@ private fun FeedItem(
                         )
                     }
                 }
+
+                Spacer(modifier = Modifier.height(height = 10.dp))
             }
         }
-
-        Spacer(modifier = Modifier.height(height = 20.dp))
 
         if (feed.novel != null) {
             FeedNovelInfo(
@@ -353,7 +353,8 @@ private fun FeedNovelInfo(
             .background(
                 color = novel.genre.boxColor,
                 shape = RoundedCornerShape(size = 16.dp),
-            ).debouncedClickable {
+            )
+            .debouncedClickable {
                 onNovelClick(novel.id)
             },
     ) {

--- a/feature/feed/src/main/java/com/into/websoso/feature/feed/component/FeedSection.kt
+++ b/feature/feed/src/main/java/com/into/websoso/feature/feed/component/FeedSection.kt
@@ -215,6 +215,17 @@ private fun FeedItem(
                 color = Secondary100,
                 modifier = Modifier.debouncedClickable { onContentClick(feed.id, feed.isLiked) },
             )
+        } else {
+            Text(
+                text = feed.content,
+                style = WebsosoTheme.typography.body2,
+                color = Black,
+                maxLines = 5,
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier.debouncedClickable { onContentClick(feed.id, feed.isLiked) },
+            )
+
+            Spacer(modifier = Modifier.height(height = 10.dp))
             if (feed.imageUrls.isNotEmpty()) {
                 Box {
                     NetworkImage(
@@ -245,18 +256,7 @@ private fun FeedItem(
                         )
                     }
                 }
-
-                Spacer(modifier = Modifier.height(height = 10.dp))
             }
-        } else {
-            Text(
-                text = feed.content,
-                style = WebsosoTheme.typography.body2,
-                color = Black,
-                maxLines = 5,
-                overflow = TextOverflow.Ellipsis,
-                modifier = Modifier.debouncedClickable { onContentClick(feed.id, feed.isLiked) },
-            )
         }
 
         Spacer(modifier = Modifier.height(height = 20.dp))

--- a/feature/feed/src/main/java/com/into/websoso/feature/feed/component/FeedSection.kt
+++ b/feature/feed/src/main/java/com/into/websoso/feature/feed/component/FeedSection.kt
@@ -215,6 +215,39 @@ private fun FeedItem(
                 color = Secondary100,
                 modifier = Modifier.debouncedClickable { onContentClick(feed.id, feed.isLiked) },
             )
+            if (feed.imageUrls.isNotEmpty()) {
+                Box {
+                    NetworkImage(
+                        imageUrl = feed.imageUrls.firstOrNull().orEmpty(),
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .aspectRatio(ratio = 334f / 237f)
+                            .clip(RoundedCornerShape(size = 14.dp)),
+                        contentScale = ContentScale.Crop,
+                    )
+
+                    Box(
+                        contentAlignment = Alignment.Center,
+                        modifier = Modifier
+                            .align(alignment = Alignment.BottomEnd)
+                            .padding(end = 12.dp, bottom = 10.dp)
+                            .size(size = 20.dp)
+                            .background(
+                                color = GrayToast,
+                                shape = CircleShape,
+                            ),
+                    ) {
+                        Text(
+                            text = feed.imageCount.toString(),
+                            style = WebsosoTheme.typography.body5,
+                            color = White,
+                            textAlign = TextAlign.Center,
+                        )
+                    }
+                }
+
+                Spacer(modifier = Modifier.height(height = 10.dp))
+            }
         } else {
             Text(
                 text = feed.content,
@@ -227,40 +260,6 @@ private fun FeedItem(
         }
 
         Spacer(modifier = Modifier.height(height = 20.dp))
-
-        if (feed.imageUrls.isNotEmpty()) {
-            Box {
-                NetworkImage(
-                    imageUrl = feed.imageUrls.firstOrNull().orEmpty(),
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .aspectRatio(ratio = 334f / 237f)
-                        .clip(RoundedCornerShape(size = 14.dp)),
-                    contentScale = ContentScale.Crop,
-                )
-
-                Box(
-                    contentAlignment = Alignment.Center,
-                    modifier = Modifier
-                        .align(alignment = Alignment.BottomEnd)
-                        .padding(end = 12.dp, bottom = 10.dp)
-                        .size(size = 20.dp)
-                        .background(
-                            color = GrayToast,
-                            shape = CircleShape,
-                        ),
-                ) {
-                    Text(
-                        text = feed.imageCount.toString(),
-                        style = WebsosoTheme.typography.body5,
-                        color = White,
-                        textAlign = TextAlign.Center,
-                    )
-                }
-            }
-
-            Spacer(modifier = Modifier.height(height = 10.dp))
-        }
 
         if (feed.novel != null) {
             FeedNovelInfo(
@@ -354,8 +353,7 @@ private fun FeedNovelInfo(
             .background(
                 color = novel.genre.boxColor,
                 shape = RoundedCornerShape(size = 16.dp),
-            )
-            .debouncedClickable {
+            ).debouncedClickable {
                 onNovelClick(novel.id)
             },
     ) {


### PR DESCRIPTION
## 📌𝘐𝘴𝘴𝘶𝘦𝘴
- closed #830 

## 📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯
- 스포일러 설정 시 이미지 보이지 않게 수정
-

## 📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵
<img width="1440" height="3088" alt="image" src="https://github.com/user-attachments/assets/9070664b-083c-428a-a94f-f28aed15c8b9" />
<img width="1440" height="3088" alt="image" src="https://github.com/user-attachments/assets/462e5a1f-ad49-46e9-b5f3-6d322dd2503c" />


## 💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴
스포일러 시 이미지 보이지 않게 하기 위해 이미지 분기를 스포일러 분기에 포함시켰습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * 피드의 갤러리 이미지와 이미지 개수 배지가 스포일러 게시물에서는 숨겨지고, 비스포일러 게시물에서만 표시되도록 동작을 수정했습니다.
  * 이미지 미리보기 관련 간격과 레이아웃을 비스포일러 경로로 통일해 표시 일관성을 개선했습니다.
  * 이미지 표시 시 간격이 조정되어 전체 게시물 레이아웃이 보다 안정적으로 보입니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->