### PR TITLE
fix: 하차 글자 밀리는 문제 수정

### DIFF
--- a/feature/library/src/main/java/com/into/websoso/feature/library/component/LibraryListItem.kt
+++ b/feature/library/src/main/java/com/into/websoso/feature/library/component/LibraryListItem.kt
@@ -169,6 +169,9 @@ private fun ReadStatusBadge(
                 text = it.readStatus.label,
                 color = White,
                 style = WebsosoTheme.typography.label2,
+                softWrap = false,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
             )
         }
     }


### PR DESCRIPTION
## 📌𝘐𝘴𝘴𝘶𝘦𝘴
- closed #843 

## 📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯
- s25 플러스에서 내 서재의 읽기 상태인 "하차" 글자가 밀리는 문제 수정
-

## 📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵
<img width="320" height="714" alt="Screenshot_20260325_172134" src="https://github.com/user-attachments/assets/15a5704b-e68e-426a-a29f-b86a080805b6" />

<img width="320" height="714" alt="Screenshot_20260325_172259" src="https://github.com/user-attachments/assets/9a078bcc-2925-416d-9c3c-68ab8e006886" />


## 💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴
`softwrap = false`
`maxLine = 1`
그리고 공식문서에서 권장하는대로 ...으로 글이 축약되게하는
 `overflow = TextOverflow.Ellipsis` 옵션을 넣어 빠르게 문제가 생기면 사용자와 개발자가 알아낼 수 있도록 하였습니다.
추후에도 문제가 여전히 있으면, 디자인 시스템의 텍스트 부분을 dp -> sp로 바꾸는 방법도 고려해보도록 하겠습니다

참고 자료 : https://developer.android.com/develop/ui/compose/text/configure-layout?hl=ko
https://developer.android.com/reference/kotlin/androidx/compose/ui/text/TextLayoutInput?hl=en

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정

* 읽음 상태 레이블의 텍스트 오버플로우 처리 개선: 레이블이 길 경우 한 줄로 제한되며 말줄임표(...)로 자동 축약됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->