### PR TITLE
feat: 일반 탐색 키워드 검색 구현

### DIFF
--- a/app/src/main/java/com/into/websoso/data/mapper/KeywordMapper.kt
+++ b/app/src/main/java/com/into/websoso/data/mapper/KeywordMapper.kt
@@ -9,8 +9,7 @@ fun KeywordsResponseDto.toData(): CategoriesEntity =
         categories = categories.map { it.toData() },
     )
 
-fun PopularKeywordsResponseDto.toData(): List<CategoriesEntity.CategoryEntity.KeywordEntity> =
-    keywords.map { it.toData() }
+fun PopularKeywordsResponseDto.toData(): List<CategoriesEntity.CategoryEntity.KeywordEntity> = keywords.map { it.toData() }
 
 fun KeywordsResponseDto.CategoryResponseDto.toData(): CategoriesEntity.CategoryEntity =
     CategoriesEntity.CategoryEntity(

--- a/app/src/main/java/com/into/websoso/data/mapper/KeywordMapper.kt
+++ b/app/src/main/java/com/into/websoso/data/mapper/KeywordMapper.kt
@@ -2,11 +2,15 @@ package com.into.websoso.data.mapper
 
 import com.into.websoso.data.model.CategoriesEntity
 import com.into.websoso.data.remote.response.KeywordsResponseDto
+import com.into.websoso.data.remote.response.PopularKeywordsResponseDto
 
 fun KeywordsResponseDto.toData(): CategoriesEntity =
     CategoriesEntity(
         categories = categories.map { it.toData() },
     )
+
+fun PopularKeywordsResponseDto.toData(): List<CategoriesEntity.CategoryEntity.KeywordEntity> =
+    keywords.map { it.toData() }
 
 fun KeywordsResponseDto.CategoryResponseDto.toData(): CategoriesEntity.CategoryEntity =
     CategoriesEntity.CategoryEntity(
@@ -16,6 +20,12 @@ fun KeywordsResponseDto.CategoryResponseDto.toData(): CategoriesEntity.CategoryE
     )
 
 fun KeywordsResponseDto.CategoryResponseDto.KeywordResponseDto.toData(): CategoriesEntity.CategoryEntity.KeywordEntity =
+    CategoriesEntity.CategoryEntity.KeywordEntity(
+        keywordId = keywordId,
+        keywordName = keywordName,
+    )
+
+fun PopularKeywordsResponseDto.KeywordResponseDto.toData(): CategoriesEntity.CategoryEntity.KeywordEntity =
     CategoriesEntity.CategoryEntity.KeywordEntity(
         keywordId = keywordId,
         keywordName = keywordName,

--- a/app/src/main/java/com/into/websoso/data/remote/api/KeywordApi.kt
+++ b/app/src/main/java/com/into/websoso/data/remote/api/KeywordApi.kt
@@ -1,6 +1,7 @@
 package com.into.websoso.data.remote.api
 
 import com.into.websoso.data.remote.response.KeywordsResponseDto
+import com.into.websoso.data.remote.response.PopularKeywordsResponseDto
 import retrofit2.http.GET
 import retrofit2.http.Query
 
@@ -9,4 +10,7 @@ interface KeywordApi {
     suspend fun getKeywords(
         @Query("query") keyword: String?,
     ): KeywordsResponseDto
+
+    @GET("keywords/popular")
+    suspend fun getPopularKeywords(): PopularKeywordsResponseDto
 }

--- a/app/src/main/java/com/into/websoso/data/remote/response/PopularKeywordsResponseDto.kt
+++ b/app/src/main/java/com/into/websoso/data/remote/response/PopularKeywordsResponseDto.kt
@@ -1,0 +1,18 @@
+package com.into.websoso.data.remote.response
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class PopularKeywordsResponseDto(
+    @SerialName("keywords")
+    val keywords: List<KeywordResponseDto>,
+) {
+    @Serializable
+    data class KeywordResponseDto(
+        @SerialName("keywordId")
+        val keywordId: Int,
+        @SerialName("keywordName")
+        val keywordName: String,
+    )
+}

--- a/app/src/main/java/com/into/websoso/data/repository/KeywordRepository.kt
+++ b/app/src/main/java/com/into/websoso/data/repository/KeywordRepository.kt
@@ -12,6 +12,5 @@ class KeywordRepository
     ) {
         suspend fun fetchKeywords(keyword: String?): CategoriesEntity = keywordApi.getKeywords(keyword).toData()
 
-        suspend fun fetchPopularKeywords(): List<CategoriesEntity.CategoryEntity.KeywordEntity> =
-            keywordApi.getPopularKeywords().toData()
+        suspend fun fetchPopularKeywords(): List<CategoriesEntity.CategoryEntity.KeywordEntity> = keywordApi.getPopularKeywords().toData()
     }

--- a/app/src/main/java/com/into/websoso/data/repository/KeywordRepository.kt
+++ b/app/src/main/java/com/into/websoso/data/repository/KeywordRepository.kt
@@ -11,4 +11,7 @@ class KeywordRepository
         private val keywordApi: KeywordApi,
     ) {
         suspend fun fetchKeywords(keyword: String?): CategoriesEntity = keywordApi.getKeywords(keyword).toData()
+
+        suspend fun fetchPopularKeywords(): List<CategoriesEntity.CategoryEntity.KeywordEntity> =
+            keywordApi.getPopularKeywords().toData()
     }

--- a/app/src/main/java/com/into/websoso/ui/normalExplore/NormalExploreActivity.kt
+++ b/app/src/main/java/com/into/websoso/ui/normalExplore/NormalExploreActivity.kt
@@ -5,16 +5,18 @@ import android.content.Intent
 import android.content.Intent.ACTION_VIEW
 import android.net.Uri
 import android.os.Bundle
+import android.view.Gravity
+import android.view.ViewGroup
 import android.view.inputmethod.EditorInfo.IME_ACTION_SEARCH
 import android.view.inputmethod.InputMethodManager
+import android.widget.TextView
 import androidx.activity.addCallback
 import androidx.activity.viewModels
 import com.into.websoso.R.color.gray_300_52515F
-import com.into.websoso.R.color.gray_50_F4F5F8
+import com.into.websoso.R.drawable.bg_normal_explore_keyword_search_chip
 import com.into.websoso.R.layout.activity_normal_explore
 import com.into.websoso.R.style.body3
 import com.into.websoso.core.common.ui.base.BaseActivity
-import com.into.websoso.core.common.ui.custom.WebsosoChip
 import com.into.websoso.core.common.ui.model.CategoriesModel.CategoryModel.KeywordModel
 import com.into.websoso.core.common.ui.model.ResultFrom.NormalExploreBack
 import com.into.websoso.core.common.util.InfiniteScrollListener
@@ -38,6 +40,7 @@ import com.into.websoso.ui.normalExplore.model.NormalExploreUiState
 import com.into.websoso.ui.novelDetail.NovelDetailActivity
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
+import kotlin.math.roundToInt
 
 @AndroidEntryPoint
 class NormalExploreActivity : BaseActivity<ActivityNormalExploreBinding>(activity_normal_explore) {
@@ -267,17 +270,26 @@ class NormalExploreActivity : BaseActivity<ActivityNormalExploreBinding>(activit
         val keywordChipGroup = binding.wcgNormalExploreKeywordSearch
         keywordChipGroup.removeAllViews()
         keywordSearches.forEach { keyword ->
-            WebsosoChip(this@NormalExploreActivity)
+            TextView(this@NormalExploreActivity)
                 .apply {
-                    setWebsosoChipText(keyword.keywordName)
-                    setWebsosoChipTextAppearance(body3)
-                    setWebsosoChipTextColor(gray_300_52515F)
-                    setWebsosoChipBackgroundColor(gray_50_F4F5F8)
-                    setWebsosoChipPaddingVertical(KEYWORD_CHIP_VERTICAL_PADDING.toFloatPxFromDp())
-                    setWebsosoChipPaddingHorizontal(KEYWORD_CHIP_HORIZONTAL_PADDING.toFloatPxFromDp())
-                    setWebsosoChipRadius(KEYWORD_CHIP_RADIUS.toFloatPxFromDp())
-                    setOnWebsosoChipClick { navigateToDetailExploreResult(keyword) }
-                }.also { websosoChip -> keywordChipGroup.addChip(websosoChip) }
+                    layoutParams = ViewGroup.LayoutParams(
+                        ViewGroup.LayoutParams.WRAP_CONTENT,
+                        KEYWORD_CHIP_HEIGHT.toFloatPxFromDp().roundToInt(),
+                    )
+                    text = keyword.keywordName
+                    gravity = Gravity.CENTER
+                    includeFontPadding = false
+                    setTextAppearance(body3)
+                    setTextColor(getColor(gray_300_52515F))
+                    setBackgroundResource(bg_normal_explore_keyword_search_chip)
+                    setPadding(
+                        KEYWORD_CHIP_HORIZONTAL_PADDING.toFloatPxFromDp().roundToInt(),
+                        0,
+                        KEYWORD_CHIP_HORIZONTAL_PADDING.toFloatPxFromDp().roundToInt(),
+                        0,
+                    )
+                    setOnClickListener { navigateToDetailExploreResult(keyword) }
+                }.also { keywordChip -> keywordChipGroup.addView(keywordChip) }
         }
     }
 
@@ -304,8 +316,7 @@ class NormalExploreActivity : BaseActivity<ActivityNormalExploreBinding>(activit
 
     companion object {
         const val SEARCH_AUTHOR = "SEARCH_AUTHOR"
-        private const val KEYWORD_CHIP_RADIUS = 20f
-        private const val KEYWORD_CHIP_VERTICAL_PADDING = 7f
+        private const val KEYWORD_CHIP_HEIGHT = 35f
         private const val KEYWORD_CHIP_HORIZONTAL_PADDING = 13f
 
         fun getIntent(

--- a/app/src/main/java/com/into/websoso/ui/normalExplore/NormalExploreActivity.kt
+++ b/app/src/main/java/com/into/websoso/ui/normalExplore/NormalExploreActivity.kt
@@ -9,11 +9,17 @@ import android.view.inputmethod.EditorInfo.IME_ACTION_SEARCH
 import android.view.inputmethod.InputMethodManager
 import androidx.activity.addCallback
 import androidx.activity.viewModels
+import com.into.websoso.R.color.gray_300_52515F
+import com.into.websoso.R.color.gray_50_F4F5F8
 import com.into.websoso.R.layout.activity_normal_explore
+import com.into.websoso.R.style.body3
 import com.into.websoso.core.common.ui.base.BaseActivity
+import com.into.websoso.core.common.ui.custom.WebsosoChip
+import com.into.websoso.core.common.ui.model.CategoriesModel.CategoryModel.KeywordModel
 import com.into.websoso.core.common.ui.model.ResultFrom.NormalExploreBack
 import com.into.websoso.core.common.util.InfiniteScrollListener
 import com.into.websoso.core.common.util.SingleEventHandler
+import com.into.websoso.core.common.util.toFloatPxFromDp
 import com.into.websoso.core.common.util.tracker.Tracker
 import com.into.websoso.core.resource.R.string.novel_inquire_link
 import com.into.websoso.databinding.ActivityNormalExploreBinding
@@ -186,6 +192,18 @@ class NormalExploreActivity : BaseActivity<ActivityNormalExploreBinding>(activit
         }
     }
 
+    private fun navigateToDetailExploreResult(keyword: KeywordModel) {
+        singleEventHandler.throttleFirst {
+            val intent = DetailExploreResultActivity.getIntent(
+                context = this,
+                detailExploreFilteredModel = DetailExploreFilteredModel(
+                    keywordIds = listOf(keyword.keywordId),
+                ),
+            )
+            startActivity(intent)
+        }
+    }
+
     private fun navigateToNovelDetail(novelId: Long) {
         singleEventHandler.throttleFirst {
             val intent = NovelDetailActivity.getIntent(this, novelId)
@@ -239,6 +257,28 @@ class NormalExploreActivity : BaseActivity<ActivityNormalExploreBinding>(activit
         normalExploreViewModel.recentSearches.observe(this) { recentSearches ->
             recentSearchAdapter.submitList(recentSearches)
         }
+
+        normalExploreViewModel.keywordSearches.observe(this) { keywordSearches ->
+            updateKeywordSearchChips(keywordSearches)
+        }
+    }
+
+    private fun updateKeywordSearchChips(keywordSearches: List<KeywordModel>) {
+        val keywordChipGroup = binding.wcgNormalExploreKeywordSearch
+        keywordChipGroup.removeAllViews()
+        keywordSearches.forEach { keyword ->
+            WebsosoChip(this@NormalExploreActivity)
+                .apply {
+                    setWebsosoChipText(keyword.keywordName)
+                    setWebsosoChipTextAppearance(body3)
+                    setWebsosoChipTextColor(gray_300_52515F)
+                    setWebsosoChipBackgroundColor(gray_50_F4F5F8)
+                    setWebsosoChipPaddingVertical(KEYWORD_CHIP_VERTICAL_PADDING.toFloatPxFromDp())
+                    setWebsosoChipPaddingHorizontal(KEYWORD_CHIP_HORIZONTAL_PADDING.toFloatPxFromDp())
+                    setWebsosoChipRadius(KEYWORD_CHIP_RADIUS.toFloatPxFromDp())
+                    setOnWebsosoChipClick { navigateToDetailExploreResult(keyword) }
+                }.also { websosoChip -> keywordChipGroup.addChip(websosoChip) }
+        }
     }
 
     private fun updateView(uiState: NormalExploreUiState) {
@@ -264,6 +304,9 @@ class NormalExploreActivity : BaseActivity<ActivityNormalExploreBinding>(activit
 
     companion object {
         const val SEARCH_AUTHOR = "SEARCH_AUTHOR"
+        private const val KEYWORD_CHIP_RADIUS = 20f
+        private const val KEYWORD_CHIP_VERTICAL_PADDING = 7f
+        private const val KEYWORD_CHIP_HORIZONTAL_PADDING = 13f
 
         fun getIntent(
             context: Context,

--- a/app/src/main/java/com/into/websoso/ui/normalExplore/NormalExploreViewModel.kt
+++ b/app/src/main/java/com/into/websoso/ui/normalExplore/NormalExploreViewModel.kt
@@ -5,7 +5,9 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.into.websoso.core.common.ui.model.CategoriesModel.CategoryModel.KeywordModel
 import com.into.websoso.data.model.SosoPickEntity
+import com.into.websoso.data.repository.KeywordRepository
 import com.into.websoso.data.repository.NovelRepository
 import com.into.websoso.domain.usecase.GetNormalExploreResultUseCase
 import com.into.websoso.ui.mapper.toUi
@@ -22,6 +24,7 @@ class NormalExploreViewModel
     constructor(
         private val getNormalExploreResultUseCase: GetNormalExploreResultUseCase,
         private val novelRepository: NovelRepository,
+        private val keywordRepository: KeywordRepository,
         private val savedStateHandle: SavedStateHandle,
     ) : ViewModel() {
         private val _uiState: MutableLiveData<NormalExploreUiState> =
@@ -55,9 +58,17 @@ class NormalExploreViewModel
         private val _isRecentSearchesVisible: MutableLiveData<Boolean> = MutableLiveData(false)
         val isRecentSearchesVisible: LiveData<Boolean> get() = _isRecentSearchesVisible
 
+        private val _keywordSearches: MutableLiveData<List<KeywordModel>> =
+            MutableLiveData(emptyList())
+        val keywordSearches: LiveData<List<KeywordModel>> get() = _keywordSearches
+
+        private val _isKeywordSearchesVisible: MutableLiveData<Boolean> = MutableLiveData(false)
+        val isKeywordSearchesVisible: LiveData<Boolean> get() = _isKeywordSearchesVisible
+
         init {
             fetchSosoPicks()
             fetchRecentSearches()
+            fetchKeywordSearches()
             if (initialSearchWord.isNotBlank()) {
                 updateSearchResult(isSearchButtonClick = true)
             }
@@ -90,6 +101,19 @@ class NormalExploreViewModel
             }
         }
 
+        private fun fetchKeywordSearches() {
+            viewModelScope.launch {
+                runCatching {
+                    keywordRepository.fetchPopularKeywords()
+                }.onSuccess { result ->
+                    _keywordSearches.value = result
+                        .map { keyword -> keyword.toUi() }
+                        .take(MAX_KEYWORD_SEARCH_COUNT)
+                    updateKeywordSearchesVisibility()
+                }
+            }
+        }
+
         fun updateSearchWord(searchWord: String) {
             _searchWord.value = searchWord
             savedStateHandle[SEARCH_AUTHOR] = searchWord
@@ -102,6 +126,7 @@ class NormalExploreViewModel
             if (isSearchButtonClick) {
                 _isSosoPickVisible.value = false
                 updateRecentSearchesVisibility()
+                updateKeywordSearchesVisibility()
             }
             viewModelScope.launch {
                 _uiState.value = _uiState.value?.copy(loading = isSearchButtonClick)
@@ -149,6 +174,7 @@ class NormalExploreViewModel
             _isNovelResultEmptyBoxVisibility.value = false
             _isSosoPickVisible.value = true
             updateRecentSearchesVisibility()
+            updateKeywordSearchesVisibility()
         }
 
         fun deleteRecentSearch(recentSearchId: Long) {
@@ -180,7 +206,13 @@ class NormalExploreViewModel
                 _isSosoPickVisible.value == true && _recentSearches.value.orEmpty().isNotEmpty()
         }
 
+        private fun updateKeywordSearchesVisibility() {
+            _isKeywordSearchesVisible.value =
+                _isSosoPickVisible.value == true && _keywordSearches.value.orEmpty().isNotEmpty()
+        }
+
         companion object {
             private const val MAX_RECENT_SEARCH_COUNT = 30
+            private const val MAX_KEYWORD_SEARCH_COUNT = 7
         }
     }

--- a/app/src/main/res/drawable/bg_normal_explore_keyword_search_chip.xml
+++ b/app/src/main/res/drawable/bg_normal_explore_keyword_search_chip.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="@color/gray_50_F4F5F8" />
+    <corners android:radius="20dp" />
+</shape>

--- a/app/src/main/res/layout/activity_normal_explore.xml
+++ b/app/src/main/res/layout/activity_normal_explore.xml
@@ -234,6 +234,56 @@
         </androidx.constraintlayout.widget.ConstraintLayout>
 
         <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/cl_normal_explore_keyword_search_section"
+            isVisible="@{normalExploreViewModel.isKeywordSearchesVisible}"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:visibility="gone"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/cl_normal_explore_genre_search_section"
+            tools:visibility="visible">
+
+            <TextView
+                android:id="@+id/tv_normal_explore_keyword_search_title"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="16dp"
+                android:layout_marginTop="32dp"
+                android:text="@string/normal_explore_keyword_search_title"
+                android:textAppearance="@style/title2"
+                android:textColor="@color/black"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <ImageView
+                android:id="@+id/iv_normal_explore_keyword_search_navigate"
+                android:layout_width="16dp"
+                android:layout_height="16dp"
+                android:layout_marginStart="3dp"
+                android:contentDescription="@null"
+                android:src="@drawable/ic_navigate_right"
+                app:layout_constraintBottom_toBottomOf="@id/tv_normal_explore_keyword_search_title"
+                app:layout_constraintStart_toEndOf="@id/tv_normal_explore_keyword_search_title"
+                app:layout_constraintTop_toTopOf="@id/tv_normal_explore_keyword_search_title"
+                app:tint="@color/black" />
+
+            <com.into.websoso.core.common.ui.custom.WebsosoChipGroup
+                android:id="@+id/wcg_normal_explore_keyword_search"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="16dp"
+                android:layout_marginTop="12dp"
+                android:layout_marginEnd="16dp"
+                app:chipSpacingHorizontal="6dp"
+                app:chipSpacingVertical="8dp"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/tv_normal_explore_keyword_search_title" />
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+        <androidx.constraintlayout.widget.ConstraintLayout
             android:id="@+id/cl_normal_explore_soso_pick_section"
             isVisible="@{normalExploreViewModel.isSosoPickVisible}"
             android:layout_width="0dp"
@@ -241,7 +291,7 @@
             android:visibility="gone"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/cl_normal_explore_genre_search_section">
+            app:layout_constraintTop_toBottomOf="@id/cl_normal_explore_keyword_search_section">
 
             <TextView
                 android:id="@+id/tv_normal_explore_soso_title"

--- a/core/resource/src/main/res/values/strings.xml
+++ b/core/resource/src/main/res/values/strings.xml
@@ -21,6 +21,7 @@
     <string name="normal_explore_recent_search_title">최근 검색어</string>
     <string name="normal_explore_recent_search_delete_all">전체삭제</string>
     <string name="normal_explore_genre_search_title">장르별 검색</string>
+    <string name="normal_explore_keyword_search_title">키워드 검색</string>
 
     <!-- 탐색 뷰 -->
     <string name="explore_normal_search_hint">작품 제목, 작가를 검색하세요</string>


### PR DESCRIPTION
## 📌𝘐𝘴𝘴𝘶𝘦𝘴
- closed #896

## 📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯
- 일반 탐색 화면에 인기 키워드 검색 섹션을 추가했습니다.
- `/keywords/popular` API를 연결하고, 키워드 칩 클릭 시 선택한 키워드 ID로 상세 탐색 결과 화면에 진입하도록 구현했습니다.
- 검색 상태에서는 키워드 섹션을 숨기고, 검색창 X 버튼으로 초기 상태 복귀 시 다시 노출되도록 처리했습니다.

## 📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵

https://github.com/user-attachments/assets/b17e1e1f-f572-4bbf-87e7-312fe52365ad



## 💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴
- `git diff --check`, `./gradlew ktlintCheck`, `./gradlew :app:compileDebugKotlin` 확인했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 최근 검색어 목록 조회 및 개별/전체 삭제 기능 추가
  * 인기 키워드 표시 기능 추가
  * 장르별 검색 바로가기 추가
  * 키워드 검색 결과를 칩(Chip) 형태로 표시

<!-- end of auto-generated comment: release notes by coderabbit.ai -->