### PR TITLE
feat: 일반 탐색 최근 검색어 구현

### DIFF
--- a/app/src/main/java/com/into/websoso/data/mapper/NovelMapper.kt
+++ b/app/src/main/java/com/into/websoso/data/mapper/NovelMapper.kt
@@ -6,6 +6,7 @@ import com.into.websoso.data.model.NovelDetailEntity
 import com.into.websoso.data.model.NovelFeedsEntity
 import com.into.websoso.data.model.NovelInfoEntity
 import com.into.websoso.data.model.PopularNovelsEntity
+import com.into.websoso.data.model.RecentSearchesEntity
 import com.into.websoso.data.model.RecommendedNovelsByUserTasteEntity
 import com.into.websoso.data.model.SosoPickEntity
 import com.into.websoso.data.remote.response.ExploreResultResponseDto
@@ -13,6 +14,7 @@ import com.into.websoso.data.remote.response.NovelDetailResponseDto
 import com.into.websoso.data.remote.response.NovelFeedResponseDto
 import com.into.websoso.data.remote.response.NovelInfoResponseDto
 import com.into.websoso.data.remote.response.PopularNovelsResponseDto
+import com.into.websoso.data.remote.response.RecentSearchesResponseDto
 import com.into.websoso.data.remote.response.RecommendedNovelsByUserTasteResponseDto
 import com.into.websoso.data.remote.response.SosoPicksResponseDto
 
@@ -93,6 +95,16 @@ fun ExploreResultResponseDto.toData(): ExploreResultEntity =
                 interestedCount = novel.interestedCount,
                 rating = novel.novelRating,
                 ratingCount = novel.novelRatingCount,
+            )
+        },
+    )
+
+fun RecentSearchesResponseDto.toData(): RecentSearchesEntity =
+    RecentSearchesEntity(
+        recentSearches = recentSearches.map { recentSearch ->
+            RecentSearchesEntity.RecentSearchEntity(
+                id = recentSearch.id,
+                keyword = recentSearch.keyword,
             )
         },
     )

--- a/app/src/main/java/com/into/websoso/data/model/RecentSearchesEntity.kt
+++ b/app/src/main/java/com/into/websoso/data/model/RecentSearchesEntity.kt
@@ -1,0 +1,11 @@
+package com.into.websoso.data.model
+
+data class RecentSearchesEntity(
+    val recentSearches: List<RecentSearchEntity>,
+) {
+    data class RecentSearchEntity(
+        val id: Long,
+        val keyword: String,
+    )
+}
+

--- a/app/src/main/java/com/into/websoso/data/remote/api/NovelApi.kt
+++ b/app/src/main/java/com/into/websoso/data/remote/api/NovelApi.kt
@@ -5,6 +5,7 @@ import com.into.websoso.data.remote.response.NovelDetailResponseDto
 import com.into.websoso.data.remote.response.NovelFeedResponseDto
 import com.into.websoso.data.remote.response.NovelInfoResponseDto
 import com.into.websoso.data.remote.response.PopularNovelsResponseDto
+import com.into.websoso.data.remote.response.RecentSearchesResponseDto
 import com.into.websoso.data.remote.response.RecommendedNovelsByUserTasteResponseDto
 import com.into.websoso.data.remote.response.SosoPicksResponseDto
 import retrofit2.http.DELETE
@@ -43,6 +44,17 @@ interface NovelApi {
         @Query("page") page: Int,
         @Query("size") size: Int,
     ): ExploreResultResponseDto
+
+    @GET("novels/recent-searches")
+    suspend fun getRecentSearches(): RecentSearchesResponseDto
+
+    @DELETE("novels/recent-searches/{recentSearchId}")
+    suspend fun deleteRecentSearch(
+        @Path("recentSearchId") recentSearchId: Long,
+    )
+
+    @DELETE("novels/recent-searches")
+    suspend fun deleteAllRecentSearches()
 
     @GET("novels/popular")
     suspend fun getPopularNovels(): PopularNovelsResponseDto

--- a/app/src/main/java/com/into/websoso/data/remote/response/RecentSearchesResponseDto.kt
+++ b/app/src/main/java/com/into/websoso/data/remote/response/RecentSearchesResponseDto.kt
@@ -1,0 +1,19 @@
+package com.into.websoso.data.remote.response
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class RecentSearchesResponseDto(
+    @SerialName("recentSearches")
+    val recentSearches: List<RecentSearchResponseDto>,
+) {
+    @Serializable
+    data class RecentSearchResponseDto(
+        @SerialName("id")
+        val id: Long,
+        @SerialName("keyword")
+        val keyword: String,
+    )
+}
+

--- a/app/src/main/java/com/into/websoso/data/repository/NovelRepository.kt
+++ b/app/src/main/java/com/into/websoso/data/repository/NovelRepository.kt
@@ -7,6 +7,7 @@ import com.into.websoso.data.model.NovelDetailEntity
 import com.into.websoso.data.model.NovelFeedsEntity
 import com.into.websoso.data.model.NovelInfoEntity
 import com.into.websoso.data.model.PopularNovelsEntity
+import com.into.websoso.data.model.RecentSearchesEntity
 import com.into.websoso.data.model.RecommendedNovelsByUserTasteEntity
 import com.into.websoso.data.model.SosoPickEntity
 import com.into.websoso.data.remote.api.NovelApi
@@ -67,6 +68,16 @@ class NovelRepository
         fun clearCachedNormalExploreResult() {
             _cachedNormalExploreResult.clear()
             cachedNormalExploreIsLoadable = true
+        }
+
+        suspend fun fetchRecentSearches(): RecentSearchesEntity = novelApi.getRecentSearches().toData()
+
+        suspend fun deleteRecentSearch(recentSearchId: Long) {
+            novelApi.deleteRecentSearch(recentSearchId)
+        }
+
+        suspend fun deleteAllRecentSearches() {
+            novelApi.deleteAllRecentSearches()
         }
 
         suspend fun fetchPopularNovels(): PopularNovelsEntity = novelApi.getPopularNovels().toData()

--- a/app/src/main/java/com/into/websoso/ui/mapper/NovelMapper.kt
+++ b/app/src/main/java/com/into/websoso/ui/mapper/NovelMapper.kt
@@ -2,10 +2,12 @@ package com.into.websoso.ui.mapper
 
 import com.into.websoso.data.model.NovelDetailEntity
 import com.into.websoso.data.model.NovelInfoEntity
+import com.into.websoso.data.model.RecentSearchesEntity.RecentSearchEntity
 import com.into.websoso.domain.model.ExploreResult
 import com.into.websoso.domain.model.ExploreResult.Novel
 import com.into.websoso.ui.normalExplore.model.NormalExploreModel
 import com.into.websoso.ui.normalExplore.model.NormalExploreModel.NovelModel
+import com.into.websoso.ui.normalExplore.model.NormalExploreModel.RecentSearchModel
 import com.into.websoso.ui.novelDetail.model.NovelDetailModel
 import com.into.websoso.ui.novelInfo.model.KeywordModel
 import com.into.websoso.ui.novelInfo.model.NovelInfoUiModel
@@ -86,4 +88,10 @@ fun Novel.toUi(): NovelModel =
         interestedCount = interestedCount,
         rating = rating,
         ratingCount = ratingCount,
+    )
+
+fun RecentSearchEntity.toUi(): RecentSearchModel =
+    RecentSearchModel(
+        id = id,
+        keyword = keyword,
     )

--- a/app/src/main/java/com/into/websoso/ui/normalExplore/NormalExploreActivity.kt
+++ b/app/src/main/java/com/into/websoso/ui/normalExplore/NormalExploreActivity.kt
@@ -22,6 +22,7 @@ import com.into.websoso.ui.normalExplore.adapter.NormalExploreAdapter
 import com.into.websoso.ui.normalExplore.adapter.NormalExploreItemType.Header
 import com.into.websoso.ui.normalExplore.adapter.NormalExploreItemType.Loading
 import com.into.websoso.ui.normalExplore.adapter.NormalExploreItemType.Novels
+import com.into.websoso.ui.normalExplore.adapter.RecentSearchAdapter
 import com.into.websoso.ui.normalExplore.model.NormalExploreUiState
 import com.into.websoso.ui.novelDetail.NovelDetailActivity
 import dagger.hilt.android.AndroidEntryPoint
@@ -36,6 +37,12 @@ class NormalExploreActivity : BaseActivity<ActivityNormalExploreBinding>(activit
         NormalExploreAdapter(
             ::navigateToNovelDetail,
             ::navigateToInquire,
+        )
+    }
+    private val recentSearchAdapter: RecentSearchAdapter by lazy {
+        RecentSearchAdapter(
+            ::searchRecentSearch,
+            normalExploreViewModel::deleteRecentSearch,
         )
     }
     private val sosoPickAdapter: SosoPickAdapter by lazy { SosoPickAdapter(::navigateToNovelDetailFromSosoPick) }
@@ -70,6 +77,7 @@ class NormalExploreActivity : BaseActivity<ActivityNormalExploreBinding>(activit
                 )
             }
             rvNormalExploreSosoPick.adapter = sosoPickAdapter
+            rvNormalExploreRecentSearch.adapter = recentSearchAdapter
             onClick = onNormalExploreButtonClick()
         }
     }
@@ -78,14 +86,11 @@ class NormalExploreActivity : BaseActivity<ActivityNormalExploreBinding>(activit
         binding.apply {
             etNormalExploreSearchContent.setOnEditorActionListener { _, actionId, _ ->
                 if (actionId == IME_ACTION_SEARCH) {
-                    normalExploreViewModel?.updateSearchWord(
+                    searchKeyword(
                         binding.etNormalExploreSearchContent.text
                             ?.toString()
                             .orEmpty(),
                     )
-                    normalExploreViewModel?.updateSearchResult(isSearchButtonClick = true)
-                    binding.etNormalExploreSearchContent.clearFocus()
-                    hideKeyboard()
                     true
                 } else {
                     false
@@ -113,14 +118,11 @@ class NormalExploreActivity : BaseActivity<ActivityNormalExploreBinding>(activit
             override fun onSearchButtonClick() {
                 singleEventHandler.throttleFirst {
                     tracker.trackEvent("click_search_result")
-                    normalExploreViewModel.updateSearchWord(
+                    searchKeyword(
                         binding.etNormalExploreSearchContent.text
                             ?.toString()
                             .orEmpty(),
                     )
-                    normalExploreViewModel.updateSearchResult(isSearchButtonClick = true)
-                    binding.etNormalExploreSearchContent.clearFocus()
-                    hideKeyboard()
                 }
             }
 
@@ -138,6 +140,19 @@ class NormalExploreActivity : BaseActivity<ActivityNormalExploreBinding>(activit
                 startActivity(intent)
             }
         }
+
+    private fun searchRecentSearch(keyword: String) {
+        singleEventHandler.throttleFirst {
+            searchKeyword(keyword)
+        }
+    }
+
+    private fun searchKeyword(keyword: String) {
+        normalExploreViewModel.updateSearchWord(keyword)
+        normalExploreViewModel.updateSearchResult(isSearchButtonClick = true)
+        binding.etNormalExploreSearchContent.clearFocus()
+        hideKeyboard()
+    }
 
     private fun showKeyboard() {
         val inputMethodManager =
@@ -198,6 +213,10 @@ class NormalExploreActivity : BaseActivity<ActivityNormalExploreBinding>(activit
         normalExploreViewModel.sosoPicks.observe(this) { sosoPicks ->
             sosoPickAdapter.submitList(sosoPicks)
         }
+
+        normalExploreViewModel.recentSearches.observe(this) { recentSearches ->
+            recentSearchAdapter.submitList(recentSearches)
+        }
     }
 
     private fun updateView(uiState: NormalExploreUiState) {
@@ -209,6 +228,8 @@ class NormalExploreActivity : BaseActivity<ActivityNormalExploreBinding>(activit
                 true -> normalExploreAdapter.submitList(listOf(header) + novels + Loading)
                 false -> normalExploreAdapter.submitList(listOf(header) + novels)
             }
+        } else {
+            normalExploreAdapter.submitList(emptyList())
         }
     }
 

--- a/app/src/main/java/com/into/websoso/ui/normalExplore/NormalExploreViewModel.kt
+++ b/app/src/main/java/com/into/websoso/ui/normalExplore/NormalExploreViewModel.kt
@@ -40,13 +40,16 @@ class NormalExploreViewModel
         private val _isNovelResultEmptyBoxVisibility: MutableLiveData<Boolean> = MutableLiveData(false)
         val isNovelResultEmptyBoxVisibility: LiveData<Boolean> get() = _isNovelResultEmptyBoxVisibility
 
-        private val _sosoPicks: MutableLiveData<List<SosoPickEntity.NovelEntity>> = MutableLiveData(emptyList())
+        private val _sosoPicks: MutableLiveData<List<SosoPickEntity.NovelEntity>> =
+            MutableLiveData(emptyList())
         val sosoPicks: LiveData<List<SosoPickEntity.NovelEntity>> get() = _sosoPicks
 
-        private val _isSosoPickVisible: MutableLiveData<Boolean> = MutableLiveData(initialSearchWord.isBlank())
+        private val _isSosoPickVisible: MutableLiveData<Boolean> =
+            MutableLiveData(initialSearchWord.isBlank())
         val isSosoPickVisible: LiveData<Boolean> get() = _isSosoPickVisible
 
-        private val _recentSearches: MutableLiveData<List<RecentSearchModel>> = MutableLiveData(emptyList())
+        private val _recentSearches: MutableLiveData<List<RecentSearchModel>> =
+            MutableLiveData(emptyList())
         val recentSearches: LiveData<List<RecentSearchModel>> get() = _recentSearches
 
         private val _isRecentSearchesVisible: MutableLiveData<Boolean> = MutableLiveData(false)
@@ -153,7 +156,8 @@ class NormalExploreViewModel
                 runCatching {
                     novelRepository.deleteRecentSearch(recentSearchId)
                 }.onSuccess {
-                    _recentSearches.value = _recentSearches.value.orEmpty()
+                    _recentSearches.value = _recentSearches.value
+                        .orEmpty()
                         .filterNot { recentSearch -> recentSearch.id == recentSearchId }
                     updateRecentSearchesVisibility()
                 }

--- a/app/src/main/java/com/into/websoso/ui/normalExplore/NormalExploreViewModel.kt
+++ b/app/src/main/java/com/into/websoso/ui/normalExplore/NormalExploreViewModel.kt
@@ -10,6 +10,7 @@ import com.into.websoso.data.repository.NovelRepository
 import com.into.websoso.domain.usecase.GetNormalExploreResultUseCase
 import com.into.websoso.ui.mapper.toUi
 import com.into.websoso.ui.normalExplore.NormalExploreActivity.Companion.SEARCH_AUTHOR
+import com.into.websoso.ui.normalExplore.model.NormalExploreModel.RecentSearchModel
 import com.into.websoso.ui.normalExplore.model.NormalExploreUiState
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
@@ -45,8 +46,15 @@ class NormalExploreViewModel
         private val _isSosoPickVisible: MutableLiveData<Boolean> = MutableLiveData(initialSearchWord.isBlank())
         val isSosoPickVisible: LiveData<Boolean> get() = _isSosoPickVisible
 
+        private val _recentSearches: MutableLiveData<List<RecentSearchModel>> = MutableLiveData(emptyList())
+        val recentSearches: LiveData<List<RecentSearchModel>> get() = _recentSearches
+
+        private val _isRecentSearchesVisible: MutableLiveData<Boolean> = MutableLiveData(false)
+        val isRecentSearchesVisible: LiveData<Boolean> get() = _isRecentSearchesVisible
+
         init {
             fetchSosoPicks()
+            fetchRecentSearches()
             if (initialSearchWord.isNotBlank()) {
                 updateSearchResult(isSearchButtonClick = true)
             }
@@ -62,6 +70,23 @@ class NormalExploreViewModel
             }
         }
 
+        private fun fetchRecentSearches() {
+            viewModelScope.launch {
+                fetchRecentSearchesInternal()
+            }
+        }
+
+        private suspend fun fetchRecentSearchesInternal() {
+            runCatching {
+                novelRepository.fetchRecentSearches()
+            }.onSuccess { result ->
+                _recentSearches.value = result.recentSearches
+                    .map { it.toUi() }
+                    .take(MAX_RECENT_SEARCH_COUNT)
+                updateRecentSearchesVisibility()
+            }
+        }
+
         fun updateSearchWord(searchWord: String) {
             _searchWord.value = searchWord
             savedStateHandle[SEARCH_AUTHOR] = searchWord
@@ -73,6 +98,7 @@ class NormalExploreViewModel
             }
             if (isSearchButtonClick) {
                 _isSosoPickVisible.value = false
+                updateRecentSearchesVisibility()
             }
             viewModelScope.launch {
                 _uiState.value = _uiState.value?.copy(loading = isSearchButtonClick)
@@ -96,6 +122,9 @@ class NormalExploreViewModel
                         )
                         _isNovelResultEmptyBoxVisibility.value = true
                     }
+                    if (isSearchButtonClick && searchWord.value.isNullOrBlank().not()) {
+                        fetchRecentSearchesInternal()
+                    }
                 }.onFailure {
                     _uiState.value = _uiState.value?.copy(
                         loading = false,
@@ -113,6 +142,41 @@ class NormalExploreViewModel
         fun updateSearchWordEmpty() {
             _searchWord.value = ""
             savedStateHandle[SEARCH_AUTHOR] = ""
+            _uiState.value = NormalExploreUiState()
+            _isNovelResultEmptyBoxVisibility.value = false
             _isSosoPickVisible.value = true
+            updateRecentSearchesVisibility()
+        }
+
+        fun deleteRecentSearch(recentSearchId: Long) {
+            viewModelScope.launch {
+                runCatching {
+                    novelRepository.deleteRecentSearch(recentSearchId)
+                }.onSuccess {
+                    _recentSearches.value = _recentSearches.value.orEmpty()
+                        .filterNot { recentSearch -> recentSearch.id == recentSearchId }
+                    updateRecentSearchesVisibility()
+                }
+            }
+        }
+
+        fun deleteAllRecentSearches() {
+            viewModelScope.launch {
+                runCatching {
+                    novelRepository.deleteAllRecentSearches()
+                }.onSuccess {
+                    _recentSearches.value = emptyList()
+                    updateRecentSearchesVisibility()
+                }
+            }
+        }
+
+        private fun updateRecentSearchesVisibility() {
+            _isRecentSearchesVisible.value =
+                _isSosoPickVisible.value == true && _recentSearches.value.orEmpty().isNotEmpty()
+        }
+
+        companion object {
+            private const val MAX_RECENT_SEARCH_COUNT = 30
         }
     }

--- a/app/src/main/java/com/into/websoso/ui/normalExplore/adapter/RecentSearchAdapter.kt
+++ b/app/src/main/java/com/into/websoso/ui/normalExplore/adapter/RecentSearchAdapter.kt
@@ -1,0 +1,80 @@
+package com.into.websoso.ui.normalExplore.adapter
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
+import com.into.websoso.databinding.ItemNormalExploreRecentSearchBinding
+import com.into.websoso.ui.normalExplore.model.NormalExploreModel.RecentSearchModel
+
+class RecentSearchAdapter(
+    private val recentSearchClickListener: (keyword: String) -> Unit,
+    private val recentSearchDeleteClickListener: (recentSearchId: Long) -> Unit,
+) : ListAdapter<RecentSearchModel, RecentSearchAdapter.RecentSearchViewHolder>(diffCallBack) {
+    override fun onCreateViewHolder(
+        parent: ViewGroup,
+        viewType: Int,
+    ): RecentSearchViewHolder =
+        RecentSearchViewHolder.from(
+            parent = parent,
+            recentSearchClickListener = recentSearchClickListener,
+            recentSearchDeleteClickListener = recentSearchDeleteClickListener,
+        )
+
+    override fun onBindViewHolder(
+        holder: RecentSearchViewHolder,
+        position: Int,
+    ) {
+        holder.bind(getItem(position))
+    }
+
+    class RecentSearchViewHolder(
+        private val binding: ItemNormalExploreRecentSearchBinding,
+        private val recentSearchClickListener: (keyword: String) -> Unit,
+        private val recentSearchDeleteClickListener: (recentSearchId: Long) -> Unit,
+    ) : RecyclerView.ViewHolder(binding.root) {
+        fun bind(recentSearch: RecentSearchModel) {
+            binding.recentSearch = recentSearch
+            binding.root.setOnClickListener {
+                recentSearchClickListener(recentSearch.keyword)
+            }
+            binding.ivNormalExploreRecentSearchDelete.setOnClickListener {
+                recentSearchDeleteClickListener(recentSearch.id)
+            }
+            binding.executePendingBindings()
+        }
+
+        companion object {
+            fun from(
+                parent: ViewGroup,
+                recentSearchClickListener: (keyword: String) -> Unit,
+                recentSearchDeleteClickListener: (recentSearchId: Long) -> Unit,
+            ): RecentSearchViewHolder =
+                RecentSearchViewHolder(
+                    ItemNormalExploreRecentSearchBinding.inflate(
+                        LayoutInflater.from(parent.context),
+                        parent,
+                        false,
+                    ),
+                    recentSearchClickListener,
+                    recentSearchDeleteClickListener,
+                )
+        }
+    }
+
+    companion object {
+        private val diffCallBack = object : DiffUtil.ItemCallback<RecentSearchModel>() {
+            override fun areItemsTheSame(
+                oldItem: RecentSearchModel,
+                newItem: RecentSearchModel,
+            ): Boolean = oldItem.id == newItem.id
+
+            override fun areContentsTheSame(
+                oldItem: RecentSearchModel,
+                newItem: RecentSearchModel,
+            ): Boolean = oldItem == newItem
+        }
+    }
+}
+

--- a/app/src/main/java/com/into/websoso/ui/normalExplore/model/NormalExploreModel.kt
+++ b/app/src/main/java/com/into/websoso/ui/normalExplore/model/NormalExploreModel.kt
@@ -15,4 +15,9 @@ data class NormalExploreModel(
         val ratingCount: Long,
         val isSelected: Boolean = false,
     )
+
+    data class RecentSearchModel(
+        val id: Long,
+        val keyword: String,
+    )
 }

--- a/app/src/main/res/drawable/bg_normal_explore_recent_search_chip.xml
+++ b/app/src/main/res/drawable/bg_normal_explore_recent_search_chip.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="@color/white" />
+    <stroke
+        android:width="1dp"
+        android:color="@color/primary_100_6A5DFD" />
+    <corners android:radius="18dp" />
+</shape>
+

--- a/app/src/main/res/drawable/ic_normal_explore_recent_search_delete.xml
+++ b/app/src/main/res/drawable/ic_normal_explore_recent_search_delete.xml
@@ -1,0 +1,19 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="8dp"
+    android:height="8dp"
+    android:viewportWidth="8"
+    android:viewportHeight="8">
+    <path
+        android:fillColor="@color/transparent"
+        android:pathData="M1,1L7,7"
+        android:strokeWidth="1"
+        android:strokeColor="@color/primary_100_6A5DFD"
+        android:strokeLineCap="round" />
+    <path
+        android:fillColor="@color/transparent"
+        android:pathData="M7,1L1,7"
+        android:strokeWidth="1"
+        android:strokeColor="@color/primary_100_6A5DFD"
+        android:strokeLineCap="round" />
+</vector>
+

--- a/app/src/main/res/layout/activity_normal_explore.xml
+++ b/app/src/main/res/layout/activity_normal_explore.xml
@@ -126,6 +126,62 @@
         </androidx.coordinatorlayout.widget.CoordinatorLayout>
 
         <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/cl_normal_explore_recent_search_section"
+            isVisible="@{normalExploreViewModel.isRecentSearchesVisible}"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:visibility="gone"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/cdl_normal_explore"
+            tools:visibility="visible">
+
+            <TextView
+                android:id="@+id/tv_normal_explore_recent_search_title"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="16dp"
+                android:layout_marginTop="24dp"
+                android:text="@string/normal_explore_recent_search_title"
+                android:textAppearance="@style/title2"
+                android:textColor="@color/black"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <TextView
+                android:id="@+id/tv_normal_explore_recent_search_delete_all"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginEnd="16dp"
+                android:onClick="@{() -> normalExploreViewModel.deleteAllRecentSearches()}"
+                android:paddingVertical="4dp"
+                android:text="@string/normal_explore_recent_search_delete_all"
+                android:textAppearance="@style/body4"
+                android:textColor="@color/gray_200_949399"
+                app:layout_constraintBottom_toBottomOf="@id/tv_normal_explore_recent_search_title"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toTopOf="@id/tv_normal_explore_recent_search_title" />
+
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/rv_normal_explore_recent_search"
+                android:layout_width="0dp"
+                android:layout_height="35dp"
+                android:layout_marginTop="12dp"
+                android:clipToPadding="false"
+                android:orientation="horizontal"
+                android:overScrollMode="never"
+                android:paddingStart="16dp"
+                android:paddingEnd="16dp"
+                app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/tv_normal_explore_recent_search_title"
+                tools:itemCount="3"
+                tools:listitem="@layout/item_normal_explore_recent_search" />
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+        <androidx.constraintlayout.widget.ConstraintLayout
             android:id="@+id/cl_normal_explore_soso_pick_section"
             isVisible="@{normalExploreViewModel.isSosoPickVisible}"
             android:layout_width="0dp"
@@ -133,7 +189,7 @@
             android:visibility="gone"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/cdl_normal_explore">
+            app:layout_constraintTop_toBottomOf="@id/cl_normal_explore_recent_search_section">
 
             <TextView
                 android:id="@+id/tv_normal_explore_soso_title"

--- a/app/src/main/res/layout/item_normal_explore_recent_search.xml
+++ b/app/src/main/res/layout/item_normal_explore_recent_search.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <data>
+
+        <variable
+            name="recentSearch"
+            type="com.into.websoso.ui.normalExplore.model.NormalExploreModel.RecentSearchModel" />
+    </data>
+
+    <LinearLayout
+        android:id="@+id/ll_normal_explore_recent_search"
+        android:layout_width="wrap_content"
+        android:layout_height="35dp"
+        android:layout_marginEnd="3dp"
+        android:background="@drawable/bg_normal_explore_recent_search_chip"
+        android:gravity="center"
+        android:orientation="horizontal"
+        android:paddingStart="13dp"
+        android:paddingEnd="13dp">
+
+        <TextView
+            android:id="@+id/tv_normal_explore_recent_search_keyword"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:ellipsize="end"
+            android:maxLines="1"
+            android:text="@{recentSearch.keyword}"
+            android:textAppearance="@style/body3"
+            android:textColor="@color/primary_100_6A5DFD"
+            tools:text="당신의 이해를 돕기" />
+
+        <ImageView
+            android:id="@+id/iv_normal_explore_recent_search_delete"
+            android:layout_width="16dp"
+            android:layout_height="16dp"
+            android:layout_marginStart="6dp"
+            android:contentDescription="@null"
+            android:padding="4dp"
+            android:src="@drawable/ic_normal_explore_recent_search_delete" />
+    </LinearLayout>
+</layout>
+

--- a/core/resource/src/main/res/values/strings.xml
+++ b/core/resource/src/main/res/values/strings.xml
@@ -18,6 +18,8 @@
     <string name="normal_explore_not_exist_result">해당 검색어를 가진 작품은\n아직 등록되지 않았어요...</string>
     <string name="normal_explore_add_novel_inquire">작품 문의하러 가기</string>
     <string name="normal_explore_result_inquire">찾는 작품이 없다면?</string>
+    <string name="normal_explore_recent_search_title">최근 검색어</string>
+    <string name="normal_explore_recent_search_delete_all">전체삭제</string>
 
     <!-- 탐색 뷰 -->
     <string name="explore_normal_search_hint">작품 제목, 작가를 검색하세요</string>


### PR DESCRIPTION
## 📌𝘐𝘴𝘴𝘶𝘦𝘴
- closed #892

## 📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯
- 일반 탐색 화면에 최근 검색어 섹션 UI를 추가했습니다.
- 최근 검색어 조회/개별 삭제/전체 삭제 API 연동을 추가했습니다.
- 검색창 X 클릭 시 검색 결과 및 empty view 상태가 초기화되도록 수정했습니다.

## 📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵



https://github.com/user-attachments/assets/4ed3a214-99f2-46e6-88dd-e4d09cd72590




## 💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴
- 삭제/전체 삭제 API 문서의 endpoint가 비어 있어 `DELETE /novels/recent-searches/{recentSearchId}`, `DELETE /novels/recent-searches` 기준으로 구현했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능

* **New Features**
  * 최근 검색 목록을 조회하고 탐색 화면에 표시할 수 있습니다.
  * 최근 검색 항목을 개별적으로 또는 일괄로 삭제할 수 있습니다.
  * 검색창 아래에 최근 검색 섹션이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->