### PR TITLE
fix: 플랫폼 필터 1차 QA

### DIFF
--- a/app/src/main/java/com/into/websoso/ui/detailExplore/DetailExploreScreen.kt
+++ b/app/src/main/java/com/into/websoso/ui/detailExplore/DetailExploreScreen.kt
@@ -59,7 +59,6 @@ fun DetailExploreScreen(
                 isKeywordChipActive = isKeywordChipSelected,
                 onTabSelected = { selectedTab = it },
                 onBackClick = onBackClick,
-                onResetClick = onResetClick,
             )
             Box(modifier = Modifier.weight(1f)) {
                 when (selectedTab) {

--- a/app/src/main/java/com/into/websoso/ui/detailExplore/component/DetailExploreAppBar.kt
+++ b/app/src/main/java/com/into/websoso/ui/detailExplore/component/DetailExploreAppBar.kt
@@ -2,7 +2,6 @@ package com.into.websoso.ui.detailExplore.component
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.IntrinsicSize
@@ -10,7 +9,6 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
@@ -25,15 +23,12 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.into.websoso.core.common.util.clickableWithoutRipple
 import com.into.websoso.core.designsystem.theme.Gray200
-import com.into.websoso.core.designsystem.theme.Gray300
 import com.into.websoso.core.designsystem.theme.Primary100
 import com.into.websoso.core.designsystem.theme.WebsosoTheme
 import com.into.websoso.core.designsystem.theme.White
-import com.into.websoso.core.resource.R.drawable.ic_detail_explore_reset
 import com.into.websoso.core.resource.R.drawable.ic_navigate_left
 import com.into.websoso.core.resource.R.string.detail_explore_info
 import com.into.websoso.core.resource.R.string.detail_explore_keyword
-import com.into.websoso.core.resource.R.string.detail_explore_reset
 import com.into.websoso.ui.detailExplore.model.SelectedFragmentTitle
 import com.into.websoso.ui.detailExplore.model.SelectedFragmentTitle.INFO
 import com.into.websoso.ui.detailExplore.model.SelectedFragmentTitle.KEYWORD
@@ -45,7 +40,6 @@ fun DetailExploreAppBar(
     isKeywordChipActive: Boolean,
     onTabSelected: (SelectedFragmentTitle) -> Unit,
     onBackClick: () -> Unit,
-    onResetClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Row(
@@ -82,25 +76,6 @@ fun DetailExploreAppBar(
             slotWidth = 69.dp,
             onClick = { onTabSelected(KEYWORD) },
         )
-        Spacer(modifier = Modifier.weight(1f))
-        Row(
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(4.dp),
-            modifier = Modifier
-                .padding(horizontal = 16.dp)
-                .clickableWithoutRipple(onClick = onResetClick),
-        ) {
-            Image(
-                painter = painterResource(id = ic_detail_explore_reset),
-                contentDescription = null,
-                modifier = Modifier.size(14.dp),
-            )
-            Text(
-                text = stringResource(detail_explore_reset),
-                style = WebsosoTheme.typography.title2,
-                color = Gray300,
-            )
-        }
     }
 }
 

--- a/app/src/main/java/com/into/websoso/ui/detailExplore/component/DetailExploreCtaButton.kt
+++ b/app/src/main/java/com/into/websoso/ui/detailExplore/component/DetailExploreCtaButton.kt
@@ -106,7 +106,7 @@ private fun SearchButton(
     ) {
         Text(
             text = stringResource(detail_explore_search_novel),
-            style = WebsosoTheme.typography.title1,
+            style = WebsosoTheme.typography.title2,
             color = White,
         )
     }


### PR DESCRIPTION
## 📌𝘐𝘴𝘴𝘶𝘦𝘴
- closed #916 

## 📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯
- 작품 찾기 찾기 글꼴을 초기화 버튼 글꼴과 통일
- 앱 상단의 액션바에 위치한 기존의 초기화 버튼 제거

## 📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵
<img width="320" height="714" alt="Screenshot_20260703_125818" src="https://github.com/user-attachments/assets/28b24302-0d60-4942-9cf4-7625ece4261e" />


## 💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 상세 탐색 화면 상단의 불필요한 초기화 UI(리셋 아이콘/문자열)가 제거되어 헤더 구성이 간결해졌습니다.
  * 초기화 동작은 기존과 동일하게 하단 CTA 버튼에서만 수행됩니다.
* **Style**
  * 상세 탐색의 검색 버튼 텍스트 타이포그래피가 변경되어 시각적 일관성이 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->