### PR TITLE
feat: 컬렉션 모듈 및 마이페이지 진입 구조 구현

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -93,6 +93,7 @@ dependencies {
     implementation(projects.feature.signin)
     implementation(projects.feature.library)
     implementation(projects.feature.feed)
+    implementation(projects.feature.collection)
 
     // AndroidX 및 Jetpack 기본 라이브러리
     implementation(libs.androidx.core.ktx)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -77,6 +77,10 @@
             android:exported="false"
             android:screenOrientation="portrait" />
         <activity
+            android:name=".ui.collection.CollectionActivity"
+            android:exported="false"
+            android:screenOrientation="portrait" />
+        <activity
             android:name=".ui.notification.NotificationActivity"
             android:exported="false"
             android:screenOrientation="portrait" />

--- a/app/src/main/java/com/into/websoso/ui/collection/CollectionActivity.kt
+++ b/app/src/main/java/com/into/websoso/ui/collection/CollectionActivity.kt
@@ -1,0 +1,25 @@
+package com.into.websoso.ui.collection
+
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import com.into.websoso.core.designsystem.theme.WebsosoTheme
+import com.into.websoso.feature.collection.CollectionNavHost
+
+class CollectionActivity : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        setContent {
+            WebsosoTheme {
+                CollectionNavHost()
+            }
+        }
+    }
+
+    companion object {
+        fun getIntent(context: Context): Intent = Intent(context, CollectionActivity::class.java)
+    }
+}

--- a/app/src/main/java/com/into/websoso/ui/collection/CollectionActivity.kt
+++ b/app/src/main/java/com/into/websoso/ui/collection/CollectionActivity.kt
@@ -7,7 +7,9 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import com.into.websoso.core.designsystem.theme.WebsosoTheme
 import com.into.websoso.feature.collection.CollectionNavHost
+import dagger.hilt.android.AndroidEntryPoint
 
+@AndroidEntryPoint
 class CollectionActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/app/src/main/java/com/into/websoso/ui/main/myPage/MyPageFragment.kt
+++ b/app/src/main/java/com/into/websoso/ui/main/myPage/MyPageFragment.kt
@@ -7,6 +7,7 @@ import android.text.Spanned.SPAN_EXCLUSIVE_EXCLUSIVE
 import android.text.style.ForegroundColorSpan
 import android.view.View
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.core.content.ContextCompat
 import androidx.core.view.isVisible
 import androidx.fragment.app.activityViewModels
@@ -28,11 +29,14 @@ import com.into.websoso.core.common.util.SingleEventHandler
 import com.into.websoso.core.common.util.getS3ImageUrl
 import com.into.websoso.core.common.util.setListViewHeightBasedOnChildren
 import com.into.websoso.core.common.util.tracker.Tracker
+import com.into.websoso.core.designsystem.theme.WebsosoTheme
 import com.into.websoso.core.resource.R.drawable.img_loading_thumbnail
 import com.into.websoso.core.resource.R.string.my_library_attractive_point_fixed_text
 import com.into.websoso.data.model.GenrePreferenceEntity
 import com.into.websoso.data.model.NovelPreferenceEntity
 import com.into.websoso.databinding.FragmentMyPageBinding
+import com.into.websoso.feature.collection.CollectionEntry
+import com.into.websoso.ui.collection.CollectionActivity
 import com.into.websoso.ui.main.MainViewModel
 import com.into.websoso.ui.main.myPage.MyLibraryViewModel
 import com.into.websoso.ui.main.myPage.adapter.RestGenrePreferenceAdapter
@@ -77,6 +81,7 @@ class MyPageFragment : BaseFragment<FragmentMyPageBinding>(fragment_my_page) {
         setupObserver()
         onProfileEditClick()
         onStorageButtonClick()
+        setupCollectionEntry()
         tracker.trackEvent("mypage")
     }
 
@@ -90,6 +95,23 @@ class MyPageFragment : BaseFragment<FragmentMyPageBinding>(fragment_my_page) {
         binding.myPageViewModel = myPageViewModel
         binding.myLibraryViewModel = myLibraryViewModel
         binding.lifecycleOwner = viewLifecycleOwner
+    }
+
+    private fun setupCollectionEntry() {
+        binding.cvMyPageCollectionEntry.apply {
+            setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+            setContent {
+                WebsosoTheme {
+                    CollectionEntry(onClick = ::navigateToCollection)
+                }
+            }
+        }
+    }
+
+    private fun navigateToCollection() {
+        singleEventHandler.throttleFirst {
+            startActivity(CollectionActivity.getIntent(requireContext()))
+        }
     }
 
     private fun setupRestGenrePreferenceAdapter() {

--- a/app/src/main/java/com/into/websoso/ui/main/myPage/MyPageFragment.kt
+++ b/app/src/main/java/com/into/websoso/ui/main/myPage/MyPageFragment.kt
@@ -38,7 +38,6 @@ import com.into.websoso.databinding.FragmentMyPageBinding
 import com.into.websoso.feature.collection.CollectionEntry
 import com.into.websoso.ui.collection.CollectionActivity
 import com.into.websoso.ui.main.MainViewModel
-import com.into.websoso.ui.main.myPage.MyLibraryViewModel
 import com.into.websoso.ui.main.myPage.adapter.RestGenrePreferenceAdapter
 import com.into.websoso.ui.main.myPage.model.MyLibraryUiState
 import com.into.websoso.ui.profileEdit.ProfileEditActivity

--- a/app/src/main/java/com/into/websoso/ui/main/myPage/MyPageFragment.kt
+++ b/app/src/main/java/com/into/websoso/ui/main/myPage/MyPageFragment.kt
@@ -109,9 +109,7 @@ class MyPageFragment : BaseFragment<FragmentMyPageBinding>(fragment_my_page) {
     }
 
     private fun navigateToCollection() {
-        singleEventHandler.throttleFirst {
-            startActivity(CollectionActivity.getIntent(requireContext()))
-        }
+        startActivity(CollectionActivity.getIntent(requireContext()))
     }
 
     private fun setupRestGenrePreferenceAdapter() {

--- a/app/src/main/res/layout/fragment_my_page.xml
+++ b/app/src/main/res/layout/fragment_my_page.xml
@@ -279,11 +279,28 @@
                         app:layout_constraintStart_toStartOf="parent"
                         app:layout_constraintTop_toBottomOf="@id/cl_my_page_user_profile" />
 
+                    <androidx.compose.ui.platform.ComposeView
+                        android:id="@+id/cv_my_page_collection_entry"
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintTop_toBottomOf="@id/view_my_page_profile_divider" />
+
+                    <View
+                        android:id="@+id/view_my_page_collection_divider"
+                        android:layout_width="0dp"
+                        android:layout_height="3dp"
+                        android:background="@color/gray_50_F4F5F8"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintTop_toBottomOf="@id/cv_my_page_collection_entry" />
+
                     <androidx.constraintlayout.widget.ConstraintLayout
                         android:id="@+id/cl_my_library_genre_preference"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        app:layout_constraintTop_toBottomOf="@id/view_my_page_profile_divider"
+                        app:layout_constraintTop_toBottomOf="@id/view_my_page_collection_divider"
                         tools:layout_editor_absoluteX="0dp">
 
                         <TextView
@@ -447,7 +464,7 @@
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
                         android:visibility="gone"
-                        app:layout_constraintTop_toBottomOf="@id/view_my_page_profile_divider">
+                        app:layout_constraintTop_toBottomOf="@id/view_my_page_collection_divider">
 
                         <TextView
                             android:id="@+id/tv_my_library_preference_analysis_title"

--- a/feature/collection/build.gradle.kts
+++ b/feature/collection/build.gradle.kts
@@ -7,3 +7,7 @@ plugins {
 android {
     setNamespace("feature.collection")
 }
+
+dependencies {
+    implementation(libs.navigation.compose)
+}

--- a/feature/collection/build.gradle.kts
+++ b/feature/collection/build.gradle.kts
@@ -1,0 +1,9 @@
+import com.into.websoso.setNamespace
+
+plugins {
+    id("websoso.android.feature")
+}
+
+android {
+    setNamespace("feature.collection")
+}

--- a/feature/collection/src/main/AndroidManifest.xml
+++ b/feature/collection/src/main/AndroidManifest.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest>
+
+</manifest>

--- a/feature/collection/src/main/java/com/into/websoso/feature/collection/CollectionEntry.kt
+++ b/feature/collection/src/main/java/com/into/websoso/feature/collection/CollectionEntry.kt
@@ -1,0 +1,72 @@
+package com.into.websoso.feature.collection
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.into.websoso.core.designsystem.theme.Gray300
+import com.into.websoso.core.designsystem.theme.Primary100
+import com.into.websoso.core.designsystem.theme.WebsosoTheme
+import com.into.websoso.core.designsystem.theme.White
+import com.into.websoso.core.resource.R
+
+@Composable
+fun CollectionEntry(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    collectionCount: Int = 0,
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .background(White)
+            .clickable(onClick = onClick)
+            .padding(
+                horizontal = 20.dp,
+                vertical = 20.dp,
+            ),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            text = "컬렉션 ",
+            color = Gray300,
+            style = WebsosoTheme.typography.title2,
+        )
+        Text(
+            text = collectionCount.toString(),
+            color = Primary100,
+            style = WebsosoTheme.typography.title2,
+        )
+        Text(
+            text = "개",
+            color = Gray300,
+            style = WebsosoTheme.typography.title2,
+        )
+        Spacer(modifier = Modifier.weight(1f))
+        Image(
+            imageVector = ImageVector.vectorResource(R.drawable.btn_setting_right),
+            contentDescription = null,
+            modifier = Modifier.size(24.dp),
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun CollectionEntryPreview() {
+    WebsosoTheme {
+        CollectionEntry(onClick = {})
+    }
+}

--- a/feature/collection/src/main/java/com/into/websoso/feature/collection/CollectionEntry.kt
+++ b/feature/collection/src/main/java/com/into/websoso/feature/collection/CollectionEntry.kt
@@ -2,7 +2,6 @@ package com.into.websoso.feature.collection
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -16,6 +15,7 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.into.websoso.core.common.extensions.debouncedClickable
 import com.into.websoso.core.designsystem.theme.Gray300
 import com.into.websoso.core.designsystem.theme.Primary100
 import com.into.websoso.core.designsystem.theme.WebsosoTheme
@@ -32,7 +32,7 @@ fun CollectionEntry(
         modifier = modifier
             .fillMaxWidth()
             .background(White)
-            .clickable(onClick = onClick)
+            .debouncedClickable(onClick = onClick)
             .padding(
                 horizontal = 20.dp,
                 vertical = 20.dp,

--- a/feature/collection/src/main/java/com/into/websoso/feature/collection/CollectionEntry.kt
+++ b/feature/collection/src/main/java/com/into/websoso/feature/collection/CollectionEntry.kt
@@ -13,6 +13,9 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.into.websoso.core.common.extensions.debouncedClickable
@@ -40,17 +43,13 @@ fun CollectionEntry(
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Text(
-            text = "컬렉션 ",
-            color = Gray300,
-            style = WebsosoTheme.typography.title2,
-        )
-        Text(
-            text = collectionCount.toString(),
-            color = Primary100,
-            style = WebsosoTheme.typography.title2,
-        )
-        Text(
-            text = "개",
+            text = buildAnnotatedString {
+                append("컬렉션 ")
+                withStyle(style = SpanStyle(color = Primary100)) {
+                    append(collectionCount.toString())
+                }
+                append("개")
+            },
             color = Gray300,
             style = WebsosoTheme.typography.title2,
         )

--- a/feature/collection/src/main/java/com/into/websoso/feature/collection/CollectionNavHost.kt
+++ b/feature/collection/src/main/java/com/into/websoso/feature/collection/CollectionNavHost.kt
@@ -1,0 +1,26 @@
+package com.into.websoso.feature.collection
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.rememberNavController
+
+private const val COLLECTION_ROUTE = "collection"
+
+@Composable
+fun CollectionNavHost(
+    modifier: Modifier = Modifier,
+) {
+    val navController = rememberNavController()
+
+    NavHost(
+        navController = navController,
+        startDestination = COLLECTION_ROUTE,
+        modifier = modifier,
+    ) {
+        composable(route = COLLECTION_ROUTE) {
+            CollectionScreen()
+        }
+    }
+}

--- a/feature/collection/src/main/java/com/into/websoso/feature/collection/CollectionNavHost.kt
+++ b/feature/collection/src/main/java/com/into/websoso/feature/collection/CollectionNavHost.kt
@@ -9,9 +9,7 @@ import androidx.navigation.compose.rememberNavController
 private const val COLLECTION_ROUTE = "collection"
 
 @Composable
-fun CollectionNavHost(
-    modifier: Modifier = Modifier,
-) {
+fun CollectionNavHost(modifier: Modifier = Modifier) {
     val navController = rememberNavController()
 
     NavHost(

--- a/feature/collection/src/main/java/com/into/websoso/feature/collection/CollectionScreen.kt
+++ b/feature/collection/src/main/java/com/into/websoso/feature/collection/CollectionScreen.kt
@@ -17,9 +17,7 @@ import com.into.websoso.core.designsystem.theme.WebsosoTheme
 import com.into.websoso.core.designsystem.theme.White
 
 @Composable
-fun CollectionScreen(
-    modifier: Modifier = Modifier,
-) {
+fun CollectionScreen(modifier: Modifier = Modifier) {
     Column(
         modifier = modifier
             .fillMaxSize()

--- a/feature/collection/src/main/java/com/into/websoso/feature/collection/CollectionScreen.kt
+++ b/feature/collection/src/main/java/com/into/websoso/feature/collection/CollectionScreen.kt
@@ -1,0 +1,50 @@
+package com.into.websoso.feature.collection
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.into.websoso.core.designsystem.theme.Black
+import com.into.websoso.core.designsystem.theme.Gray200
+import com.into.websoso.core.designsystem.theme.WebsosoTheme
+import com.into.websoso.core.designsystem.theme.White
+
+@Composable
+fun CollectionScreen(
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .background(White)
+            .padding(horizontal = 20.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center,
+    ) {
+        Text(
+            text = "컬렉션",
+            color = Black,
+            style = WebsosoTheme.typography.headline1,
+        )
+        Text(
+            text = "임시화면",
+            color = Gray200,
+            style = WebsosoTheme.typography.body2,
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun CollectionScreenPreview() {
+    WebsosoTheme {
+        CollectionScreen()
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -32,6 +32,7 @@ lifecycle-extensions = "2.2.0"
 datastore-preferences = "1.2.0"
 security-crypto = "1.1.0"
 paging = "3.3.6"
+navigation = "2.9.8"
 
 # Testing Libraries
 junit = "4.13.2"
@@ -167,6 +168,7 @@ compose-material3 = { module = "androidx.compose.material3:material3" }
 compose-runtime-livedata = { module = "androidx.compose.runtime:runtime-livedata" }
 compose-ui-tooling = { module = "androidx.compose.ui:ui-tooling" }
 compose-hilt-navigation = { module = "androidx.hilt:hilt-navigation-compose", version.ref = "hilt-navigation-compose" }
+navigation-compose = { module = "androidx.navigation:navigation-compose", version.ref = "navigation" }
 lifecycle-runtime-compose = { module = "androidx.lifecycle:lifecycle-runtime-compose" }
 androidx-foundation = { group = "androidx.compose.foundation", name = "foundation", version.ref = "foundation" }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -44,6 +44,7 @@ include(
     ":feature:signin",
     ":feature:library",
     ":feature:feed",
+    ":feature:collection",
 )
 include(":domain:feed")
 include(":data:user")


### PR DESCRIPTION
## 📌𝘐𝘴𝘴𝘶𝘦𝘴
- closed #933 

## 📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯

### Overview

컬렉션 기능을 기존 앱과 분리해 확장할 수 있도록 `feature:collection` 모듈과 전용 진입 구조를 추가합니다.  
마이페이지의 컬렉션 항목에서 별도 `CollectionActivity`로 이동하고, Activity 내부에서는 Navigation Compose 기반의 `CollectionNavHost`가 컬렉션 화면 흐름을 담당합니다.

### 작업 배경

기존 `app` 모듈의 마이페이지는 XML 기반 화면이므로, 컬렉션 진입 UI만 `ComposeView`로 삽입해 기존 화면 구조를 유지했습니다.  
컬렉션 내부 화면은 이후 목록·생성·검색 화면이 추가될 것을 고려해 별도 feature 모듈과 Activity, NavHost를 진입 경계로 사용합니다.

이 PR은 컬렉션 전체 작업을 나눈 Stacked PR의 첫 번째 단계이며, 실제 컬렉션 목록과 생성·검색 기능은 후속 PR에서 다룹니다.

### 주요 변경 사항

#### 1. 컬렉션 feature 모듈 구성

- `feature:collection` 모듈 및 AndroidManifest 추가
- 프로젝트 설정과 `app` 모듈에 컬렉션 모듈 연결
- 컬렉션 내부 화면 이동을 위한 Navigation Compose 의존성 추가
- Navigation Compose 버전 `2.9.8` 등록

#### 2. 컬렉션 전용 Activity 및 내부 Navigation 구성

- Compose 기반 `CollectionActivity` 추가
- Hilt 사용을 위한 `@AndroidEntryPoint` 적용
- 외부 노출이 필요하지 않아 Manifest에 `exported=false`로 등록
- `WebsosoTheme` 안에서 `CollectionNavHost` 실행
- 최초 진입 destination으로 기본 `CollectionScreen` 연결

#### 3. 마이페이지 컬렉션 진입부 연결

- 기존 XML 마이페이지에 `ComposeView` 추가
- ViewTree 생명주기에 맞춰 Compose가 해제되도록 `DisposeOnViewTreeLifecycleDestroyed` 적용
- 컬렉션 개수와 우측 이동 아이콘을 표시하는 `CollectionEntry` 구현
- 연속 클릭을 방지하기 위해 기존 `SingleEventHandler.throttleFirst` 패턴 재사용
- 컬렉션 항목 클릭 시 `CollectionActivity` 실행

### 이번 PR에서 제외한 범위

- 컬렉션 목록 최종 UI
- 컬렉션 생성 화면
- 작품 검색 및 서재 선택
- 컬렉션 API 연결
- 실제 컬렉션 개수 조회
- 딥링크

위 기능은 후속 Stacked PR에서 단계별로 추가합니다.

### 검증

- `./gradlew testDebugUnitTest :app:assembleDebug ktlintCheck --console=plain`
- 전체 단위 테스트 성공
- 앱 Debug 빌드 성공
- ktlint 성공

## 📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵
<img width="360" height="780" alt="Screenshot_20260818_183543" src="https://github.com/user-attachments/assets/a2e5569c-0562-4b52-bebf-0836b5dc9500" />



## 💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴

### 리뷰 포인트

- `app → feature:collection` 의존 방향이 기존 멀티 모듈 구조에 적합한지
- XML 화면 내부의 `ComposeView` 생명주기 설정이 적절한지
- 별도 Activity와 내부 NavHost로 컬렉션 흐름을 분리한 진입 구조가 적절한지
- 현재 컬렉션 개수는 API 연결 전 단계이므로 기본값 `0`으로 표시되는 점

### Stacked PR 안내

- Base: `develop`
- Head: `feat/933`
- 다음 PR은 `feat/933`을 base로 하여 컬렉션 목록 UI 변경만 분리할 예정입니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 새로운 기능
- 마이페이지에 컬렉션 진입 영역을 추가했습니다.
- 컬렉션 개수와 설정 아이콘을 확인할 수 있습니다.
- 컬렉션 영역을 누르면 전용 컬렉션 화면으로 이동합니다.
- 컬렉션 화면과 기본 탐색 구조를 새로 제공합니다.
- 현재 컬렉션 화면에는 제목과 안내용 임시 콘텐츠가 표시됩니다.
- 화면은 세로 방향으로 제공되며, 컬렉션 화면에서 향후 관련 기능을 이용할 수 있습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->