### PR TITLE
fix: 피드 글 작품 연결 시 하단 패딩 수정

### DIFF
--- a/feature/feed/src/main/java/com/into/websoso/feature/feed/component/FeedSection.kt
+++ b/feature/feed/src/main/java/com/into/websoso/feature/feed/component/FeedSection.kt
@@ -299,6 +299,8 @@ private fun FeedItem(
         }
 
         if (feed.novel != null) {
+            Spacer(modifier = Modifier.height(height = 10.dp))
+
             FeedNovelInfo(
                 novel = feed.novel,
                 onNovelClick = onNovelClick,

--- a/feature/feed/src/main/java/com/into/websoso/feature/feed/component/FeedSection.kt
+++ b/feature/feed/src/main/java/com/into/websoso/feature/feed/component/FeedSection.kt
@@ -252,6 +252,8 @@ private fun FeedItem(
                 color = Secondary100,
                 modifier = Modifier.debouncedClickable { onContentClick(feed.id, feed.isLiked) },
             )
+
+            Spacer(modifier = Modifier.height(height = 20.dp))
         } else {
             Text(
                 text = feed.content,
@@ -299,8 +301,6 @@ private fun FeedItem(
         }
 
         if (feed.novel != null) {
-            Spacer(modifier = Modifier.height(height = 10.dp))
-
             FeedNovelInfo(
                 novel = feed.novel,
                 onNovelClick = onNovelClick,


### PR DESCRIPTION
## 📌𝘐𝘴𝘴𝘶𝘦𝘴
- closed #838 

## 📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯
- 작품 연결 시 20 dp만큼 간격있도록 수정
-

## 📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵
<img width="1440" height="3088" alt="image" src="https://github.com/user-attachments/assets/b02d9ac1-aaf4-4160-85a1-2b76ffa0cccf" />


## 💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴
830번 이슈 고칠 시 누락됬던 것이라 수정했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **스타일**
  * 스포일러 처리된 피드 항목에서 스포일러 액션 텍스트 뒤에 간격을 추가해 시각적 레이아웃과 읽기 흐름을 개선했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->