### PR TITLE
fix: 서재 datastore sorttype 마이그레이션

### DIFF
--- a/core/datastore/src/main/java/com/into/websoso/core/datastore/datasource/library/mapper/LibraryFilterMapper.kt
+++ b/core/datastore/src/main/java/com/into/websoso/core/datastore/datasource/library/mapper/LibraryFilterMapper.kt
@@ -1,6 +1,7 @@
 package com.into.websoso.core.datastore.datasource.library.mapper
 
 import com.into.websoso.core.datastore.datasource.library.model.LibraryFilterPreferences
+import com.into.websoso.data.filter.model.DEFAULT_SORT_CRITERIA
 import com.into.websoso.data.filter.model.LibraryFilter
 
 internal fun LibraryFilter.toPreferences(): LibraryFilterPreferences =
@@ -17,9 +18,30 @@ internal fun LibraryFilter.toPreferences(): LibraryFilterPreferences =
         keywords = keywords,
     )
 
+// 1.8.x 이하는 정렬 기준을 enum 이름("RECENT", "OLD")으로 저장했다.
+// 서버 v2 명세 key로 마이그레이션하고, 알 수 없는 값은 기본값으로 대체한다.
+private val LEGACY_SORT_CRITERIA_MIGRATION = mapOf(
+    "RECENT" to "created_desc",
+    "OLD" to "created_asc",
+)
+
+private val VALID_SORT_CRITERIA_KEYS = setOf(
+    "created_desc",
+    "created_asc",
+    "title",
+    "read_date",
+    "rating_desc",
+    "rating_asc",
+)
+
+private fun String.toMigratedSortCriteria(): String =
+    LEGACY_SORT_CRITERIA_MIGRATION[this]
+        ?: takeIf { it in VALID_SORT_CRITERIA_KEYS }
+        ?: DEFAULT_SORT_CRITERIA
+
 internal fun LibraryFilterPreferences.toData(): LibraryFilter =
     LibraryFilter(
-        sortCriteria = sortCriteria,
+        sortCriteria = sortCriteria.toMigratedSortCriteria(),
         isInterested = isInterested,
         readStatuses = readStatuses,
         attractivePoints = attractivePoints,


### PR DESCRIPTION
## 📌𝘐𝘴𝘴𝘶𝘦𝘴
- closed #926 

## 📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯
- 
-

## 📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵


## 💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴
https://discord.com/channels/1185753783020568648/1530072575114346506 참고하시면 될 것 같습니다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 기존에 저장된 정렬 기준을 최신 정렬 방식으로 자동 변환합니다.
  * 지원되지 않거나 잘못된 정렬 기준은 기본 정렬 기준으로 보정됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->