### PR TITLE
fix: 16kb 지원

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -76,12 +76,11 @@ android {
 
 configurations.all {
     resolutionStrategy {
+        // SSPullToRefresh가 android-gif-drawable 1.2.28을 끌고 옴
+        // 1.2.28은 16KB 페이지 미지원, 1.2.29에서 지원 추가됨
         force("pl.droidsonroids.gif:android-gif-drawable:1.2.29")
     }
 }
-
-// 룸 디비 제거
-// 좋아요 기능 좀더 생각해보기
 
 dependencies {
     // 프로젝트 의존성

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -74,14 +74,6 @@ android {
     }
 }
 
-configurations.all {
-    resolutionStrategy {
-        // SSPullToRefresh가 android-gif-drawable 1.2.28을 끌고 옴
-        // 1.2.28은 16KB 페이지 미지원, 1.2.29에서 지원 추가됨
-        force("pl.droidsonroids.gif:android-gif-drawable:1.2.29")
-    }
-}
-
 dependencies {
     // 프로젝트 의존성
     implementation(projects.core.resource)
@@ -136,7 +128,7 @@ dependencies {
     // UI 관련 유틸 라이브러리
     implementation(libs.dots.indicator) // ViewPager2 indicator
     implementation(libs.lottie) // Lottie 애니메이션
-    implementation(libs.pull.to.refresh) // Pull 새로고침
+    implementation(libs.swipe.refresh.layout) // Pull 새로고침
 
     // Third-party SDK
     implementation(libs.kakao) // 카카오 로그인 API

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -74,6 +74,12 @@ android {
     }
 }
 
+configurations.all {
+    resolutionStrategy {
+        force("pl.droidsonroids.gif:android-gif-drawable:1.2.29")
+    }
+}
+
 // 룸 디비 제거
 // 좋아요 기능 좀더 생각해보기
 

--- a/app/src/main/java/com/into/websoso/ui/novelFeed/NovelFeedFragment.kt
+++ b/app/src/main/java/com/into/websoso/ui/novelFeed/NovelFeedFragment.kt
@@ -5,7 +5,6 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.view.ViewGroup.LayoutParams
 import android.view.WindowManager.LayoutParams.WRAP_CONTENT
 import android.widget.PopupWindow
 import android.widget.TextView
@@ -341,17 +340,8 @@ class NovelFeedFragment : BaseFragment<FragmentNovelFeedBinding>(R.layout.fragme
     }
 
     private fun setupRefreshView() {
-        binding.sptrNovelFeedRefresh.apply {
-            setRefreshViewParams(
-                params = LayoutParams(
-                    30.toIntPxFromDp(),
-                    30.toIntPxFromDp(),
-                ),
-            )
-            setLottieAnimation("lottie_websoso_loading.json")
-            setOnRefreshListener {
-                novelFeedViewModel.updateRefreshedFeeds(novelId)
-            }
+        binding.sptrNovelFeedRefresh.setOnRefreshListener {
+            novelFeedViewModel.updateRefreshedFeeds(novelId)
         }
     }
 
@@ -375,7 +365,7 @@ class NovelFeedFragment : BaseFragment<FragmentNovelFeedBinding>(R.layout.fragme
 
                 !novelFeedUiState.loading -> {
                     binding.wllNovelFeed.setWebsosoLoadingVisibility(false)
-                    binding.sptrNovelFeedRefresh.setRefreshing(false)
+                    binding.sptrNovelFeedRefresh.isRefreshing = false
                     updateFeeds(novelFeedUiState)
                 }
             }

--- a/app/src/main/res/layout/fragment_novel_feed.xml
+++ b/app/src/main/res/layout/fragment_novel_feed.xml
@@ -21,7 +21,7 @@
                 android:background="@color/white"
                 app:layout_constraintTop_toTopOf="parent" />
 
-            <com.simform.refresh.SSPullToRefreshLayout
+            <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
                 android:id="@+id/sptr_novel_feed_refresh"
                 android:layout_width="match_parent"
                 android:layout_height="0dp"
@@ -36,7 +36,7 @@
                     android:overScrollMode="never"
                     app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
                     tools:listitem="@layout/item_feed" />
-            </com.simform.refresh.SSPullToRefreshLayout>
+            </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
 
             <androidx.constraintlayout.widget.ConstraintLayout
                 android:id="@+id/cl_novel_feed_none"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -57,7 +57,7 @@ lottie = "6.7.1"
 pull-to-refresh = "1.5.2"
 
 # Social Login Libraries
-kakao = "2.23.1"
+kakao = "2.23.2"
 
 # Ktlint
 ktlint = "14.0.1"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -54,7 +54,7 @@ coil-transformers = "1.0.6"
 # Misc UI Libraries
 dots-indicator = "5.1.0"
 lottie = "6.7.1"
-pull-to-refresh = "1.5.2"
+swipe-refresh-layout = "1.2.0"
 
 # Social Login Libraries
 kakao = "2.23.1"
@@ -130,7 +130,7 @@ coil-transformers = { module = "jp.wasabeef.transformers:coil", version.ref = "c
 # Misc UI Libraries
 dots-indicator = { module = "com.tbuonomo:dotsindicator", version.ref = "dots-indicator" }
 lottie = { module = "com.airbnb.android:lottie", version.ref = "lottie" }
-pull-to-refresh = { module = "com.github.SimformSolutionsPvtLtd:SSPullToRefresh", version.ref = "pull-to-refresh" }
+swipe-refresh-layout = { module = "androidx.swiperefreshlayout:swiperefreshlayout", version.ref = "swipe-refresh-layout" }
 
 # Social Login Libraries
 kakao = { module = "com.kakao.sdk:v2-user", version.ref = "kakao" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -57,7 +57,7 @@ lottie = "6.7.1"
 pull-to-refresh = "1.5.2"
 
 # Social Login Libraries
-kakao = "2.23.2"
+kakao = "2.23.1"
 
 # Ktlint
 ktlint = "14.0.1"


### PR DESCRIPTION
## 📌𝘐𝘴𝘴𝘶𝘦𝘴
- closed #857 

## 📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯
- 
-

## 📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵


## 💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴

kakao sdk가 [android-gif-drawable](https://github.com/koral--/android-gif-drawable/tree/dev) 라이브러리를 16kb 미지원하는 버전으로 의존해서 생긴 문제라 sdk 업데이트 후 drawable 라이브러리를 강제로 업데이트 했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * 새로고침 라이브러리를 AndroidX SwipeRefreshLayout으로 교체하여 빌드 의존성 정리 및 불필요한 주석 제거
* **Refactor**
  * 새로고침 관련 구현을 단순화하여 표준 위젯으로 통일(사용자 관점의 새로고침 동작과 표시 종료 처리는 유지)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->