### PR TITLE
feat: 피드 날짜 수정

### DIFF
--- a/feature/feed/src/main/java/com/into/websoso/feature/feed/component/FeedSection.kt
+++ b/feature/feed/src/main/java/com/into/websoso/feature/feed/component/FeedSection.kt
@@ -392,8 +392,7 @@ private fun FeedNovelInfo(
             .background(
                 color = novel.genre.boxColor,
                 shape = RoundedCornerShape(size = 16.dp),
-            )
-            .debouncedClickable {
+            ).debouncedClickable {
                 onNovelClick(novel.id)
             },
     ) {

--- a/feature/feed/src/main/java/com/into/websoso/feature/feed/component/FeedSection.kt
+++ b/feature/feed/src/main/java/com/into/websoso/feature/feed/component/FeedSection.kt
@@ -204,7 +204,7 @@ private fun FeedItem(
                     modifier = Modifier.padding(all = 3.dp),
                 )
                 Text(
-                    text = feed.formattedCreatedDate,
+                    text = feed.createdDate,
                     style = WebsosoTheme.typography.body5,
                     color = Gray200,
                 )
@@ -392,7 +392,8 @@ private fun FeedNovelInfo(
             .background(
                 color = novel.genre.boxColor,
                 shape = RoundedCornerShape(size = 16.dp),
-            ).debouncedClickable {
+            )
+            .debouncedClickable {
                 onNovelClick(novel.id)
             },
     ) {

--- a/feature/feed/src/main/java/com/into/websoso/feature/feed/model/FeedUiModel.kt
+++ b/feature/feed/src/main/java/com/into/websoso/feature/feed/model/FeedUiModel.kt
@@ -7,8 +7,6 @@ import com.into.websoso.feed.model.Feed
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toImmutableList
-import java.time.LocalDate
-import java.time.format.DateTimeParseException
 
 fun Feed.toFeedUiModel(): FeedUiModel {
     val novel = if (novel.id != null) {
@@ -68,18 +66,6 @@ data class FeedUiModel(
     val isVisible: Boolean get() = !isSpoiler && imageUrls.isNotEmpty()
     val relevantCategoriesByKr: ImmutableList<String>
         get() = relevantCategories.map { NovelCategory.fromTagToKorean(it) }.toImmutableList()
-    val formattedCreatedDate: String
-        get() {
-            if (createdDate.contains("월") && createdDate.contains("일")) {
-                return createdDate
-            }
-            return try {
-                val date = LocalDate.parse(createdDate)
-                "${date.monthValue}월 ${date.dayOfMonth}일"
-            } catch (e: DateTimeParseException) {
-                createdDate
-            }
-        }
 
     data class UserUiModel(
         val id: Long = 0L,


### PR DESCRIPTION
## 📌𝘐𝘴𝘴𝘶𝘦𝘴
- closed #842 

## 📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯
- 
-

## 📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵
<img width="212" height="462" alt="image" src="https://github.com/user-attachments/assets/987cc161-a1ce-46a7-89f5-4ffc07469133" />
<img width="196" height="446" alt="image" src="https://github.com/user-attachments/assets/f33f2fe6-bd86-4514-a5c9-a0e19f742e1c" />


## 💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴

피드 날짜 정책 수정으로 feeduimodel의 formmateddate 제거하고 createddate그대로 가져오는 걸로 변경했습니다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **Refactor**
  * 피드 항목의 날짜 처리 방식을 단순화하여 날짜 표시가 더 일관되고 안정적으로 동작하도록 수정했습니다. 사용자에게 보이는 날짜 표현에는 변화가 없으며 내부 구현이 정리되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->