### PR TITLE
fix: 1.9.0 QA

### DIFF
--- a/core/network/src/main/java/com/into/websoso/core/network/datasource/library/LibraryApi.kt
+++ b/core/network/src/main/java/com/into/websoso/core/network/datasource/library/LibraryApi.kt
@@ -22,7 +22,7 @@ internal interface LibraryApi {
         @Query("isInterest") isInterest: Boolean?,
         @Query("readStatuses") readStatuses: List<String>?,
         @Query("genres") genres: List<String>?,
-        @Query("isComplete") isComplete: Boolean?,
+        @Query("isCompleted") isComplete: Boolean?,
         @Query("ratingMin") ratingMin: Float?,
         @Query("ratingMax") ratingMax: Float?,
         @Query("unratedOnly") unratedOnly: Boolean?,

--- a/data/account/src/main/java/com/into/websoso/data/account/AccountRepository.kt
+++ b/data/account/src/main/java/com/into/websoso/data/account/AccountRepository.kt
@@ -4,6 +4,9 @@ import com.into.websoso.core.auth.AuthPlatform
 import com.into.websoso.core.auth.AuthToken
 import com.into.websoso.data.account.datasource.AccountLocalDataSource
 import com.into.websoso.data.account.datasource.AccountRemoteDataSource
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -18,11 +21,15 @@ class AccountRepository
         var isRegisterUser: Boolean = false
             private set
 
-        var userId: Long = 0L
-            private set
+        private val _userId = MutableStateFlow(0L)
+
+        val userIdFlow: StateFlow<Long> = _userId.asStateFlow()
+
+        val userId: Long
+            get() = _userId.value
 
         fun updateUserId(userId: Long) {
-            this.userId = userId
+            _userId.value = userId
         }
 
         suspend fun accessToken(): String = accountLocalDataSource.selectAccessToken()

--- a/data/library/src/main/java/com/into/websoso/data/library/repository/MyLibraryRepository.kt
+++ b/data/library/src/main/java/com/into/websoso/data/library/repository/MyLibraryRepository.kt
@@ -11,12 +11,14 @@ import com.into.websoso.data.filter.model.LibraryFilter
 import com.into.websoso.data.library.LibraryRepository
 import com.into.websoso.data.library.LibraryRepository.Companion.PAGE_SIZE
 import com.into.websoso.data.library.datasource.LibraryRemoteDataSource
+import com.into.websoso.data.library.model.LibraryKeywordEntity
 import com.into.websoso.data.library.model.NovelEntity
 import com.into.websoso.data.library.paging.LibraryPagingSource
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.update
 import javax.inject.Inject
@@ -57,7 +59,10 @@ class MyLibraryRepository
                     ).flow
                 }
 
-        override suspend fun getRegisteredKeywords() = libraryRemoteDataSource.getUserNovelKeywords(userId = accountRepository.userId)
+        override suspend fun getRegisteredKeywords(): List<LibraryKeywordEntity> {
+            val userId = accountRepository.userIdFlow.first { it != 0L }
+            return libraryRemoteDataSource.getUserNovelKeywords(userId = userId)
+        }
 
         private suspend fun getUserNovels(
             cursor: String?,

--- a/feature/library/src/main/java/com/into/websoso/feature/library/LibraryViewModel.kt
+++ b/feature/library/src/main/java/com/into/websoso/feature/library/LibraryViewModel.kt
@@ -1,5 +1,6 @@
 package com.into.websoso.feature.library
 
+import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.paging.PagingData
@@ -83,6 +84,7 @@ class LibraryViewModel
                             temp.copy(keywords = temp.keywords.copy(registered = registered))
                         }
                     }
+                    .onFailure { Log.e("LibraryViewModel", "등록 키워드 로드 실패", it) }
             }
         }
 

--- a/feature/library/src/main/java/com/into/websoso/feature/library/LibraryViewModel.kt
+++ b/feature/library/src/main/java/com/into/websoso/feature/library/LibraryViewModel.kt
@@ -175,6 +175,7 @@ class LibraryViewModel
             _tempFilterUiState.update {
                 uiState.value.libraryFilterUiModel
             }
+            loadRegisteredKeywords()
         }
 
         fun updateReadStatus(readStatus: ReadStatus) {

--- a/feature/library/src/main/java/com/into/websoso/feature/library/LibraryViewModel.kt
+++ b/feature/library/src/main/java/com/into/websoso/feature/library/LibraryViewModel.kt
@@ -40,226 +40,227 @@ import javax.inject.Inject
 
 @HiltViewModel
 class LibraryViewModel
-    @Inject
-    constructor(
-        private val libraryRepository: LibraryRepository,
-        private val filterRepository: FilterRepository,
-    ) : ViewModel() {
-        private var pagingJob: Job? = null
+@Inject
+constructor(
+    private val libraryRepository: LibraryRepository,
+    private val filterRepository: FilterRepository,
+) : ViewModel() {
+    private var pagingJob: Job? = null
 
-        private val _uiState = MutableStateFlow(LibraryUiState())
-        val uiState: StateFlow<LibraryUiState> = _uiState.asStateFlow()
+    private val _uiState = MutableStateFlow(LibraryUiState())
+    val uiState: StateFlow<LibraryUiState> = _uiState.asStateFlow()
 
-        private val _tempFilterUiState = MutableStateFlow(uiState.value.libraryFilterUiModel)
-        val tempFilterUiState = _tempFilterUiState.asStateFlow()
+    private val _tempFilterUiState = MutableStateFlow(uiState.value.libraryFilterUiModel)
+    val tempFilterUiState = _tempFilterUiState.asStateFlow()
 
-        private val _scrollToTopEvent = Channel<Unit>(Channel.BUFFERED)
-        val scrollToTopEvent: Flow<Unit> = _scrollToTopEvent.receiveAsFlow()
+    private val _scrollToTopEvent = Channel<Unit>(Channel.BUFFERED)
+    val scrollToTopEvent: Flow<Unit> = _scrollToTopEvent.receiveAsFlow()
 
-        private val _keywordLimitEvent = Channel<Unit>(Channel.BUFFERED)
-        val keywordLimitEvent: Flow<Unit> = _keywordLimitEvent.receiveAsFlow()
+    private val _keywordLimitEvent = Channel<Unit>(Channel.BUFFERED)
+    val keywordLimitEvent: Flow<Unit> = _keywordLimitEvent.receiveAsFlow()
 
-        val novels: MutableStateFlow<PagingData<NovelUiModel>> = MutableStateFlow(PagingData.empty())
+    val novels: MutableStateFlow<PagingData<NovelUiModel>> = MutableStateFlow(PagingData.empty())
 
-        init {
-            loadLibrary()
-            loadNovelsCount()
-            updateLibraryFilter()
-            loadRegisteredKeywords()
-        }
+    init {
+        loadLibrary()
+        loadNovelsCount()
+        updateLibraryFilter()
+        loadRegisteredKeywords()
+    }
 
-        private fun loadRegisteredKeywords() {
-            viewModelScope.launch {
-                runCatching { libraryRepository.getRegisteredKeywords() }
-                    .onSuccess { entities ->
-                        val registered = entities.map { Keyword(id = it.keywordId, name = it.keywordName) }
-                        _uiState.update { state ->
-                            state.copy(
-                                libraryFilterUiModel = state.libraryFilterUiModel.copy(
-                                    keywords = state.libraryFilterUiModel.keywords.copy(registered = registered),
-                                ),
-                            )
-                        }
-                        _tempFilterUiState.update { temp ->
-                            temp.copy(keywords = temp.keywords.copy(registered = registered))
-                        }
-                    }
-                    .onFailure { Log.e("LibraryViewModel", "등록 키워드 로드 실패", it) }
-            }
-        }
-
-        private fun loadNovelsCount() {
-            viewModelScope.launch {
-                libraryRepository.novelTotalCount.collect { result ->
-                    _uiState.update { it.copy(novelTotalCount = result) }
-                }
-            }
-        }
-
-        private fun loadLibrary() {
-            pagingJob?.cancel()
-
-            pagingJob = viewModelScope.launch {
-                libraryRepository
-                    .getLibraryFlow()
-                    .map { pagingData -> pagingData.map(NovelEntity::toUiModel) }
-                    .cachedIn(viewModelScope)
-                    .collect { result ->
-                        novels.update { result }
-                    }
-            }
-        }
-
-        fun refresh() {
-            loadLibrary()
-        }
-
-        private fun updateLibraryFilter() {
-            viewModelScope.launch {
-                filterRepository.filterFlow.collect { filter ->
-                    _uiState.update { uiState ->
-                        uiState.copy(
-                            libraryFilterUiModel = uiState.libraryFilterUiModel.copy(
-                                sortCriteria = SortCriteria.from(filter.sortCriteria),
-                                isInterested = filter.isInterested,
-                                readStatuses = filter.readStatuses.toReadStatuses(),
-                                genres = filter.genres.toGenres(),
-                                seriesStatuses = SeriesStatuses.fromIsComplete(filter.isComplete),
-                                attractivePoints = filter.attractivePoints.toAttractivePoints(),
-                                ratingFilter = RatingFilter(
-                                    min = filter.ratingMin,
-                                    max = filter.ratingMax,
-                                    isRatingless = filter.isRatingless,
-                                ),
-                                keywords = uiState.libraryFilterUiModel.keywords.copy(
-                                    selectedNames = filter.keywords.toSet(),
-                                ),
+    private fun loadRegisteredKeywords() {
+        viewModelScope.launch {
+            runCatching { libraryRepository.getRegisteredKeywords() }
+                .onSuccess { entities ->
+                    val registered =
+                        entities.map { Keyword(id = it.keywordId, name = it.keywordName) }
+                    _uiState.update { state ->
+                        state.copy(
+                            libraryFilterUiModel = state.libraryFilterUiModel.copy(
+                                keywords = state.libraryFilterUiModel.keywords.copy(registered = registered),
                             ),
                         )
                     }
+                    _tempFilterUiState.update { temp ->
+                        temp.copy(keywords = temp.keywords.copy(registered = registered))
+                    }
                 }
-            }
+                .onFailure { Log.e("LibraryViewModel", "등록 키워드 로드 실패", it) }
         }
+    }
 
-        fun updateViewType() {
-            _uiState.update {
-                it.copy(isGrid = !it.isGrid)
-            }
-        }
-
-        fun resetScrollPosition() {
-            viewModelScope.launch {
-                _scrollToTopEvent.send(Unit)
-            }
-        }
-
-        fun updateSortCriteria(sortCriteria: SortCriteria) {
-            viewModelScope.launch {
-                filterRepository.updateFilter(
-                    sortCriteria = sortCriteria.key,
-                )
-            }
-        }
-
-        fun updateInterestedNovels() {
-            val updatedInterested = !uiState.value.libraryFilterUiModel.isInterested
-
-            viewModelScope.launch {
-                filterRepository.updateFilter(
-                    isInterested = updatedInterested,
-                )
-            }
-        }
-
-        fun updateMyLibraryFilter() {
-            _tempFilterUiState.update {
-                uiState.value.libraryFilterUiModel
-            }
-        }
-
-        fun updateReadStatus(readStatus: ReadStatus) {
-            _tempFilterUiState.update {
-                it.copy(readStatuses = it.readStatuses.set(readStatus))
-            }
-        }
-
-        fun updateGenre(genre: Genre) {
-            _tempFilterUiState.update {
-                it.copy(genres = it.genres.set(genre))
-            }
-        }
-
-        fun updateSeriesStatus(seriesStatus: SeriesStatus) {
-            _tempFilterUiState.update {
-                it.copy(seriesStatuses = it.seriesStatuses.set(seriesStatus))
-            }
-        }
-
-        fun updateAttractivePoints(attractivePoint: AttractivePoint) {
-            _tempFilterUiState.update {
-                it.copy(attractivePoints = it.attractivePoints.set(attractivePoint))
-            }
-        }
-
-        fun updateRatingRange(
-            min: Float,
-            max: Float,
-        ) {
-            _tempFilterUiState.update {
-                it.copy(ratingFilter = it.ratingFilter.setRange(min, max))
-            }
-        }
-
-        fun updateRatingless() {
-            _tempFilterUiState.update {
-                it.copy(ratingFilter = it.ratingFilter.toggleRatingless())
-            }
-        }
-
-        fun clearRating() {
-            _tempFilterUiState.update {
-                it.copy(ratingFilter = RatingFilter())
-            }
-        }
-
-        fun updateKeyword(keywordName: String) {
-            val current = _tempFilterUiState.value.keywords
-            val isNewSelection = !current.isSelected(keywordName)
-
-            if (isNewSelection && current.selectedNames.size >= Keywords.MAX_SELECTION) {
-                viewModelScope.launch { _keywordLimitEvent.send(Unit) }
-                return
-            }
-
-            _tempFilterUiState.update {
-                it.copy(keywords = it.keywords.set(keywordName))
-            }
-        }
-
-        fun resetFilter() {
-            _tempFilterUiState.update { current ->
-                LibraryFilterUiModel(
-                    isInterested = current.isInterested,
-                    sortCriteria = current.sortCriteria,
-                    keywords = Keywords(registered = current.keywords.registered),
-                )
-            }
-        }
-
-        fun searchFilteredNovels() {
-            val tempFilter = _tempFilterUiState.value
-
-            viewModelScope.launch {
-                filterRepository.applyLibraryFilter(
-                    readStatuses = tempFilter.readStatuses.selectedKeys,
-                    attractivePoints = tempFilter.attractivePoints.selectedKeys,
-                    genres = tempFilter.genres.selectedKeys,
-                    isComplete = tempFilter.seriesStatuses.isComplete,
-                    ratingMin = tempFilter.ratingFilter.min,
-                    ratingMax = tempFilter.ratingFilter.max,
-                    isRatingless = tempFilter.ratingFilter.isRatingless,
-                    keywords = tempFilter.keywords.selectedLabels,
-                )
+    private fun loadNovelsCount() {
+        viewModelScope.launch {
+            libraryRepository.novelTotalCount.collect { result ->
+                _uiState.update { it.copy(novelTotalCount = result) }
             }
         }
     }
+
+    private fun loadLibrary() {
+        pagingJob?.cancel()
+
+        pagingJob = viewModelScope.launch {
+            libraryRepository
+                .getLibraryFlow()
+                .map { pagingData -> pagingData.map(NovelEntity::toUiModel) }
+                .cachedIn(viewModelScope)
+                .collect { result ->
+                    novels.update { result }
+                }
+        }
+    }
+
+    fun refresh() {
+        loadLibrary()
+    }
+
+    private fun updateLibraryFilter() {
+        viewModelScope.launch {
+            filterRepository.filterFlow.collect { filter ->
+                _uiState.update { uiState ->
+                    uiState.copy(
+                        libraryFilterUiModel = uiState.libraryFilterUiModel.copy(
+                            sortCriteria = SortCriteria.from(filter.sortCriteria),
+                            isInterested = filter.isInterested,
+                            readStatuses = filter.readStatuses.toReadStatuses(),
+                            genres = filter.genres.toGenres(),
+                            seriesStatuses = SeriesStatuses.fromIsComplete(filter.isComplete),
+                            attractivePoints = filter.attractivePoints.toAttractivePoints(),
+                            ratingFilter = RatingFilter(
+                                min = filter.ratingMin,
+                                max = filter.ratingMax,
+                                isRatingless = filter.isRatingless,
+                            ),
+                            keywords = uiState.libraryFilterUiModel.keywords.copy(
+                                selectedNames = filter.keywords.toSet(),
+                            ),
+                        ),
+                    )
+                }
+            }
+        }
+    }
+
+    fun updateViewType() {
+        _uiState.update {
+            it.copy(isGrid = !it.isGrid)
+        }
+    }
+
+    fun resetScrollPosition() {
+        viewModelScope.launch {
+            _scrollToTopEvent.send(Unit)
+        }
+    }
+
+    fun updateSortCriteria(sortCriteria: SortCriteria) {
+        viewModelScope.launch {
+            filterRepository.updateFilter(
+                sortCriteria = sortCriteria.key,
+            )
+        }
+    }
+
+    fun updateInterestedNovels() {
+        val updatedInterested = !uiState.value.libraryFilterUiModel.isInterested
+
+        viewModelScope.launch {
+            filterRepository.updateFilter(
+                isInterested = updatedInterested,
+            )
+        }
+    }
+
+    fun updateMyLibraryFilter() {
+        _tempFilterUiState.update {
+            uiState.value.libraryFilterUiModel
+        }
+    }
+
+    fun updateReadStatus(readStatus: ReadStatus) {
+        _tempFilterUiState.update {
+            it.copy(readStatuses = it.readStatuses.set(readStatus))
+        }
+    }
+
+    fun updateGenre(genre: Genre) {
+        _tempFilterUiState.update {
+            it.copy(genres = it.genres.set(genre))
+        }
+    }
+
+    fun updateSeriesStatus(seriesStatus: SeriesStatus) {
+        _tempFilterUiState.update {
+            it.copy(seriesStatuses = it.seriesStatuses.set(seriesStatus))
+        }
+    }
+
+    fun updateAttractivePoints(attractivePoint: AttractivePoint) {
+        _tempFilterUiState.update {
+            it.copy(attractivePoints = it.attractivePoints.set(attractivePoint))
+        }
+    }
+
+    fun updateRatingRange(
+        min: Float,
+        max: Float,
+    ) {
+        _tempFilterUiState.update {
+            it.copy(ratingFilter = it.ratingFilter.setRange(min, max))
+        }
+    }
+
+    fun updateRatingless() {
+        _tempFilterUiState.update {
+            it.copy(ratingFilter = it.ratingFilter.toggleRatingless())
+        }
+    }
+
+    fun clearRating() {
+        _tempFilterUiState.update {
+            it.copy(ratingFilter = RatingFilter())
+        }
+    }
+
+    fun updateKeyword(keywordName: String) {
+        val current = _tempFilterUiState.value.keywords
+        val isNewSelection = !current.isSelected(keywordName)
+
+        if (isNewSelection && current.selectedNames.size >= Keywords.MAX_SELECTION) {
+            viewModelScope.launch { _keywordLimitEvent.send(Unit) }
+            return
+        }
+
+        _tempFilterUiState.update {
+            it.copy(keywords = it.keywords.set(keywordName))
+        }
+    }
+
+    fun resetFilter() {
+        _tempFilterUiState.update { current ->
+            LibraryFilterUiModel(
+                isInterested = current.isInterested,
+                sortCriteria = current.sortCriteria,
+                keywords = Keywords(registered = current.keywords.registered),
+            )
+        }
+    }
+
+    fun searchFilteredNovels() {
+        val tempFilter = _tempFilterUiState.value
+
+        viewModelScope.launch {
+            filterRepository.applyLibraryFilter(
+                readStatuses = tempFilter.readStatuses.selectedKeys,
+                attractivePoints = tempFilter.attractivePoints.selectedKeys,
+                genres = tempFilter.genres.selectedKeys,
+                isComplete = tempFilter.seriesStatuses.isComplete,
+                ratingMin = tempFilter.ratingFilter.min,
+                ratingMax = tempFilter.ratingFilter.max,
+                isRatingless = tempFilter.ratingFilter.isRatingless,
+                keywords = tempFilter.keywords.selectedLabels,
+            )
+        }
+    }
+}

--- a/feature/library/src/main/java/com/into/websoso/feature/library/LibraryViewModel.kt
+++ b/feature/library/src/main/java/com/into/websoso/feature/library/LibraryViewModel.kt
@@ -40,227 +40,226 @@ import javax.inject.Inject
 
 @HiltViewModel
 class LibraryViewModel
-@Inject
-constructor(
-    private val libraryRepository: LibraryRepository,
-    private val filterRepository: FilterRepository,
-) : ViewModel() {
-    private var pagingJob: Job? = null
+    @Inject
+    constructor(
+        private val libraryRepository: LibraryRepository,
+        private val filterRepository: FilterRepository,
+    ) : ViewModel() {
+        private var pagingJob: Job? = null
 
-    private val _uiState = MutableStateFlow(LibraryUiState())
-    val uiState: StateFlow<LibraryUiState> = _uiState.asStateFlow()
+        private val _uiState = MutableStateFlow(LibraryUiState())
+        val uiState: StateFlow<LibraryUiState> = _uiState.asStateFlow()
 
-    private val _tempFilterUiState = MutableStateFlow(uiState.value.libraryFilterUiModel)
-    val tempFilterUiState = _tempFilterUiState.asStateFlow()
+        private val _tempFilterUiState = MutableStateFlow(uiState.value.libraryFilterUiModel)
+        val tempFilterUiState = _tempFilterUiState.asStateFlow()
 
-    private val _scrollToTopEvent = Channel<Unit>(Channel.BUFFERED)
-    val scrollToTopEvent: Flow<Unit> = _scrollToTopEvent.receiveAsFlow()
+        private val _scrollToTopEvent = Channel<Unit>(Channel.BUFFERED)
+        val scrollToTopEvent: Flow<Unit> = _scrollToTopEvent.receiveAsFlow()
 
-    private val _keywordLimitEvent = Channel<Unit>(Channel.BUFFERED)
-    val keywordLimitEvent: Flow<Unit> = _keywordLimitEvent.receiveAsFlow()
+        private val _keywordLimitEvent = Channel<Unit>(Channel.BUFFERED)
+        val keywordLimitEvent: Flow<Unit> = _keywordLimitEvent.receiveAsFlow()
 
-    val novels: MutableStateFlow<PagingData<NovelUiModel>> = MutableStateFlow(PagingData.empty())
+        val novels: MutableStateFlow<PagingData<NovelUiModel>> = MutableStateFlow(PagingData.empty())
 
-    init {
-        loadLibrary()
-        loadNovelsCount()
-        updateLibraryFilter()
-        loadRegisteredKeywords()
-    }
+        init {
+            loadLibrary()
+            loadNovelsCount()
+            updateLibraryFilter()
+            loadRegisteredKeywords()
+        }
 
-    private fun loadRegisteredKeywords() {
-        viewModelScope.launch {
-            runCatching { libraryRepository.getRegisteredKeywords() }
-                .onSuccess { entities ->
-                    val registered =
-                        entities.map { Keyword(id = it.keywordId, name = it.keywordName) }
-                    _uiState.update { state ->
-                        state.copy(
-                            libraryFilterUiModel = state.libraryFilterUiModel.copy(
-                                keywords = state.libraryFilterUiModel.keywords.copy(registered = registered),
+        private fun loadRegisteredKeywords() {
+            viewModelScope.launch {
+                runCatching { libraryRepository.getRegisteredKeywords() }
+                    .onSuccess { entities ->
+                        val registered =
+                            entities.map { Keyword(id = it.keywordId, name = it.keywordName) }
+                        _uiState.update { state ->
+                            state.copy(
+                                libraryFilterUiModel = state.libraryFilterUiModel.copy(
+                                    keywords = state.libraryFilterUiModel.keywords.copy(registered = registered),
+                                ),
+                            )
+                        }
+                        _tempFilterUiState.update { temp ->
+                            temp.copy(keywords = temp.keywords.copy(registered = registered))
+                        }
+                    }.onFailure { Log.e("LibraryViewModel", "등록 키워드 로드 실패", it) }
+            }
+        }
+
+        private fun loadNovelsCount() {
+            viewModelScope.launch {
+                libraryRepository.novelTotalCount.collect { result ->
+                    _uiState.update { it.copy(novelTotalCount = result) }
+                }
+            }
+        }
+
+        private fun loadLibrary() {
+            pagingJob?.cancel()
+
+            pagingJob = viewModelScope.launch {
+                libraryRepository
+                    .getLibraryFlow()
+                    .map { pagingData -> pagingData.map(NovelEntity::toUiModel) }
+                    .cachedIn(viewModelScope)
+                    .collect { result ->
+                        novels.update { result }
+                    }
+            }
+        }
+
+        fun refresh() {
+            loadLibrary()
+        }
+
+        private fun updateLibraryFilter() {
+            viewModelScope.launch {
+                filterRepository.filterFlow.collect { filter ->
+                    _uiState.update { uiState ->
+                        uiState.copy(
+                            libraryFilterUiModel = uiState.libraryFilterUiModel.copy(
+                                sortCriteria = SortCriteria.from(filter.sortCriteria),
+                                isInterested = filter.isInterested,
+                                readStatuses = filter.readStatuses.toReadStatuses(),
+                                genres = filter.genres.toGenres(),
+                                seriesStatuses = SeriesStatuses.fromIsComplete(filter.isComplete),
+                                attractivePoints = filter.attractivePoints.toAttractivePoints(),
+                                ratingFilter = RatingFilter(
+                                    min = filter.ratingMin,
+                                    max = filter.ratingMax,
+                                    isRatingless = filter.isRatingless,
+                                ),
+                                keywords = uiState.libraryFilterUiModel.keywords.copy(
+                                    selectedNames = filter.keywords.toSet(),
+                                ),
                             ),
                         )
                     }
-                    _tempFilterUiState.update { temp ->
-                        temp.copy(keywords = temp.keywords.copy(registered = registered))
-                    }
-                }
-                .onFailure { Log.e("LibraryViewModel", "등록 키워드 로드 실패", it) }
-        }
-    }
-
-    private fun loadNovelsCount() {
-        viewModelScope.launch {
-            libraryRepository.novelTotalCount.collect { result ->
-                _uiState.update { it.copy(novelTotalCount = result) }
-            }
-        }
-    }
-
-    private fun loadLibrary() {
-        pagingJob?.cancel()
-
-        pagingJob = viewModelScope.launch {
-            libraryRepository
-                .getLibraryFlow()
-                .map { pagingData -> pagingData.map(NovelEntity::toUiModel) }
-                .cachedIn(viewModelScope)
-                .collect { result ->
-                    novels.update { result }
-                }
-        }
-    }
-
-    fun refresh() {
-        loadLibrary()
-    }
-
-    private fun updateLibraryFilter() {
-        viewModelScope.launch {
-            filterRepository.filterFlow.collect { filter ->
-                _uiState.update { uiState ->
-                    uiState.copy(
-                        libraryFilterUiModel = uiState.libraryFilterUiModel.copy(
-                            sortCriteria = SortCriteria.from(filter.sortCriteria),
-                            isInterested = filter.isInterested,
-                            readStatuses = filter.readStatuses.toReadStatuses(),
-                            genres = filter.genres.toGenres(),
-                            seriesStatuses = SeriesStatuses.fromIsComplete(filter.isComplete),
-                            attractivePoints = filter.attractivePoints.toAttractivePoints(),
-                            ratingFilter = RatingFilter(
-                                min = filter.ratingMin,
-                                max = filter.ratingMax,
-                                isRatingless = filter.isRatingless,
-                            ),
-                            keywords = uiState.libraryFilterUiModel.keywords.copy(
-                                selectedNames = filter.keywords.toSet(),
-                            ),
-                        ),
-                    )
                 }
             }
         }
-    }
 
-    fun updateViewType() {
-        _uiState.update {
-            it.copy(isGrid = !it.isGrid)
-        }
-    }
-
-    fun resetScrollPosition() {
-        viewModelScope.launch {
-            _scrollToTopEvent.send(Unit)
-        }
-    }
-
-    fun updateSortCriteria(sortCriteria: SortCriteria) {
-        viewModelScope.launch {
-            filterRepository.updateFilter(
-                sortCriteria = sortCriteria.key,
-            )
-        }
-    }
-
-    fun updateInterestedNovels() {
-        val updatedInterested = !uiState.value.libraryFilterUiModel.isInterested
-
-        viewModelScope.launch {
-            filterRepository.updateFilter(
-                isInterested = updatedInterested,
-            )
-        }
-    }
-
-    fun updateMyLibraryFilter() {
-        _tempFilterUiState.update {
-            uiState.value.libraryFilterUiModel
-        }
-    }
-
-    fun updateReadStatus(readStatus: ReadStatus) {
-        _tempFilterUiState.update {
-            it.copy(readStatuses = it.readStatuses.set(readStatus))
-        }
-    }
-
-    fun updateGenre(genre: Genre) {
-        _tempFilterUiState.update {
-            it.copy(genres = it.genres.set(genre))
-        }
-    }
-
-    fun updateSeriesStatus(seriesStatus: SeriesStatus) {
-        _tempFilterUiState.update {
-            it.copy(seriesStatuses = it.seriesStatuses.set(seriesStatus))
-        }
-    }
-
-    fun updateAttractivePoints(attractivePoint: AttractivePoint) {
-        _tempFilterUiState.update {
-            it.copy(attractivePoints = it.attractivePoints.set(attractivePoint))
-        }
-    }
-
-    fun updateRatingRange(
-        min: Float,
-        max: Float,
-    ) {
-        _tempFilterUiState.update {
-            it.copy(ratingFilter = it.ratingFilter.setRange(min, max))
-        }
-    }
-
-    fun updateRatingless() {
-        _tempFilterUiState.update {
-            it.copy(ratingFilter = it.ratingFilter.toggleRatingless())
-        }
-    }
-
-    fun clearRating() {
-        _tempFilterUiState.update {
-            it.copy(ratingFilter = RatingFilter())
-        }
-    }
-
-    fun updateKeyword(keywordName: String) {
-        val current = _tempFilterUiState.value.keywords
-        val isNewSelection = !current.isSelected(keywordName)
-
-        if (isNewSelection && current.selectedNames.size >= Keywords.MAX_SELECTION) {
-            viewModelScope.launch { _keywordLimitEvent.send(Unit) }
-            return
+        fun updateViewType() {
+            _uiState.update {
+                it.copy(isGrid = !it.isGrid)
+            }
         }
 
-        _tempFilterUiState.update {
-            it.copy(keywords = it.keywords.set(keywordName))
+        fun resetScrollPosition() {
+            viewModelScope.launch {
+                _scrollToTopEvent.send(Unit)
+            }
+        }
+
+        fun updateSortCriteria(sortCriteria: SortCriteria) {
+            viewModelScope.launch {
+                filterRepository.updateFilter(
+                    sortCriteria = sortCriteria.key,
+                )
+            }
+        }
+
+        fun updateInterestedNovels() {
+            val updatedInterested = !uiState.value.libraryFilterUiModel.isInterested
+
+            viewModelScope.launch {
+                filterRepository.updateFilter(
+                    isInterested = updatedInterested,
+                )
+            }
+        }
+
+        fun updateMyLibraryFilter() {
+            _tempFilterUiState.update {
+                uiState.value.libraryFilterUiModel
+            }
+        }
+
+        fun updateReadStatus(readStatus: ReadStatus) {
+            _tempFilterUiState.update {
+                it.copy(readStatuses = it.readStatuses.set(readStatus))
+            }
+        }
+
+        fun updateGenre(genre: Genre) {
+            _tempFilterUiState.update {
+                it.copy(genres = it.genres.set(genre))
+            }
+        }
+
+        fun updateSeriesStatus(seriesStatus: SeriesStatus) {
+            _tempFilterUiState.update {
+                it.copy(seriesStatuses = it.seriesStatuses.set(seriesStatus))
+            }
+        }
+
+        fun updateAttractivePoints(attractivePoint: AttractivePoint) {
+            _tempFilterUiState.update {
+                it.copy(attractivePoints = it.attractivePoints.set(attractivePoint))
+            }
+        }
+
+        fun updateRatingRange(
+            min: Float,
+            max: Float,
+        ) {
+            _tempFilterUiState.update {
+                it.copy(ratingFilter = it.ratingFilter.setRange(min, max))
+            }
+        }
+
+        fun updateRatingless() {
+            _tempFilterUiState.update {
+                it.copy(ratingFilter = it.ratingFilter.toggleRatingless())
+            }
+        }
+
+        fun clearRating() {
+            _tempFilterUiState.update {
+                it.copy(ratingFilter = RatingFilter())
+            }
+        }
+
+        fun updateKeyword(keywordName: String) {
+            val current = _tempFilterUiState.value.keywords
+            val isNewSelection = !current.isSelected(keywordName)
+
+            if (isNewSelection && current.selectedNames.size >= Keywords.MAX_SELECTION) {
+                viewModelScope.launch { _keywordLimitEvent.send(Unit) }
+                return
+            }
+
+            _tempFilterUiState.update {
+                it.copy(keywords = it.keywords.set(keywordName))
+            }
+        }
+
+        fun resetFilter() {
+            _tempFilterUiState.update { current ->
+                LibraryFilterUiModel(
+                    isInterested = current.isInterested,
+                    sortCriteria = current.sortCriteria,
+                    keywords = Keywords(registered = current.keywords.registered),
+                )
+            }
+        }
+
+        fun searchFilteredNovels() {
+            val tempFilter = _tempFilterUiState.value
+
+            viewModelScope.launch {
+                filterRepository.applyLibraryFilter(
+                    readStatuses = tempFilter.readStatuses.selectedKeys,
+                    attractivePoints = tempFilter.attractivePoints.selectedKeys,
+                    genres = tempFilter.genres.selectedKeys,
+                    isComplete = tempFilter.seriesStatuses.isComplete,
+                    ratingMin = tempFilter.ratingFilter.min,
+                    ratingMax = tempFilter.ratingFilter.max,
+                    isRatingless = tempFilter.ratingFilter.isRatingless,
+                    keywords = tempFilter.keywords.selectedLabels,
+                )
+            }
         }
     }
-
-    fun resetFilter() {
-        _tempFilterUiState.update { current ->
-            LibraryFilterUiModel(
-                isInterested = current.isInterested,
-                sortCriteria = current.sortCriteria,
-                keywords = Keywords(registered = current.keywords.registered),
-            )
-        }
-    }
-
-    fun searchFilteredNovels() {
-        val tempFilter = _tempFilterUiState.value
-
-        viewModelScope.launch {
-            filterRepository.applyLibraryFilter(
-                readStatuses = tempFilter.readStatuses.selectedKeys,
-                attractivePoints = tempFilter.attractivePoints.selectedKeys,
-                genres = tempFilter.genres.selectedKeys,
-                isComplete = tempFilter.seriesStatuses.isComplete,
-                ratingMin = tempFilter.ratingFilter.min,
-                ratingMax = tempFilter.ratingFilter.max,
-                isRatingless = tempFilter.ratingFilter.isRatingless,
-                keywords = tempFilter.keywords.selectedLabels,
-            )
-        }
-    }
-}

--- a/feature/library/src/main/java/com/into/websoso/feature/library/component/LibrarySortBottomSheet.kt
+++ b/feature/library/src/main/java/com/into/websoso/feature/library/component/LibrarySortBottomSheet.kt
@@ -4,10 +4,13 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
@@ -82,28 +85,35 @@ private fun LibrarySortItem(
     Box(
         modifier = Modifier
             .fillMaxWidth()
-            .clip(RoundedCornerShape(40.dp))
+            .clip(RoundedCornerShape(12.dp))
             .background(if (isSelected) Primary20 else Transparent)
             .debouncedClickable(onClick = onClick)
             .padding(vertical = 16.dp),
         contentAlignment = Alignment.Center,
     ) {
-        if (isSelected) {
-            Icon(
-                imageVector = ImageVector.vectorResource(id = ic_library_sort_check),
-                contentDescription = null,
-                tint = Primary100,
-                modifier = Modifier
-                    .align(Alignment.CenterStart)
-                    .padding(start = 8.dp)
-                    .size(20.dp),
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            // 왼쪽 체크 슬롯: 오른쪽 균형 슬롯과 대칭이라 텍스트는 항상 중앙 정렬을 유지한다.
+            Box(modifier = Modifier.size(20.dp)) {
+                if (isSelected) {
+                    Icon(
+                        imageVector = ImageVector.vectorResource(id = ic_library_sort_check),
+                        contentDescription = null,
+                        tint = Primary100,
+                        modifier = Modifier.size(20.dp),
+                    )
+                }
+            }
+            Spacer(modifier = Modifier.width(12.dp))
+            Text(
+                text = label,
+                style = WebsosoTheme.typography.body2,
+                color = if (isSelected) Black else Gray200,
             )
+            Spacer(modifier = Modifier.width(12.dp))
+            Spacer(modifier = Modifier.width(20.dp))
         }
-        Text(
-            text = label,
-            style = WebsosoTheme.typography.body2,
-            color = if (isSelected) Black else Gray200,
-        )
     }
 }
 

--- a/feature/library/src/main/java/com/into/websoso/feature/library/component/LibrarySortBottomSheet.kt
+++ b/feature/library/src/main/java/com/into/websoso/feature/library/component/LibrarySortBottomSheet.kt
@@ -2,14 +2,12 @@ package com.into.websoso.feature.library.component
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
@@ -28,9 +26,9 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.into.websoso.core.common.extensions.debouncedClickable
 import com.into.websoso.core.designsystem.theme.Black
-import com.into.websoso.core.designsystem.theme.Gray300
+import com.into.websoso.core.designsystem.theme.Gray200
 import com.into.websoso.core.designsystem.theme.Primary100
-import com.into.websoso.core.designsystem.theme.Primary50
+import com.into.websoso.core.designsystem.theme.Primary20
 import com.into.websoso.core.designsystem.theme.Transparent
 import com.into.websoso.core.designsystem.theme.WebsosoTheme
 import com.into.websoso.core.designsystem.theme.White
@@ -81,29 +79,30 @@ private fun LibrarySortItem(
     isSelected: Boolean,
     onClick: () -> Unit,
 ) {
-    Row(
+    Box(
         modifier = Modifier
             .fillMaxWidth()
-            .clip(RoundedCornerShape(8.dp))
-            .background(if (isSelected) Primary50 else Transparent)
+            .clip(RoundedCornerShape(40.dp))
+            .background(if (isSelected) Primary20 else Transparent)
             .debouncedClickable(onClick = onClick)
             .padding(vertical = 16.dp),
-        horizontalArrangement = Arrangement.Center,
-        verticalAlignment = Alignment.CenterVertically,
+        contentAlignment = Alignment.Center,
     ) {
         if (isSelected) {
             Icon(
                 imageVector = ImageVector.vectorResource(id = ic_library_sort_check),
                 contentDescription = null,
                 tint = Primary100,
-                modifier = Modifier.size(20.dp),
+                modifier = Modifier
+                    .align(Alignment.CenterStart)
+                    .padding(start = 8.dp)
+                    .size(20.dp),
             )
-            Spacer(modifier = Modifier.width(6.dp))
         }
         Text(
             text = label,
             style = WebsosoTheme.typography.body2,
-            color = if (isSelected) Black else Gray300,
+            color = if (isSelected) Black else Gray200,
         )
     }
 }

--- a/feature/library/src/main/java/com/into/websoso/feature/library/component/LibrayFilterTopBar.kt
+++ b/feature/library/src/main/java/com/into/websoso/feature/library/component/LibrayFilterTopBar.kt
@@ -32,6 +32,7 @@ import com.into.websoso.core.common.extensions.debouncedClickable
 import com.into.websoso.core.designsystem.theme.Black
 import com.into.websoso.core.designsystem.theme.Gray200
 import com.into.websoso.core.designsystem.theme.Gray300
+import com.into.websoso.core.designsystem.theme.Gray50
 import com.into.websoso.core.designsystem.theme.Gray70
 import com.into.websoso.core.designsystem.theme.WebsosoTheme
 import com.into.websoso.core.designsystem.theme.White
@@ -55,24 +56,37 @@ internal fun LibraryFilterTopBar(
     modifier: Modifier = Modifier,
 ) {
     Column(
-        modifier = modifier
-            .fillMaxWidth()
-            .padding(start = 20.dp),
+        modifier = modifier.fillMaxWidth(),
     ) {
-        NovelFilterChipSection(
-            libraryFilterUiModel = libraryFilterUiModel,
-            onFilterClick = onFilterClick,
-            onInterestClick = onInterestClick,
-        )
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(start = 20.dp),
+        ) {
+            NovelFilterChipSection(
+                libraryFilterUiModel = libraryFilterUiModel,
+                onFilterClick = onFilterClick,
+                onInterestClick = onInterestClick,
+            )
+
+            Spacer(modifier = Modifier.height(10.dp))
+
+            NovelFilterStatusBar(
+                totalCount = totalCount,
+                sortCriteria = libraryFilterUiModel.sortCriteria,
+                isGrid = isGrid,
+                onSortClick = onSortClick,
+                onToggleViewType = onToggleViewType,
+            )
+        }
 
         Spacer(modifier = Modifier.height(10.dp))
 
-        NovelFilterStatusBar(
-            totalCount = totalCount,
-            sortCriteria = libraryFilterUiModel.sortCriteria,
-            isGrid = isGrid,
-            onSortClick = onSortClick,
-            onToggleViewType = onToggleViewType,
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(1.dp)
+                .background(color = Gray50),
         )
     }
 }

--- a/feature/library/src/main/java/com/into/websoso/feature/library/component/LibrayFilterTopBar.kt
+++ b/feature/library/src/main/java/com/into/websoso/feature/library/component/LibrayFilterTopBar.kt
@@ -221,7 +221,7 @@ private fun NovelFilterStatusBar(
                         id = if (isGrid) ic_library_grid else ic_library_list,
                     ),
                     contentDescription = null,
-                    modifier = Modifier.size(12.dp),
+                    modifier = Modifier.size(18.dp),
                 )
             }
         }
@@ -250,7 +250,7 @@ private fun SortTypeSelector(
 
             Text(
                 text = sortCriteria.label,
-                style = WebsosoTheme.typography.body5,
+                style = WebsosoTheme.typography.body4,
                 color = Gray300,
             )
         }

--- a/feature/library/src/main/java/com/into/websoso/feature/library/filter/LibraryFilterBottomSheetScreen.kt
+++ b/feature/library/src/main/java/com/into/websoso/feature/library/filter/LibraryFilterBottomSheetScreen.kt
@@ -127,6 +127,8 @@ internal fun LibraryFilterBottomSheetScreen(
                         )
                     }
 
+                    Spacer(modifier = Modifier.height(12.dp))
+
                     Box(
                         modifier = Modifier
                             .fillMaxWidth()

--- a/feature/library/src/main/java/com/into/websoso/feature/library/filter/LibraryFilterBottomSheetScreen.kt
+++ b/feature/library/src/main/java/com/into/websoso/feature/library/filter/LibraryFilterBottomSheetScreen.kt
@@ -1,5 +1,6 @@
 package com.into.websoso.feature.library.filter
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -17,9 +18,11 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.into.websoso.core.designsystem.theme.Gray50
 import com.into.websoso.core.designsystem.theme.WebsosoTheme
 import com.into.websoso.core.designsystem.theme.White
 import com.into.websoso.domain.library.model.AttractivePoint
@@ -43,6 +46,10 @@ import com.into.websoso.feature.library.filter.component.LibraryFilterBottomShee
 import com.into.websoso.feature.library.filter.component.LibraryFilterSelectedChips
 import com.into.websoso.feature.library.filter.component.LibraryFilterTabRow
 import com.into.websoso.feature.library.model.LibraryFilterUiModel
+
+private val SELECTED_CHIPS_ROW_HEIGHT = 36.5.dp
+
+private val FILTER_CONTENT_REGION_HEIGHT = 333.5.dp
 
 @Composable
 @OptIn(ExperimentalMaterial3Api::class)
@@ -96,57 +103,78 @@ internal fun LibraryFilterBottomSheetScreen(
 
             Spacer(modifier = Modifier.height(16.dp))
 
-            if (activeTabs.isNotEmpty()) {
-                LibraryFilterSelectedChips(
-                    filterUiState = filterUiState,
-                    onReadStatusClick = onReadStatusClick,
-                    onGenreClick = onGenreClick,
-                    onSeriesStatusClick = onSeriesStatusClick,
-                    onAttractivePointClick = onAttractivePointClick,
-                    onRatingRemove = onRatingRemove,
-                    onKeywordClick = onKeywordClick,
-                    modifier = Modifier.padding(horizontal = 20.dp),
-                )
-                Spacer(modifier = Modifier.height(16.dp))
-            }
-
-            Box(
+            Column(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .height(280.dp)
-                    .padding(horizontal = 20.dp),
+                    .height(FILTER_CONTENT_REGION_HEIGHT),
             ) {
-                when (selectedTab) {
-                    READ_STATUS -> LibraryFilterBottomSheetReadStatus(
-                        readStatuses = filterUiState.readStatuses,
-                        onReadStatusClick = onReadStatusClick,
+                if (activeTabs.isNotEmpty()) {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(SELECTED_CHIPS_ROW_HEIGHT)
+                            .padding(horizontal = 20.dp),
+                        contentAlignment = Alignment.CenterStart,
+                    ) {
+                        LibraryFilterSelectedChips(
+                            filterUiState = filterUiState,
+                            onReadStatusClick = onReadStatusClick,
+                            onGenreClick = onGenreClick,
+                            onSeriesStatusClick = onSeriesStatusClick,
+                            onAttractivePointClick = onAttractivePointClick,
+                            onRatingRemove = onRatingRemove,
+                            onKeywordClick = onKeywordClick,
+                        )
+                    }
+
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(1.dp)
+                            .background(Gray50),
                     )
 
-                    GENRE -> LibraryFilterBottomSheetGenre(
-                        genres = filterUiState.genres,
-                        onGenreClick = onGenreClick,
-                    )
+                    Spacer(modifier = Modifier.height(16.dp))
+                }
 
-                    SERIES_STATUS -> LibraryFilterBottomSheetSeriesStatus(
-                        seriesStatuses = filterUiState.seriesStatuses,
-                        onSeriesStatusClick = onSeriesStatusClick,
-                    )
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .weight(1f)
+                        .padding(horizontal = 20.dp),
+                ) {
+                    when (selectedTab) {
+                        READ_STATUS -> LibraryFilterBottomSheetReadStatus(
+                            readStatuses = filterUiState.readStatuses,
+                            onReadStatusClick = onReadStatusClick,
+                        )
 
-                    RATING -> LibraryFilterBottomSheetRating(
-                        ratingFilter = filterUiState.ratingFilter,
-                        onRangeChange = onRatingRangeChange,
-                        onRatinglessToggle = onRatinglessToggle,
-                    )
+                        GENRE -> LibraryFilterBottomSheetGenre(
+                            genres = filterUiState.genres,
+                            onGenreClick = onGenreClick,
+                        )
 
-                    ATTRACTIVE_POINT -> LibraryFilterBottomSheetAttractivePoints(
-                        attractivePoints = filterUiState.attractivePoints,
-                        onAttractivePointClick = onAttractivePointClick,
-                    )
+                        SERIES_STATUS -> LibraryFilterBottomSheetSeriesStatus(
+                            seriesStatuses = filterUiState.seriesStatuses,
+                            onSeriesStatusClick = onSeriesStatusClick,
+                        )
 
-                    KEYWORD -> LibraryFilterBottomSheetKeyword(
-                        keywords = filterUiState.keywords,
-                        onKeywordClick = onKeywordClick,
-                    )
+                        RATING -> LibraryFilterBottomSheetRating(
+                            ratingFilter = filterUiState.ratingFilter,
+                            onRangeChange = onRatingRangeChange,
+                            onRatinglessToggle = onRatinglessToggle,
+                        )
+
+                        ATTRACTIVE_POINT -> LibraryFilterBottomSheetAttractivePoints(
+                            attractivePoints = filterUiState.attractivePoints,
+                            onAttractivePointClick = onAttractivePointClick,
+                        )
+
+                        KEYWORD -> LibraryFilterBottomSheetKeyword(
+                            keywords = filterUiState.keywords,
+                            onKeywordClick = onKeywordClick,
+                        )
+                    }
                 }
             }
 

--- a/feature/library/src/main/java/com/into/websoso/feature/library/filter/component/LibraryFilterBottomSheetButtons.kt
+++ b/feature/library/src/main/java/com/into/websoso/feature/library/filter/component/LibraryFilterBottomSheetButtons.kt
@@ -4,9 +4,8 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.IntrinsicSize
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -18,83 +17,94 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.ui.res.vectorResource
-import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.into.websoso.core.common.extensions.debouncedClickable
 import com.into.websoso.core.designsystem.theme.Gray200
-import com.into.websoso.core.designsystem.theme.Gray50
+import com.into.websoso.core.designsystem.theme.Gray60
 import com.into.websoso.core.designsystem.theme.Primary100
 import com.into.websoso.core.designsystem.theme.WebsosoTheme
 import com.into.websoso.core.designsystem.theme.White
-import com.into.websoso.core.resource.R.drawable.ic_library_reset
+import com.into.websoso.core.resource.R.drawable.ic_detail_explore_reset
+import com.into.websoso.core.resource.R.string.detail_explore_reset
+import com.into.websoso.core.resource.R.string.detail_explore_search_novel
 
 @Composable
 internal fun LibraryFilterBottomSheetButtons(
     onResetClick: () -> Unit,
     onFilterSearchClick: () -> Unit,
 ) {
-    Row(
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(space = 10.dp),
+    Column(
         modifier = Modifier
             .fillMaxWidth()
-            .height(IntrinsicSize.Min)
-            .padding(horizontal = 16.dp)
-            .padding(bottom = 10.dp),
+            .background(White)
+            .padding(start = 17.dp, top = 10.dp, end = 15.dp, bottom = 10.dp),
     ) {
         Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(10.dp),
             verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(space = 4.dp),
-            modifier = Modifier
-                .fillMaxHeight()
-                .clip(RoundedCornerShape(10.dp))
-                .background(color = Gray50)
-                .border(
-                    width = 1.dp,
-                    color = Color(0xFFE4E4E7),
-                    shape = RoundedCornerShape(10.dp),
-                )
-                .debouncedClickable { onResetClick() }
-                .padding(
-                    vertical = 20.dp,
-                    horizontal = 34.dp,
-                ),
         ) {
-            Icon(
-                imageVector = ImageVector.vectorResource(id = ic_library_reset),
-                contentDescription = null,
-                tint = Gray200,
-                modifier = Modifier.size(size = 14.dp),
-            )
-            Text(
-                text = "초기화",
-                style = WebsosoTheme.typography.title2,
-                color = Gray200,
-            )
-        }
-        Box(
-            contentAlignment = Alignment.Center,
-            modifier = Modifier
-                .fillMaxHeight()
-                .clip(RoundedCornerShape(10.dp))
-                .background(color = Primary100)
-                .debouncedClickable { onFilterSearchClick() }
-                .padding(vertical = 20.dp)
-                .weight(weight = 1f),
-        ) {
-            Text(
-                text = "작품 찾기",
-                style = WebsosoTheme.typography.title2,
-                color = White,
+            ResetButton(onClick = onResetClick)
+            SearchButton(
+                onClick = onFilterSearchClick,
+                modifier = Modifier.weight(1f),
             )
         }
     }
 }
 
-@Preview(showBackground = true)
+@Composable
+private fun ResetButton(onClick: () -> Unit) {
+    val shape = RoundedCornerShape(14.dp)
+
+    Row(
+        modifier = Modifier
+            .size(width = 87.dp, height = 53.dp)
+            .clip(shape)
+            .background(White, shape)
+            .border(width = 1.dp, color = Gray60, shape = shape)
+            .debouncedClickable(onClick = onClick),
+        horizontalArrangement = Arrangement.spacedBy(4.dp, Alignment.CenterHorizontally),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Icon(
+            painter = painterResource(id = ic_detail_explore_reset),
+            contentDescription = null,
+            tint = Gray200,
+            modifier = Modifier.size(14.dp),
+        )
+        Text(
+            text = stringResource(detail_explore_reset),
+            style = WebsosoTheme.typography.title2,
+            color = Gray200,
+        )
+    }
+}
+
+@Composable
+private fun SearchButton(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        modifier = modifier
+            .height(53.dp)
+            .clip(RoundedCornerShape(14.dp))
+            .background(Primary100)
+            .debouncedClickable(onClick = onClick),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(
+            text = stringResource(detail_explore_search_novel),
+            style = WebsosoTheme.typography.title2,
+            color = White,
+        )
+    }
+}
+
+@androidx.compose.ui.tooling.preview.Preview(showBackground = true)
 @Composable
 private fun LibraryFilterBottomSheetButtonsPreview() {
     WebsosoTheme {

--- a/feature/library/src/main/java/com/into/websoso/feature/library/filter/component/LibraryFilterBottomSheetClickableItem.kt
+++ b/feature/library/src/main/java/com/into/websoso/feature/library/filter/component/LibraryFilterBottomSheetClickableItem.kt
@@ -31,10 +31,11 @@ internal fun LibraryFilterBottomSheetClickableItem(
     iconSize: Dp,
     horizontalPadding: Dp,
     isSelected: Boolean = false,
+    modifier: Modifier = Modifier,
 ) {
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,
-        modifier = Modifier
+        modifier = modifier
             .debouncedClickable(onClick = onClick)
             .padding(horizontal = horizontalPadding),
     ) {

--- a/feature/library/src/main/java/com/into/websoso/feature/library/filter/component/LibraryFilterBottomSheetRating.kt
+++ b/feature/library/src/main/java/com/into/websoso/feature/library/filter/component/LibraryFilterBottomSheetRating.kt
@@ -19,7 +19,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.scale
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import com.into.websoso.core.designsystem.theme.Black
+import com.into.websoso.core.designsystem.theme.Gray300
 import com.into.websoso.core.designsystem.theme.Gray100
 import com.into.websoso.core.designsystem.theme.Gray200
 import com.into.websoso.core.designsystem.theme.Gray50
@@ -70,7 +70,7 @@ internal fun LibraryFilterBottomSheetRating(
             Text(
                 text = "별점 등록 안된 작품만 보기",
                 style = WebsosoTheme.typography.title2,
-                color = Black,
+                color = Gray300,
             )
             Spacer(modifier = Modifier.weight(1f))
             Switch(

--- a/feature/library/src/main/java/com/into/websoso/feature/library/filter/component/LibraryFilterBottomSheetRating.kt
+++ b/feature/library/src/main/java/com/into/websoso/feature/library/filter/component/LibraryFilterBottomSheetRating.kt
@@ -68,8 +68,8 @@ internal fun LibraryFilterBottomSheetRating(
             verticalAlignment = Alignment.CenterVertically,
         ) {
             Text(
-                text = "별점 등록 안 된 작품만 보기",
-                style = WebsosoTheme.typography.body2,
+                text = "별점 등록 안된 작품만 보기",
+                style = WebsosoTheme.typography.title2,
                 color = Black,
             )
             Spacer(modifier = Modifier.weight(1f))
@@ -77,6 +77,7 @@ internal fun LibraryFilterBottomSheetRating(
                 checked = ratingFilter.isRatingless,
                 onCheckedChange = { onRatinglessToggle() },
                 modifier = Modifier.scale(0.85f),
+                thumbContent = {},
                 colors = SwitchDefaults.colors(
                     checkedThumbColor = White,
                     checkedTrackColor = Primary100,

--- a/feature/library/src/main/java/com/into/websoso/feature/library/filter/component/LibraryFilterBottomSheetReadStatus.kt
+++ b/feature/library/src/main/java/com/into/websoso/feature/library/filter/component/LibraryFilterBottomSheetReadStatus.kt
@@ -1,14 +1,20 @@
 package com.into.websoso.feature.library.filter.component
 
 import android.annotation.SuppressLint
-import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.width
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.into.websoso.core.designsystem.theme.Gray70
 import com.into.websoso.core.designsystem.theme.WebsosoTheme
 import com.into.websoso.core.resource.R.drawable.ic_library_finished
 import com.into.websoso.core.resource.R.drawable.ic_library_reading
@@ -26,35 +32,51 @@ internal fun LibraryFilterBottomSheetReadStatus(
     onReadStatusClick: (ReadStatus) -> Unit,
 ) {
     Row(
-        horizontalArrangement = Arrangement.SpaceBetween,
         verticalAlignment = Alignment.CenterVertically,
-        modifier = Modifier.fillMaxWidth(),
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(IntrinsicSize.Min),
     ) {
         LibraryFilterBottomSheetClickableItem(
             icon = ic_library_reading,
             iconTitle = "보는 중",
             iconSize = 24.dp,
-            horizontalPadding = 36.dp,
+            horizontalPadding = 0.dp,
             onClick = { onReadStatusClick(WATCHING) },
             isSelected = readStatuses[WATCHING],
+            modifier = Modifier.weight(1f),
         )
+        ReadStatusDivider()
         LibraryFilterBottomSheetClickableItem(
             icon = ic_library_finished,
             iconTitle = "봤어요",
             iconSize = 24.dp,
-            horizontalPadding = 36.dp,
+            horizontalPadding = 0.dp,
             onClick = { onReadStatusClick(WATCHED) },
             isSelected = readStatuses[WATCHED],
+            modifier = Modifier.weight(1f),
         )
+        ReadStatusDivider()
         LibraryFilterBottomSheetClickableItem(
             icon = ic_library_stopped,
             iconTitle = "하차",
             iconSize = 24.dp,
-            horizontalPadding = 36.dp,
+            horizontalPadding = 0.dp,
             onClick = { onReadStatusClick(QUIT) },
             isSelected = readStatuses[QUIT],
+            modifier = Modifier.weight(1f),
         )
     }
+}
+
+@Composable
+private fun ReadStatusDivider() {
+    Box(
+        modifier = Modifier
+            .fillMaxHeight()
+            .width(1.dp)
+            .background(Gray70),
+    )
 }
 
 @Preview(showBackground = true)

--- a/feature/library/src/main/java/com/into/websoso/feature/library/filter/component/LibraryFilterChip.kt
+++ b/feature/library/src/main/java/com/into/websoso/feature/library/filter/component/LibraryFilterChip.kt
@@ -43,7 +43,7 @@ internal fun LibraryFilterTagChip(
         isSelected = isSelected,
         onClick = onClick,
         cornerRadius = 20.dp,
-        horizontalPadding = 13.dp,
+        horizontalPadding = 9.5.dp,
         verticalPadding = 7.dp,
         modifier = modifier,
     )
@@ -96,7 +96,7 @@ private fun LibraryFilterChipBase(
     ) {
         Text(
             text = label,
-            style = WebsosoTheme.typography.body2,
+            style = WebsosoTheme.typography.body5,
             color = textColor,
         )
     }
@@ -125,7 +125,7 @@ internal fun LibraryFilterRemovableChip(
     ) {
         Text(
             text = label,
-            style = WebsosoTheme.typography.body2,
+            style = WebsosoTheme.typography.body5,
             color = Primary100,
         )
         Image(

--- a/feature/library/src/main/java/com/into/websoso/feature/library/filter/component/LibraryFilterSelectedChips.kt
+++ b/feature/library/src/main/java/com/into/websoso/feature/library/filter/component/LibraryFilterSelectedChips.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -28,7 +29,8 @@ internal fun LibraryFilterSelectedChips(
     Row(
         modifier = modifier
             .fillMaxWidth()
-            .horizontalScroll(rememberScrollState()),
+            .horizontalScroll(rememberScrollState())
+            .padding(end = 20.dp),
         horizontalArrangement = Arrangement.spacedBy(6.dp),
     ) {
         filterUiState.readStatuses.value.filterValues { it }.keys.forEach { status ->

--- a/feature/library/src/main/java/com/into/websoso/feature/library/filter/component/LibraryFilterTabRow.kt
+++ b/feature/library/src/main/java/com/into/websoso/feature/library/filter/component/LibraryFilterTabRow.kt
@@ -37,7 +37,9 @@ internal fun LibraryFilterTabRow(
     modifier: Modifier = Modifier,
 ) {
     Row(
-        modifier = modifier.horizontalScroll(rememberScrollState()),
+        modifier = modifier
+            .horizontalScroll(rememberScrollState())
+            .padding(end = 20.dp),
         horizontalArrangement = Arrangement.spacedBy(18.dp),
         verticalAlignment = Alignment.Bottom,
     ) {

--- a/feature/library/src/main/java/com/into/websoso/feature/library/model/LibraryFilterUiModel.kt
+++ b/feature/library/src/main/java/com/into/websoso/feature/library/model/LibraryFilterUiModel.kt
@@ -24,13 +24,13 @@ data class LibraryFilterUiModel(
     val readStatusLabelText: String
         get() = createLabel(
             values = readStatuses.selectedLabels,
-            labelTitle = "읽기 상태",
+            labelTitle = "읽기상태",
         )
 
     val attractivePointLabelText: String
         get() = createLabel(
             values = attractivePoints.selectedLabels,
-            labelTitle = "매력 포인트",
+            labelTitle = "매력포인트",
         )
 
     val genreLabelText: String
@@ -42,7 +42,7 @@ data class LibraryFilterUiModel(
     val seriesStatusLabelText: String
         get() = createLabel(
             values = seriesStatuses.selectedLabels,
-            labelTitle = "연재 상태",
+            labelTitle = "연재상태",
         )
 
     val keywordLabelText: String


### PR DESCRIPTION
## 📌𝘐𝘴𝘴𝘶𝘦𝘴
- closed #918 

## 📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯

### 서재 필터 바텀시트
- 필터 태그 칩 좌우 패딩 조정 (13 → 9.5dp)
- 선택 칩 목록 가로 스크롤 끝 패딩(20dp) 추가
- 상단 필터 탭 로우 오른쪽 트레일링 패딩(20dp) 추가 → 키워드 탭까지 가로 스크롤 여백 확보
- 읽기상태(보는중 / 봤어요 / 하차) 항목 사이 세로 구분선 추가
- 선택 칩 노출 시 하단 가로 구분선 추가 (미선택 시 미노출)
- 칩 선택 시 시트가 위로 커지지 않고 콘텐츠가 아래로 밀리도록 시트 전체 높이 고정
- 별점 토글(Switch) thumb 크기를 상태(on/off)와 무관하게 고정
- "별점 등록 안된 작품만 보기" 텍스트 스타일 title2로 변경 + 맞춤법 수정
- 초기화 / 작품 찾기 버튼을 작품 탐색 탭 버튼과 동일하게 통일

### 서재 상단바 / 정렬
- 리스트 · 갤러리 뷰 토글 아이콘 크기 12 → 18dp
- 정렬 라벨(최신순) 스타일 body5 → body4
- 정렬 바텀시트: 선택 시에도 텍스트는 중앙 정렬 유지 + 체크 아이콘만 왼쪽 오버레이, 선택 배경 라운드 40 / Primary20, 미선택 텍스트 색 Gray200

### 버그 수정
- 연재상태 필터 요청 파라미터 오타 수정 (`isComplete` → `isCompleted`) — 서재 연재중 / 완결작 필터 미동작 해결
- 등록 키워드 미표시 수정: `userId`가 로그인 후 비동기로 세팅되기 전에 키워드를 요청하던 레이스 → `userId`를 반응형(StateFlow)으로 노출하고 유효값을 기다린 뒤 요청

## 📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵


## 💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 내 서재 필터와 정렬 화면의 레이아웃과 스타일이 개선되어 더 보기 쉬워졌습니다.
  * 선택된 필터 칩, 읽기 상태 선택, 리셋/검색 버튼 구성이 더 직관적으로 정리되었습니다.

* **Bug Fixes**
  * 등록 키워드와 사용자 ID가 더 안정적으로 연동되도록 개선되었습니다.
  * 작품 목록 조회 시 완료 여부 관련 조건이 최신 형식으로 반영되었습니다.
  * 등록 키워드 로딩 실패 시 처리와 로그가 보강되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->