### PR TITLE
fix: 피드 필터 카테고리 칩사이 간격 수정

### DIFF
--- a/feature/feed/src/main/java/com/into/websoso/feature/feed/component/MyFeedFilterModal.kt
+++ b/feature/feed/src/main/java/com/into/websoso/feature/feed/component/MyFeedFilterModal.kt
@@ -1,9 +1,10 @@
 package com.into.websoso.feature.feed.component
 
 import androidx.annotation.DrawableRes
-import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -19,7 +20,6 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
-import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -28,9 +28,11 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.into.websoso.core.common.extensions.debouncedClickable
@@ -66,8 +68,7 @@ internal fun MyFeedFilterModal(
                     topStart = 16.dp,
                     topEnd = 16.dp,
                 ),
-            )
-            .navigationBarsPadding(),
+            ).navigationBarsPadding(),
     ) {
         Row(
             horizontalArrangement = Arrangement.SpaceBetween,
@@ -152,8 +153,7 @@ internal fun MyFeedFilterModal(
                 .background(
                     color = Primary100,
                     shape = RoundedCornerShape(size = 14.dp),
-                )
-                .debouncedClickable {
+                ).debouncedClickable {
                     onApplyFilterClick(MyFeedFilter(tempGenres, tempIsVisible, tempIsUnVisible))
                 },
         ) {
@@ -217,8 +217,8 @@ private fun GenreChipGroup(
 ) {
     FlowRow(
         modifier = modifier.fillMaxWidth(),
-        horizontalArrangement = Arrangement.spacedBy(space = 6.dp),
-        verticalArrangement = Arrangement.spacedBy(space = 14.dp),
+        horizontalArrangement = Arrangement.spacedBy(space = 4.dp),
+        verticalArrangement = Arrangement.spacedBy(space = 8.dp),
     ) {
         NovelCategory.entries.forEach { category ->
             val isSelected = selectedCategories.contains(category)
@@ -244,16 +244,23 @@ private fun GenreChip(
     text: String,
     isSelected: Boolean,
     onChipClick: () -> Unit,
+    modifier: Modifier = Modifier,
 ) {
-    Surface(
-        shape = RoundedCornerShape(size = 20.dp),
-        border = BorderStroke(width = 1.dp, color = if (isSelected) Primary100 else Gray50),
-        color = if (isSelected) Primary50 else Gray50,
-        onClick = onChipClick,
+    Box(
+        modifier = modifier
+            .clip(RoundedCornerShape(size = 20.dp))
+            .border(
+                width = 1.dp,
+                color = if (isSelected) Primary100 else Gray50,
+                shape = RoundedCornerShape(size = 20.dp),
+            ).background(color = if (isSelected) Primary50 else Gray50)
+            .clickable(onClick = onChipClick),
+        contentAlignment = Alignment.Center,
     ) {
         Text(
             text = text,
-            modifier = Modifier.padding(horizontal = 10.dp, vertical = 8.dp),
+            modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp),
+            textAlign = TextAlign.Center,
             color = if (isSelected) Primary100 else Gray300,
             style = WebsosoTheme.typography.body2,
         )


### PR DESCRIPTION
## 📌𝘐𝘴𝘴𝘶𝘦𝘴
- closed #867

## 📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯
- 피드 필터 카테고리 칩 사이 수정 간격 수정

## 📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵
<img width="1080" height="2340" alt="image" src="https://github.com/user-attachments/assets/a09c1b50-a583-4bb0-a514-73eb59c3a027" />


## 💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 장르 분류의 한글 표기 오타를 수정했습니다.

* **스타일 개선**
  * 피드 필터 모달의 아이콘 크기와 간격을 최적화했습니다.
  * 필터 UI 요소의 시각적 색상 표현을 개선했습니다.
  * 라이브러리 필터의 아이콘 크기를 조정하여 UI의 일관성을 강화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->