### PR TITLE
fix: 피드 쪽 무한 스크롤 구현 추가

### DIFF
--- a/feature/feed/build.gradle.kts
+++ b/feature/feed/build.gradle.kts
@@ -15,4 +15,5 @@ dependencies {
     implementation(projects.data.feed)
     implementation(projects.domain.feed)
     implementation(libs.paging.compose)
+    implementation(libs.androidx.foundation)
 }

--- a/feature/feed/src/main/java/com/into/websoso/feature/feed/FeedRoute.kt
+++ b/feature/feed/src/main/java/com/into/websoso/feature/feed/FeedRoute.kt
@@ -74,5 +74,6 @@ fun FeedRoute(
         onSecondItemClick = onSecondItemClick,
         onRefreshPull = viewModel::refresh,
         onWriteFeedClick = { },
+        onLoadMore = viewModel::fetchNextPage,
     )
 }

--- a/feature/feed/src/main/java/com/into/websoso/feature/feed/FeedScreen.kt
+++ b/feature/feed/src/main/java/com/into/websoso/feature/feed/FeedScreen.kt
@@ -67,6 +67,7 @@ internal fun FeedScreen(
     onSecondItemClick: (feedId: Long, isMyFeed: Boolean) -> Unit,
     onRefreshPull: () -> Unit,
     onWriteFeedClick: () -> Unit,
+    onLoadMore: () -> Unit,
 ) {
     Scaffold(containerColor = White) { _ ->
         Column(modifier = Modifier.statusBarsPadding()) {
@@ -177,6 +178,7 @@ internal fun FeedScreen(
                 onWriteFeedClick = onWriteFeedClick,
                 isRefreshing = uiState.isRefreshing,
                 isLoading = uiState.loading,
+                onLoadMore = onLoadMore,
             )
         }
 
@@ -287,6 +289,7 @@ private fun FeedScreenPreview() {
             onSecondItemClick = { _, _ -> },
             onRefreshPull = {},
             onWriteFeedClick = {},
+            onLoadMore = {},
         )
     }
 }

--- a/feature/feed/src/main/java/com/into/websoso/feature/feed/UpdateFeedRoute.kt
+++ b/feature/feed/src/main/java/com/into/websoso/feature/feed/UpdateFeedRoute.kt
@@ -74,5 +74,6 @@ fun UpdateFeedRoute(
         onSecondItemClick = onSecondItemClick,
         onRefreshPull = viewModel::refresh,
         onWriteFeedClick = onWriteFeedClick,
+        onLoadMore = viewModel::fetchNextPage,
     )
 }

--- a/feature/feed/src/main/java/com/into/websoso/feature/feed/UpdatedFeedViewModel.kt
+++ b/feature/feed/src/main/java/com/into/websoso/feature/feed/UpdatedFeedViewModel.kt
@@ -119,15 +119,45 @@ class UpdatedFeedViewModel
                     }
                 }.onSuccess { result ->
                     _uiState.update { currentState ->
-                        val updatedSource = currentState.currentData.copy(
-                            lastId = result.isLoadable.let {
-                                if (it) result.feeds.lastOrNull()?.id ?: 0 else 0
-                            },
-                            isLoadable = result.isLoadable,
-                        )
-                        currentState
-                            .updateCurrentSource(updatedSource)
-                            .copy(loading = false, isRefreshing = false)
+                        val newLastId = if (result.isLoadable) {
+                            result.feeds.lastOrNull()?.id ?: 0L
+                        } else {
+                            currentState.currentData.lastId
+                        }
+
+                        val tab = currentState.selectedTab
+                        val category = currentState.sosoCategory
+
+                        when (tab) {
+                            FeedTab.MY_FEED -> currentState.copy(
+                                myFeedData = currentState.myFeedData.copy(
+                                    lastId = newLastId,
+                                    isLoadable = result.isLoadable,
+                                ),
+                                loading = false,
+                                isRefreshing = false,
+                            )
+
+                            FeedTab.SOSO_FEED -> if (category == SosoFeedType.ALL) {
+                                currentState.copy(
+                                    sosoAllData = currentState.sosoAllData.copy(
+                                        lastId = newLastId,
+                                        isLoadable = result.isLoadable,
+                                    ),
+                                    loading = false,
+                                    isRefreshing = false,
+                                )
+                            } else {
+                                currentState.copy(
+                                    sosoRecommendationData = currentState.sosoRecommendationData.copy(
+                                        lastId = newLastId,
+                                        isLoadable = result.isLoadable,
+                                    ),
+                                    loading = false,
+                                    isRefreshing = false,
+                                )
+                            }
+                        }
                     }
                 }.onFailure {
                     _uiState.update { it.copy(loading = false, isRefreshing = false, error = true) }

--- a/feature/feed/src/main/java/com/into/websoso/feature/feed/UpdatedFeedViewModel.kt
+++ b/feature/feed/src/main/java/com/into/websoso/feature/feed/UpdatedFeedViewModel.kt
@@ -131,7 +131,14 @@ class UpdatedFeedViewModel
                         when (tab) {
                             FeedTab.MY_FEED -> currentState.copy(
                                 myFeedData = currentState.myFeedData.copy(
-                                    lastId = newLastId,
+                                    lastId = if (result.isLoadable) {
+                                        currentState.myFeedData.feeds
+                                            .lastOrNull()
+                                            ?.id
+                                            ?: 0L
+                                    } else {
+                                        currentState.myFeedData.lastId
+                                    },
                                     isLoadable = result.isLoadable,
                                 ),
                                 loading = false,

--- a/feature/feed/src/main/java/com/into/websoso/feature/feed/UpdatedFeedViewModel.kt
+++ b/feature/feed/src/main/java/com/into/websoso/feature/feed/UpdatedFeedViewModel.kt
@@ -92,13 +92,16 @@ class UpdatedFeedViewModel
             val current = state.currentData
             val lastFeedId = feedId ?: current.lastId
 
+            val tab = state.selectedTab
+            val category = state.sosoCategory
+
             if (state.loading || (!current.isLoadable && lastFeedId != 0L)) return
 
             _uiState.update { it.copy(loading = true) }
 
             viewModelScope.launch {
                 runCatching {
-                    when (state.selectedTab) {
+                    when (tab) {
                         FeedTab.MY_FEED -> {
                             getMyFeedsUseCase(
                                 lastFeedId = lastFeedId,
@@ -112,7 +115,7 @@ class UpdatedFeedViewModel
 
                         FeedTab.SOSO_FEED -> {
                             getFeedsUseCase(
-                                feedsOption = state.sosoCategory.name.uppercase(),
+                                feedsOption = category.name.uppercase(),
                                 lastFeedId = lastFeedId,
                             )
                         }
@@ -124,9 +127,6 @@ class UpdatedFeedViewModel
                         } else {
                             currentState.currentData.lastId
                         }
-
-                        val tab = currentState.selectedTab
-                        val category = currentState.sosoCategory
 
                         when (tab) {
                             FeedTab.MY_FEED -> currentState.copy(

--- a/feature/feed/src/main/java/com/into/websoso/feature/feed/component/FeedSection.kt
+++ b/feature/feed/src/main/java/com/into/websoso/feature/feed/component/FeedSection.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.CircularProgressIndicator
@@ -27,6 +28,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -55,6 +57,8 @@ import com.into.websoso.feature.feed.model.FeedTab
 import com.into.websoso.feature.feed.model.FeedUiModel
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.filter
 
 @Composable
 internal fun FeedSection(
@@ -92,7 +96,25 @@ internal fun FeedSection(
             }
 
             else -> {
-                LazyColumn(modifier = Modifier.padding(horizontal = 20.dp)) {
+                val listState = rememberLazyListState()
+
+                LaunchedEffect(listState) {
+                    snapshotFlow {
+                        val lastVisible =
+                            listState.layoutInfo.visibleItemsInfo
+                                .lastOrNull()
+                                ?.index ?: 0
+                        val total = listState.layoutInfo.totalItemsCount
+                        lastVisible >= total - 3
+                    }.distinctUntilChanged()
+                        .filter { it }
+                        .collect { onLoadMore() }
+                }
+
+                LazyColumn(
+                    state = listState,
+                    modifier = Modifier.padding(horizontal = 20.dp),
+                ) {
                     itemsIndexed(items = feeds) { index, feed ->
                         FeedItem(
                             feed = feed,
@@ -107,12 +129,9 @@ internal fun FeedSection(
 
                         if (index < feeds.lastIndex) HorizontalDivider(color = Gray50)
                     }
-                    item {
-                        LaunchedEffect(feeds.size) {
-                            onLoadMore()
-                        }
 
-                        if (isLoading) {
+                    if (isLoading) {
+                        item {
                             Box(
                                 modifier = Modifier
                                     .fillMaxWidth()
@@ -371,8 +390,7 @@ private fun FeedNovelInfo(
             .background(
                 color = novel.genre.boxColor,
                 shape = RoundedCornerShape(size = 16.dp),
-            )
-            .debouncedClickable {
+            ).debouncedClickable {
                 onNovelClick(novel.id)
             },
     ) {

--- a/feature/feed/src/main/java/com/into/websoso/feature/feed/component/FeedSection.kt
+++ b/feature/feed/src/main/java/com/into/websoso/feature/feed/component/FeedSection.kt
@@ -22,6 +22,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -67,6 +68,7 @@ internal fun FeedSection(
     onSecondItemClick: (feedId: Long, isMyFeed: Boolean) -> Unit,
     onRefreshPull: () -> Unit,
     onWriteFeedClick: () -> Unit,
+    onLoadMore: () -> Unit,
     isLoading: Boolean,
     isRefreshing: Boolean,
 ) {
@@ -104,6 +106,22 @@ internal fun FeedSection(
                         )
 
                         if (index < feeds.lastIndex) HorizontalDivider(color = Gray50)
+                    }
+                    item {
+                        LaunchedEffect(feeds.size) {
+                            onLoadMore()
+                        }
+
+                        if (isLoading) {
+                            Box(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(vertical = 16.dp),
+                                contentAlignment = Alignment.Center,
+                            ) {
+                                CircularProgressIndicator()
+                            }
+                        }
                     }
                 }
             }
@@ -437,6 +455,7 @@ private fun FeedSectionPreview() {
                 onSecondItemClick = { _, _ -> },
                 onRefreshPull = { },
                 onWriteFeedClick = {},
+                onLoadMore = {},
                 isRefreshing = false,
                 isLoading = false,
             )

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -68,6 +68,7 @@ compose-ui = "1.10.0"
 
 # Kotlinx-collection
 kotlinx-collections-immutable = "0.3.8"
+foundation = "1.10.4"
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "android-gradle-plugin" }
@@ -167,6 +168,7 @@ compose-runtime-livedata = { module = "androidx.compose.runtime:runtime-livedata
 compose-ui-tooling = { module = "androidx.compose.ui:ui-tooling" }
 compose-hilt-navigation = { module = "androidx.hilt:hilt-navigation-compose", version.ref = "hilt-navigation-compose" }
 lifecycle-runtime-compose = { module = "androidx.lifecycle:lifecycle-runtime-compose" }
+androidx-foundation = { group = "androidx.compose.foundation", name = "foundation", version.ref = "foundation" }
 
 [bundles]
 compose = [


### PR DESCRIPTION
## 📌𝘐𝘴𝘴𝘶𝘦𝘴
- closed #833

## 📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯
- 피드 쪽 무한 스크롤 적용되어 있지 않은 것을 적용했습니다
- `onLoadMore` 라는 람다를 추가해서 마지막 아이템에 도달했을 때 호출되게 했고, onLoadMore 콜백이 왔을 땐 viewModel 함수의 loadNextPage를 호출하게 했슴니다!

## 📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵
용량이 커서 단톡에 올렸서요 ㅠ

## 💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 피드 끝에 도달했을 때 추가 콘텐츠를 로드하는 기능 추가
  * 더 많은 항목을 불러오는 중일 때 로딩 인디케이터 표시

<!-- end of auto-generated comment: release notes by coderabbit.ai -->