### PR TITLE
feat: 작품 평가 UI 수정

### DIFF
--- a/app/src/main/java/com/into/websoso/ui/novelRating/NovelRatingActivity.kt
+++ b/app/src/main/java/com/into/websoso/ui/novelRating/NovelRatingActivity.kt
@@ -55,7 +55,6 @@ class NovelRatingActivity : BaseActivity<ActivityNovelRatingBinding>(activity_no
     lateinit var tracker: Tracker
 
     private val novelRatingViewModel: NovelRatingViewModel by viewModels()
-    private val charmPoints: List<CharmPoint> = CharmPoint.entries.toList()
     private lateinit var charmPointItems: List<CharmPointItem>
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -306,7 +305,7 @@ class NovelRatingActivity : BaseActivity<ActivityNovelRatingBinding>(activity_no
     }
 
     private fun handleCharmPointClick(charmPoint: CharmPoint) {
-        novelRatingViewModel.updateCharmPoints(charmPoints.find { it == charmPoint } ?: return)
+        novelRatingViewModel.updateCharmPoints(charmPoint)
     }
 
     private fun showDatePickerBottomSheetDialog() {

--- a/app/src/main/java/com/into/websoso/ui/novelRating/NovelRatingActivity.kt
+++ b/app/src/main/java/com/into/websoso/ui/novelRating/NovelRatingActivity.kt
@@ -221,9 +221,6 @@ class NovelRatingActivity : BaseActivity<ActivityNovelRatingBinding>(activity_no
 
         charmPointItems.forEach { item ->
             val isSelected = item.charmPoint in selectedCharmPoints
-            item.container.isSelected = isSelected
-            item.icon.isSelected = isSelected
-            item.title.isSelected = isSelected
             item.icon.setColorFilter(if (isSelected) selectedColor else defaultIconColor)
             item.title.setTextColor(if (isSelected) selectedColor else defaultTextColor)
         }

--- a/app/src/main/java/com/into/websoso/ui/novelRating/NovelRatingActivity.kt
+++ b/app/src/main/java/com/into/websoso/ui/novelRating/NovelRatingActivity.kt
@@ -253,48 +253,11 @@ class NovelRatingActivity : BaseActivity<ActivityNovelRatingBinding>(activity_no
     }
 
     private fun setupCharmPointItems() {
-        val charmPointViews = mapOf(
-            CharmPoint.WORLDVIEW to CharmPointViews(
-                container = binding.llNovelRatingCharmPointWorldview,
-                icon = binding.ivNovelRatingCharmPointWorldview,
-                title = binding.tvNovelRatingCharmPointWorldview,
-            ),
-            CharmPoint.MATERIAL to CharmPointViews(
-                container = binding.llNovelRatingCharmPointMaterial,
-                icon = binding.ivNovelRatingCharmPointMaterial,
-                title = binding.tvNovelRatingCharmPointMaterial,
-            ),
-            CharmPoint.WRITINGSKILL to CharmPointViews(
-                container = binding.llNovelRatingCharmPointWritingSkill,
-                icon = binding.ivNovelRatingCharmPointWritingSkill,
-                title = binding.tvNovelRatingCharmPointWritingSkill,
-            ),
-            CharmPoint.CHARACTER to CharmPointViews(
-                container = binding.llNovelRatingCharmPointCharacter,
-                icon = binding.ivNovelRatingCharmPointCharacter,
-                title = binding.tvNovelRatingCharmPointCharacter,
-            ),
-            CharmPoint.RELATIONSHIP to CharmPointViews(
-                container = binding.llNovelRatingCharmPointRelationship,
-                icon = binding.ivNovelRatingCharmPointRelationship,
-                title = binding.tvNovelRatingCharmPointRelationship,
-            ),
-            CharmPoint.VIBE to CharmPointViews(
-                container = binding.llNovelRatingCharmPointVibe,
-                icon = binding.ivNovelRatingCharmPointVibe,
-                title = binding.tvNovelRatingCharmPointVibe,
-            ),
-        )
         val orderedCharmPoints = getString(novel_rating_charm_points).toWrappedCharmPoint()
         charmPointItems = orderedCharmPoints.map { charmPoint ->
-            val views = charmPointViews.getValue(charmPoint)
-            views.title.text = charmPoint.title
-            CharmPointItem(
-                charmPoint = charmPoint,
-                container = views.container,
-                icon = views.icon,
-                title = views.title,
-            )
+            charmPoint.toCharmPointItem().also { item ->
+                item.title.text = charmPoint.title
+            }
         }
 
         charmPointItems.forEach { item ->
@@ -303,6 +266,51 @@ class NovelRatingActivity : BaseActivity<ActivityNovelRatingBinding>(activity_no
             }
         }
     }
+
+    private fun CharmPoint.toCharmPointItem(): CharmPointItem =
+        when (this) {
+            CharmPoint.WORLDVIEW -> CharmPointItem(
+                charmPoint = this,
+                container = binding.llNovelRatingCharmPointWorldview,
+                icon = binding.ivNovelRatingCharmPointWorldview,
+                title = binding.tvNovelRatingCharmPointWorldview,
+            )
+
+            CharmPoint.MATERIAL -> CharmPointItem(
+                charmPoint = this,
+                container = binding.llNovelRatingCharmPointMaterial,
+                icon = binding.ivNovelRatingCharmPointMaterial,
+                title = binding.tvNovelRatingCharmPointMaterial,
+            )
+
+            CharmPoint.WRITINGSKILL -> CharmPointItem(
+                charmPoint = this,
+                container = binding.llNovelRatingCharmPointWritingSkill,
+                icon = binding.ivNovelRatingCharmPointWritingSkill,
+                title = binding.tvNovelRatingCharmPointWritingSkill,
+            )
+
+            CharmPoint.CHARACTER -> CharmPointItem(
+                charmPoint = this,
+                container = binding.llNovelRatingCharmPointCharacter,
+                icon = binding.ivNovelRatingCharmPointCharacter,
+                title = binding.tvNovelRatingCharmPointCharacter,
+            )
+
+            CharmPoint.RELATIONSHIP -> CharmPointItem(
+                charmPoint = this,
+                container = binding.llNovelRatingCharmPointRelationship,
+                icon = binding.ivNovelRatingCharmPointRelationship,
+                title = binding.tvNovelRatingCharmPointRelationship,
+            )
+
+            CharmPoint.VIBE -> CharmPointItem(
+                charmPoint = this,
+                container = binding.llNovelRatingCharmPointVibe,
+                icon = binding.ivNovelRatingCharmPointVibe,
+                title = binding.tvNovelRatingCharmPointVibe,
+            )
+        }
 
     private fun handleCharmPointClick(charmPoint: CharmPoint) {
         novelRatingViewModel.updateCharmPoints(charmPoint)
@@ -371,12 +379,6 @@ class NovelRatingActivity : BaseActivity<ActivityNovelRatingBinding>(activity_no
 
     private data class CharmPointItem(
         val charmPoint: CharmPoint,
-        val container: View,
-        val icon: ImageView,
-        val title: TextView,
-    )
-
-    private data class CharmPointViews(
         val container: View,
         val icon: ImageView,
         val title: TextView,

--- a/app/src/main/java/com/into/websoso/ui/novelRating/NovelRatingActivity.kt
+++ b/app/src/main/java/com/into/websoso/ui/novelRating/NovelRatingActivity.kt
@@ -5,12 +5,14 @@ import android.content.Intent
 import android.os.Bundle
 import android.text.SpannableString
 import android.text.style.UnderlineSpan
+import android.view.View
+import android.widget.ImageView
+import android.widget.TextView
 import androidx.activity.OnBackPressedCallback
 import androidx.activity.viewModels
-import androidx.core.view.forEach
-import com.into.websoso.R.color.bg_novel_rating_chip_background_selector
-import com.into.websoso.R.color.bg_novel_rating_chip_stroke_selector
-import com.into.websoso.R.color.bg_novel_rating_chip_text_selector
+import androidx.core.content.ContextCompat
+import com.into.websoso.R.color.gray_200_949399
+import com.into.websoso.R.color.gray_80_DDDDE3
 import com.into.websoso.R.color.primary_100_6A5DFD
 import com.into.websoso.R.color.primary_50_F1EFFF
 import com.into.websoso.R.drawable.bg_novel_detail_primary_100_radius_8dp
@@ -54,13 +56,14 @@ class NovelRatingActivity : BaseActivity<ActivityNovelRatingBinding>(activity_no
 
     private val novelRatingViewModel: NovelRatingViewModel by viewModels()
     private val charmPoints: List<CharmPoint> = CharmPoint.entries.toList()
+    private lateinit var charmPointItems: List<CharmPointItem>
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         bindView()
         setupNovelRating()
         setupObserver()
-        setupCharmPointChips()
+        setupCharmPointItems()
         setupWebsosoLoadingLayout()
         setupBackPressCallback()
         tracker.trackEvent("rate")
@@ -189,7 +192,7 @@ class NovelRatingActivity : BaseActivity<ActivityNovelRatingBinding>(activity_no
 
     private fun updateView(uiState: NovelRatingUiState) {
         updateSelectedDate(uiState.novelRatingModel.ratingDateModel)
-        updateCharmPointChips(uiState.novelRatingModel.charmPoints)
+        updateCharmPointItems(uiState.novelRatingModel.charmPoints)
         updateKeywordChips(uiState.keywordsModel.currentSelectedKeywords)
     }
 
@@ -210,17 +213,19 @@ class NovelRatingActivity : BaseActivity<ActivityNovelRatingBinding>(activity_no
         binding.tvNovelRatingDisplayDate.text = underlinedText
     }
 
-    private fun updateCharmPointChips(previousSelectedCharmPoints: List<CharmPoint>) {
-        val selectedTitles = previousSelectedCharmPoints.map { it.title }.toSet()
+    private fun updateCharmPointItems(previousSelectedCharmPoints: List<CharmPoint>) {
+        val selectedCharmPoints = previousSelectedCharmPoints.toSet()
+        val selectedColor = ContextCompat.getColor(this, primary_100_6A5DFD)
+        val defaultIconColor = ContextCompat.getColor(this, gray_80_DDDDE3)
+        val defaultTextColor = ContextCompat.getColor(this, gray_200_949399)
 
-        listOf(
-            binding.wcgNovelRatingCharmPointsRow1,
-            binding.wcgNovelRatingCharmPointsRow2,
-        ).forEach { chipGroup ->
-            chipGroup.forEach { view ->
-                val chip = view as WebsosoChip
-                chip.isSelected = chip.text.toString() in selectedTitles
-            }
+        charmPointItems.forEach { item ->
+            val isSelected = item.charmPoint in selectedCharmPoints
+            item.container.isSelected = isSelected
+            item.icon.isSelected = isSelected
+            item.title.isSelected = isSelected
+            item.icon.setColorFilter(if (isSelected) selectedColor else defaultIconColor)
+            item.title.setTextColor(if (isSelected) selectedColor else defaultTextColor)
         }
     }
 
@@ -251,36 +256,57 @@ class NovelRatingActivity : BaseActivity<ActivityNovelRatingBinding>(activity_no
         }
     }
 
-    private fun setupCharmPointChips() {
-        val charmPoints = getString(novel_rating_charm_points).toWrappedCharmPoint()
-
-        val firstRow = charmPoints.take(3)
-        val secondRow = charmPoints.drop(3)
-
-        binding.wcgNovelRatingCharmPointsRow1.removeAllViews()
-        binding.wcgNovelRatingCharmPointsRow2.removeAllViews()
-
-        firstRow.forEach { charmPoint ->
-            binding.wcgNovelRatingCharmPointsRow1.addChip(createCharmPointChip(charmPoint))
+    private fun setupCharmPointItems() {
+        val orderedCharmPoints = getString(novel_rating_charm_points).toWrappedCharmPoint()
+        val charmPointViews = listOf(
+            CharmPointViews(
+                container = binding.llNovelRatingCharmPointWorldview,
+                icon = binding.ivNovelRatingCharmPointWorldview,
+                title = binding.tvNovelRatingCharmPointWorldview,
+            ),
+            CharmPointViews(
+                container = binding.llNovelRatingCharmPointMaterial,
+                icon = binding.ivNovelRatingCharmPointMaterial,
+                title = binding.tvNovelRatingCharmPointMaterial,
+            ),
+            CharmPointViews(
+                container = binding.llNovelRatingCharmPointWritingSkill,
+                icon = binding.ivNovelRatingCharmPointWritingSkill,
+                title = binding.tvNovelRatingCharmPointWritingSkill,
+            ),
+            CharmPointViews(
+                container = binding.llNovelRatingCharmPointCharacter,
+                icon = binding.ivNovelRatingCharmPointCharacter,
+                title = binding.tvNovelRatingCharmPointCharacter,
+            ),
+            CharmPointViews(
+                container = binding.llNovelRatingCharmPointRelationship,
+                icon = binding.ivNovelRatingCharmPointRelationship,
+                title = binding.tvNovelRatingCharmPointRelationship,
+            ),
+            CharmPointViews(
+                container = binding.llNovelRatingCharmPointVibe,
+                icon = binding.ivNovelRatingCharmPointVibe,
+                title = binding.tvNovelRatingCharmPointVibe,
+            ),
+        )
+        charmPointItems = orderedCharmPoints.zip(charmPointViews) { charmPoint, views ->
+            views.title.text = charmPoint.title
+            CharmPointItem(
+                charmPoint = charmPoint,
+                container = views.container,
+                icon = views.icon,
+                title = views.title,
+            )
         }
 
-        secondRow.forEach { charmPoint ->
-            binding.wcgNovelRatingCharmPointsRow2.addChip(createCharmPointChip(charmPoint))
+        charmPointItems.forEach { item ->
+            item.container.setOnClickListener {
+                handleCharmPointClick(item.charmPoint)
+            }
         }
+        updateCharmPointItems(emptyList())
     }
-
-    private fun createCharmPointChip(charmPoint: CharmPoint): WebsosoChip =
-        WebsosoChip(this@NovelRatingActivity).apply {
-            setWebsosoChipText(charmPoint.title)
-            setWebsosoChipTextAppearance(body2)
-            setWebsosoChipTextColor(bg_novel_rating_chip_text_selector)
-            setWebsosoChipStrokeColor(bg_novel_rating_chip_stroke_selector)
-            setWebsosoChipBackgroundColor(bg_novel_rating_chip_background_selector)
-            setWebsosoChipPaddingVertical(12f.toFloatPxFromDp())
-            setWebsosoChipPaddingHorizontal(6f.toFloatPxFromDp())
-            setWebsosoChipRadius(20f.toFloatPxFromDp())
-            setOnWebsosoChipClick { handleCharmPointClick(charmPoint) }
-        }
 
     private fun handleCharmPointClick(charmPoint: CharmPoint) {
         novelRatingViewModel.updateCharmPoints(charmPoints.find { it == charmPoint } ?: return)
@@ -346,4 +372,17 @@ class NovelRatingActivity : BaseActivity<ActivityNovelRatingBinding>(activity_no
                 putExtra(NOVEL, novel)
             }
     }
+
+    private data class CharmPointItem(
+        val charmPoint: CharmPoint,
+        val container: View,
+        val icon: ImageView,
+        val title: TextView,
+    )
+
+    private data class CharmPointViews(
+        val container: View,
+        val icon: ImageView,
+        val title: TextView,
+    )
 }

--- a/app/src/main/java/com/into/websoso/ui/novelRating/NovelRatingActivity.kt
+++ b/app/src/main/java/com/into/websoso/ui/novelRating/NovelRatingActivity.kt
@@ -306,7 +306,6 @@ class NovelRatingActivity : BaseActivity<ActivityNovelRatingBinding>(activity_no
                 handleCharmPointClick(item.charmPoint)
             }
         }
-        updateCharmPointItems(emptyList())
     }
 
     private fun handleCharmPointClick(charmPoint: CharmPoint) {

--- a/app/src/main/java/com/into/websoso/ui/novelRating/NovelRatingActivity.kt
+++ b/app/src/main/java/com/into/websoso/ui/novelRating/NovelRatingActivity.kt
@@ -257,40 +257,41 @@ class NovelRatingActivity : BaseActivity<ActivityNovelRatingBinding>(activity_no
     }
 
     private fun setupCharmPointItems() {
-        val orderedCharmPoints = getString(novel_rating_charm_points).toWrappedCharmPoint()
-        val charmPointViews = listOf(
-            CharmPointViews(
+        val charmPointViews = mapOf(
+            CharmPoint.WORLDVIEW to CharmPointViews(
                 container = binding.llNovelRatingCharmPointWorldview,
                 icon = binding.ivNovelRatingCharmPointWorldview,
                 title = binding.tvNovelRatingCharmPointWorldview,
             ),
-            CharmPointViews(
+            CharmPoint.MATERIAL to CharmPointViews(
                 container = binding.llNovelRatingCharmPointMaterial,
                 icon = binding.ivNovelRatingCharmPointMaterial,
                 title = binding.tvNovelRatingCharmPointMaterial,
             ),
-            CharmPointViews(
+            CharmPoint.WRITINGSKILL to CharmPointViews(
                 container = binding.llNovelRatingCharmPointWritingSkill,
                 icon = binding.ivNovelRatingCharmPointWritingSkill,
                 title = binding.tvNovelRatingCharmPointWritingSkill,
             ),
-            CharmPointViews(
+            CharmPoint.CHARACTER to CharmPointViews(
                 container = binding.llNovelRatingCharmPointCharacter,
                 icon = binding.ivNovelRatingCharmPointCharacter,
                 title = binding.tvNovelRatingCharmPointCharacter,
             ),
-            CharmPointViews(
+            CharmPoint.RELATIONSHIP to CharmPointViews(
                 container = binding.llNovelRatingCharmPointRelationship,
                 icon = binding.ivNovelRatingCharmPointRelationship,
                 title = binding.tvNovelRatingCharmPointRelationship,
             ),
-            CharmPointViews(
+            CharmPoint.VIBE to CharmPointViews(
                 container = binding.llNovelRatingCharmPointVibe,
                 icon = binding.ivNovelRatingCharmPointVibe,
                 title = binding.tvNovelRatingCharmPointVibe,
             ),
         )
-        charmPointItems = orderedCharmPoints.zip(charmPointViews) { charmPoint, views ->
+        val orderedCharmPoints = getString(novel_rating_charm_points).toWrappedCharmPoint()
+        charmPointItems = orderedCharmPoints.map { charmPoint ->
+            val views = charmPointViews.getValue(charmPoint)
             views.title.text = charmPoint.title
             CharmPointItem(
                 charmPoint = charmPoint,

--- a/app/src/main/res/color/bg_novel_detail_rating_read_status_icon_selector.xml
+++ b/app/src/main/res/color/bg_novel_detail_rating_read_status_icon_selector.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <item android:color="@color/primary_100_6A5DFD" android:state_checked="true" />
+    <item android:color="@color/gray_80_DDDDE3" android:state_checked="false" />
+</selector>

--- a/app/src/main/res/layout/activity_novel_rating.xml
+++ b/app/src/main/res/layout/activity_novel_rating.xml
@@ -59,7 +59,7 @@
                         android:textColor="@color/bg_novel_detail_rating_read_status_selector"
                         app:icon="@drawable/ic_novel_rating_watching"
                         app:iconGravity="top"
-                        app:iconTint="@color/bg_novel_detail_rating_read_status_selector" />
+                        app:iconTint="@color/bg_novel_detail_rating_read_status_icon_selector" />
 
                     <com.google.android.material.button.MaterialButton
                         android:id="@+id/btn_novel_rating_watched"
@@ -75,7 +75,7 @@
                         android:textColor="@color/bg_novel_detail_rating_read_status_selector"
                         app:icon="@drawable/ic_novel_rating_watched"
                         app:iconGravity="top"
-                        app:iconTint="@color/bg_novel_detail_rating_read_status_selector" />
+                        app:iconTint="@color/bg_novel_detail_rating_read_status_icon_selector" />
 
                     <com.google.android.material.button.MaterialButton
                         android:id="@+id/btn_novel_rating_quit"
@@ -91,7 +91,7 @@
                         android:textColor="@color/bg_novel_detail_rating_read_status_selector"
                         app:icon="@drawable/ic_novel_rating_quit"
                         app:iconGravity="top"
-                        app:iconTint="@color/bg_novel_detail_rating_read_status_selector" />
+                        app:iconTint="@color/bg_novel_detail_rating_read_status_icon_selector" />
                 </com.google.android.material.button.MaterialButtonToggleGroup>
 
                 <TextView
@@ -122,12 +122,24 @@
                     android:id="@+id/rb_novel_rating"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:layout_marginTop="24dp"
+                    android:layout_marginTop="16dp"
                     android:minHeight="30dp"
                     android:numStars="5"
                     android:onRatingChanged="@{(view, rating, fromUser) -> viewModel.updateRatingValue(rating)}"
                     android:progressDrawable="@drawable/ic_novel_rating_star_selector"
                     android:rating="@{viewModel.uiState.novelRatingModel.userNovelRating}"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/tv_novel_rating_star_title" />
+
+                <TextView
+                    android:id="@+id/tv_novel_rating_star_title"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="24dp"
+                    android:text="@string/novel_rating_star_title"
+                    android:textAppearance="@style/title3"
+                    android:textColor="@color/black"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toBottomOf="@id/divider_novel_rating_add_date" />
@@ -148,7 +160,7 @@
                     android:layout_height="wrap_content"
                     android:layout_marginTop="24dp"
                     android:text="@string/novel_rating_charm_point_title"
-                    android:textAppearance="@style/body1"
+                    android:textAppearance="@style/title3"
                     android:textColor="@color/black"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
@@ -158,30 +170,175 @@
                     android:id="@+id/ll_novel_rating_charm_points_container"
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
-                    android:layout_marginHorizontal="84dp"
-                    android:layout_marginTop="14dp"
-                    android:gravity="center_horizontal"
-                    android:orientation="vertical"
+                    android:layout_marginHorizontal="20dp"
+                    android:layout_marginTop="24dp"
+                    android:gravity="center"
+                    android:orientation="horizontal"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toBottomOf="@id/tv_novel_rating_charm_point">
 
-                    <com.into.websoso.core.common.ui.custom.WebsosoChipGroup
-                        android:id="@+id/wcg_novel_rating_charm_points_row1"
-                        android:layout_width="wrap_content"
+                    <LinearLayout
+                        android:id="@+id/ll_novel_rating_charm_point_worldview"
+                        android:layout_width="0dp"
                         android:layout_height="wrap_content"
-                        app:chipSpacing="6dp"
-                        app:singleLine="true"
-                        app:singleSelection="false" />
+                        android:layout_weight="1"
+                        android:gravity="center"
+                        android:orientation="vertical"
+                        android:paddingVertical="7dp">
 
-                    <com.into.websoso.core.common.ui.custom.WebsosoChipGroup
-                        android:id="@+id/wcg_novel_rating_charm_points_row2"
-                        android:layout_width="wrap_content"
+                        <ImageView
+                            android:id="@+id/iv_novel_rating_charm_point_worldview"
+                            android:layout_width="36dp"
+                            android:layout_height="36dp"
+                            android:padding="2dp"
+                            android:src="@drawable/ic_library_world_view"
+                            app:tint="@color/gray_80_DDDDE3" />
+
+                        <TextView
+                            android:id="@+id/tv_novel_rating_charm_point_worldview"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_marginTop="6dp"
+                            android:textAppearance="@style/body4"
+                            android:textColor="@color/gray_200_949399"
+                            tools:text="세계관" />
+                    </LinearLayout>
+
+                    <LinearLayout
+                        android:id="@+id/ll_novel_rating_charm_point_material"
+                        android:layout_width="0dp"
                         android:layout_height="wrap_content"
-                        android:layout_marginTop="6dp"
-                        app:chipSpacing="6dp"
-                        app:singleLine="true"
-                        app:singleSelection="false" />
+                        android:layout_weight="1"
+                        android:gravity="center"
+                        android:orientation="vertical"
+                        android:paddingVertical="7dp">
+
+                        <ImageView
+                            android:id="@+id/iv_novel_rating_charm_point_material"
+                            android:layout_width="36dp"
+                            android:layout_height="36dp"
+                            android:padding="2dp"
+                            android:src="@drawable/ic_library_material"
+                            app:tint="@color/gray_80_DDDDE3" />
+
+                        <TextView
+                            android:id="@+id/tv_novel_rating_charm_point_material"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_marginTop="6dp"
+                            android:textAppearance="@style/body4"
+                            android:textColor="@color/gray_200_949399"
+                            tools:text="소재" />
+                    </LinearLayout>
+
+                    <LinearLayout
+                        android:id="@+id/ll_novel_rating_charm_point_writing_skill"
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:gravity="center"
+                        android:orientation="vertical"
+                        android:paddingVertical="7dp">
+
+                        <ImageView
+                            android:id="@+id/iv_novel_rating_charm_point_writing_skill"
+                            android:layout_width="36dp"
+                            android:layout_height="36dp"
+                            android:padding="2dp"
+                            android:src="@drawable/ic_library_writingskill"
+                            app:tint="@color/gray_80_DDDDE3" />
+
+                        <TextView
+                            android:id="@+id/tv_novel_rating_charm_point_writing_skill"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_marginTop="6dp"
+                            android:textAppearance="@style/body4"
+                            android:textColor="@color/gray_200_949399"
+                            tools:text="필력" />
+                    </LinearLayout>
+
+                    <LinearLayout
+                        android:id="@+id/ll_novel_rating_charm_point_character"
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:gravity="center"
+                        android:orientation="vertical"
+                        android:paddingVertical="7dp">
+
+                        <ImageView
+                            android:id="@+id/iv_novel_rating_charm_point_character"
+                            android:layout_width="36dp"
+                            android:layout_height="36dp"
+                            android:padding="2dp"
+                            android:src="@drawable/ic_library_character"
+                            app:tint="@color/gray_80_DDDDE3" />
+
+                        <TextView
+                            android:id="@+id/tv_novel_rating_charm_point_character"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_marginTop="6dp"
+                            android:textAppearance="@style/body4"
+                            android:textColor="@color/gray_200_949399"
+                            tools:text="캐릭터" />
+                    </LinearLayout>
+
+                    <LinearLayout
+                        android:id="@+id/ll_novel_rating_charm_point_relationship"
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:gravity="center"
+                        android:orientation="vertical"
+                        android:paddingVertical="7dp">
+
+                        <ImageView
+                            android:id="@+id/iv_novel_rating_charm_point_relationship"
+                            android:layout_width="36dp"
+                            android:layout_height="36dp"
+                            android:padding="2dp"
+                            android:src="@drawable/ic_library_relationship"
+                            app:tint="@color/gray_80_DDDDE3" />
+
+                        <TextView
+                            android:id="@+id/tv_novel_rating_charm_point_relationship"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_marginTop="6dp"
+                            android:textAppearance="@style/body4"
+                            android:textColor="@color/gray_200_949399"
+                            tools:text="관계" />
+                    </LinearLayout>
+
+                    <LinearLayout
+                        android:id="@+id/ll_novel_rating_charm_point_vibe"
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:gravity="center"
+                        android:orientation="vertical"
+                        android:paddingVertical="7dp">
+
+                        <ImageView
+                            android:id="@+id/iv_novel_rating_charm_point_vibe"
+                            android:layout_width="36dp"
+                            android:layout_height="36dp"
+                            android:padding="2dp"
+                            android:src="@drawable/ic_library_vibe"
+                            app:tint="@color/gray_80_DDDDE3" />
+
+                        <TextView
+                            android:id="@+id/tv_novel_rating_charm_point_vibe"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_marginTop="6dp"
+                            android:textAppearance="@style/body4"
+                            android:textColor="@color/gray_200_949399"
+                            tools:text="분위기" />
+                    </LinearLayout>
                 </LinearLayout>
 
                 <com.google.android.material.divider.MaterialDivider
@@ -200,7 +357,7 @@
                     android:layout_height="wrap_content"
                     android:layout_marginTop="24dp"
                     android:text="@string/novel_rating_keyword"
-                    android:textAppearance="@style/body1"
+                    android:textAppearance="@style/title3"
                     android:textColor="@color/black"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"

--- a/core/resource/src/main/res/values/strings.xml
+++ b/core/resource/src/main/res/values/strings.xml
@@ -145,6 +145,7 @@
     <string name="novel_rating_read_status_watching">보는 중</string>
     <string name="novel_rating_read_status_watched">봤어요</string>
     <string name="novel_rating_read_status_quit">하차</string>
+    <string name="novel_rating_star_title">별점</string>
     <string name="novel_rating_charm_points">세계관,소재,필력,캐릭터,관계,분위기</string>
     <string name="novel_rating_cancel_alert_title">평가를 그만하시겠어요?</string>
     <string name="novel_rating_cancel_alert_accept">그만하기</string>
@@ -171,7 +172,7 @@
     <string name="novel_rating_keyword_enroll">%d개 선택</string>
     <string name="novel_rating_charm_point_title">매력포인트</string>
     <string name="novel_rating_keyword">키워드</string>
-    <string name="novel_rating_keyword_button">이 작품에 대해 소개해주세요!</string>
+    <string name="novel_rating_keyword_button">작품을 나타내는 키워드는?</string>
     <string name="novel_rating_keyword_exceed">최대 20개까지 선택 가능해요</string>
     <string name="novel_rating_charm_point_exceed">최대 3개까지 선택 가능해요</string>
 


### PR DESCRIPTION
## 📌𝘐𝘴𝘴𝘶𝘦𝘴
- closed #889 

## 📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯
기존 : 아이콘과 글자 색 통일
- 아이콘 defalut 색 통일→ gray 80
- 글자 defalut 색 통일 -> gray200
- `별점` 타이틀 추가
- 매력포인트 `칩`에서 `아이콘`으로 변경
- 키워드 placeholder 문구  `작품을 나타내는 키워드는?` 으로 변경

## 📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵
<img width="320" height="714" alt="Screenshot_20260601_184911" src="https://github.com/user-attachments/assets/4c7f7e91-3152-4e44-a604-693105997273" />


## 💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **UI 개선**
  * 작품 평가 화면의 매력 포인트 선택 UI를 칩 기반에서 아이콘+라벨 고정 뷰(6개) 구성으로 재설계했습니다.
  * 별점 영역 레이아웃(여백·높이·제약)을 정리하고 시각적 배치를 개선했습니다.
* **스타일**
  * 읽음 상태 버튼 아이콘이 상태에 따라 동적으로 색상이 변경되도록 아이콘 틴트를 적용했습니다.
* **문구**
  * 별점 제목과 키워드 버튼 문구를 사용자 친화적으로 갱신했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->