### PR TITLE
feat: 컬렉션 목록 화면 UI 구현

### DIFF
--- a/app/src/main/java/com/into/websoso/ui/collection/CollectionActivity.kt
+++ b/app/src/main/java/com/into/websoso/ui/collection/CollectionActivity.kt
@@ -16,7 +16,7 @@ class CollectionActivity : ComponentActivity() {
 
         setContent {
             WebsosoTheme {
-                CollectionNavHost()
+                CollectionNavHost(onNavigateBack = ::finish)
             }
         }
     }

--- a/app/src/main/java/com/into/websoso/ui/main/myPage/MyPageFragment.kt
+++ b/app/src/main/java/com/into/websoso/ui/main/myPage/MyPageFragment.kt
@@ -35,7 +35,7 @@ import com.into.websoso.core.resource.R.string.my_library_attractive_point_fixed
 import com.into.websoso.data.model.GenrePreferenceEntity
 import com.into.websoso.data.model.NovelPreferenceEntity
 import com.into.websoso.databinding.FragmentMyPageBinding
-import com.into.websoso.feature.collection.CollectionEntry
+import com.into.websoso.feature.collection.component.CollectionEntry
 import com.into.websoso.ui.collection.CollectionActivity
 import com.into.websoso.ui.main.MainViewModel
 import com.into.websoso.ui.main.myPage.adapter.RestGenrePreferenceAdapter

--- a/app/src/main/java/com/into/websoso/ui/main/myPage/MyPageFragment.kt
+++ b/app/src/main/java/com/into/websoso/ui/main/myPage/MyPageFragment.kt
@@ -35,7 +35,7 @@ import com.into.websoso.core.resource.R.string.my_library_attractive_point_fixed
 import com.into.websoso.data.model.GenrePreferenceEntity
 import com.into.websoso.data.model.NovelPreferenceEntity
 import com.into.websoso.databinding.FragmentMyPageBinding
-import com.into.websoso.feature.collection.CollectionEntry
+import com.into.websoso.feature.collection.component.CollectionEntry
 import com.into.websoso.ui.collection.CollectionActivity
 import com.into.websoso.ui.main.MainViewModel
 import com.into.websoso.ui.main.myPage.MyLibraryViewModel

--- a/core/resource/src/main/res/drawable/ic_collection_create.xml
+++ b/core/resource/src/main/res/drawable/ic_collection_create.xml
@@ -1,0 +1,23 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="18dp"
+    android:height="18dp"
+    android:viewportWidth="19.44"
+    android:viewportHeight="19.44">
+    <path
+        android:pathData="M9.707,0.36C14.838,0.36 19.08,4.593 19.08,9.716C19.08,14.847 14.847,19.08 9.716,19.08C4.593,19.08 0.36,14.847 0.36,9.716C0.36,4.594 4.584,0.36 9.707,0.36Z"
+        android:fillColor="#FFFFFF"
+        android:strokeColor="#EEEEF2"
+        android:strokeWidth="0.72" />
+    <path
+        android:pathData="M5.4,9.72L14.04,9.72"
+        android:fillColor="#00000000"
+        android:strokeColor="#6A5DFD"
+        android:strokeLineCap="round"
+        android:strokeWidth="2.254" />
+    <path
+        android:pathData="M9.72,5.4L9.72,14.04"
+        android:fillColor="#00000000"
+        android:strokeColor="#6A5DFD"
+        android:strokeLineCap="round"
+        android:strokeWidth="2.254" />
+</vector>

--- a/core/resource/src/main/res/values/strings.xml
+++ b/core/resource/src/main/res/values/strings.xml
@@ -445,4 +445,8 @@
     <!-- 서재 뷰-->
     <string name="library">서재</string>
     <string name="library_filter_remove_selected_chip">필터 제거</string>
+
+    <!-- 컬렉션 뷰 -->
+    <string name="collection_my">내 컬렉션</string>
+    <string name="collection_liked">좋아요한 컬렉션</string>
 </resources>

--- a/feature/collection/src/main/java/com/into/websoso/feature/collection/CollectionNavHost.kt
+++ b/feature/collection/src/main/java/com/into/websoso/feature/collection/CollectionNavHost.kt
@@ -10,6 +10,7 @@ private const val COLLECTION_ROUTE = "collection"
 
 @Composable
 fun CollectionNavHost(
+    onNavigateBack: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val navController = rememberNavController()
@@ -20,7 +21,7 @@ fun CollectionNavHost(
         modifier = modifier,
     ) {
         composable(route = COLLECTION_ROUTE) {
-            CollectionScreen()
+            CollectionScreen(onNavigateBack = onNavigateBack)
         }
     }
 }

--- a/feature/collection/src/main/java/com/into/websoso/feature/collection/CollectionNavHost.kt
+++ b/feature/collection/src/main/java/com/into/websoso/feature/collection/CollectionNavHost.kt
@@ -9,7 +9,10 @@ import androidx.navigation.compose.rememberNavController
 private const val COLLECTION_ROUTE = "collection"
 
 @Composable
-fun CollectionNavHost(modifier: Modifier = Modifier) {
+fun CollectionNavHost(
+    onNavigateBack: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
     val navController = rememberNavController()
 
     NavHost(
@@ -18,7 +21,7 @@ fun CollectionNavHost(modifier: Modifier = Modifier) {
         modifier = modifier,
     ) {
         composable(route = COLLECTION_ROUTE) {
-            CollectionScreen()
+            CollectionScreen(onNavigateBack = onNavigateBack)
         }
     }
 }

--- a/feature/collection/src/main/java/com/into/websoso/feature/collection/CollectionScreen.kt
+++ b/feature/collection/src/main/java/com/into/websoso/feature/collection/CollectionScreen.kt
@@ -10,6 +10,10 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
@@ -20,12 +24,15 @@ import com.into.websoso.core.designsystem.theme.WebsosoTheme
 import com.into.websoso.core.designsystem.theme.White
 import com.into.websoso.feature.collection.component.CollectionAppBar
 import com.into.websoso.feature.collection.component.CollectionTabRow
+import com.into.websoso.feature.collection.model.CollectionTab
 
 @Composable
 fun CollectionScreen(
     onNavigateBack: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    var selectedTab by rememberSaveable { mutableStateOf(CollectionTab.MY_COLLECTION) }
+
     Column(
         modifier = modifier
             .fillMaxSize()
@@ -33,7 +40,10 @@ fun CollectionScreen(
             .statusBarsPadding(),
     ) {
         CollectionAppBar(onNavigateBack = onNavigateBack)
-        CollectionTabRow()
+        CollectionTabRow(
+            selectedTab = selectedTab,
+            onTabSelected = { selectedTab = it },
+        )
         Box(
             modifier = Modifier
                 .fillMaxWidth()

--- a/feature/collection/src/main/java/com/into/websoso/feature/collection/CollectionScreen.kt
+++ b/feature/collection/src/main/java/com/into/websoso/feature/collection/CollectionScreen.kt
@@ -23,6 +23,7 @@ import com.into.websoso.core.designsystem.theme.Gray200
 import com.into.websoso.core.designsystem.theme.WebsosoTheme
 import com.into.websoso.core.designsystem.theme.White
 import com.into.websoso.feature.collection.component.CollectionAppBar
+import com.into.websoso.feature.collection.component.CollectionCreateButton
 import com.into.websoso.feature.collection.component.CollectionTabRow
 import com.into.websoso.feature.collection.model.CollectionTab
 
@@ -43,6 +44,12 @@ fun CollectionScreen(
         CollectionTabRow(
             selectedTab = selectedTab,
             onTabSelected = { selectedTab = it },
+        )
+        CollectionCreateButton(
+            modifier = Modifier.padding(
+                horizontal = 20.dp,
+                vertical = 16.dp,
+            ),
         )
         Box(
             modifier = Modifier

--- a/feature/collection/src/main/java/com/into/websoso/feature/collection/CollectionScreen.kt
+++ b/feature/collection/src/main/java/com/into/websoso/feature/collection/CollectionScreen.kt
@@ -2,9 +2,12 @@ package com.into.websoso.feature.collection
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -15,27 +18,43 @@ import com.into.websoso.core.designsystem.theme.Black
 import com.into.websoso.core.designsystem.theme.Gray200
 import com.into.websoso.core.designsystem.theme.WebsosoTheme
 import com.into.websoso.core.designsystem.theme.White
+import com.into.websoso.feature.collection.component.CollectionAppBar
 
 @Composable
-fun CollectionScreen(modifier: Modifier = Modifier) {
+fun CollectionScreen(
+    onNavigateBack: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
     Column(
         modifier = modifier
             .fillMaxSize()
             .background(White)
-            .padding(horizontal = 20.dp),
-        horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.Center,
+            .statusBarsPadding(),
     ) {
-        Text(
-            text = "컬렉션",
-            color = Black,
-            style = WebsosoTheme.typography.headline1,
-        )
-        Text(
-            text = "임시화면",
-            color = Gray200,
-            style = WebsosoTheme.typography.body2,
-        )
+        CollectionAppBar(onNavigateBack = onNavigateBack)
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .weight(1f)
+                .padding(horizontal = 20.dp),
+            contentAlignment = Alignment.Center,
+        ) {
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.Center,
+            ) {
+                Text(
+                    text = "컬렉션",
+                    color = Black,
+                    style = WebsosoTheme.typography.headline1,
+                )
+                Text(
+                    text = "임시화면",
+                    color = Gray200,
+                    style = WebsosoTheme.typography.body2,
+                )
+            }
+        }
     }
 }
 
@@ -43,6 +62,6 @@ fun CollectionScreen(modifier: Modifier = Modifier) {
 @Composable
 private fun CollectionScreenPreview() {
     WebsosoTheme {
-        CollectionScreen()
+        CollectionScreen(onNavigateBack = {})
     }
 }

--- a/feature/collection/src/main/java/com/into/websoso/feature/collection/CollectionScreen.kt
+++ b/feature/collection/src/main/java/com/into/websoso/feature/collection/CollectionScreen.kt
@@ -19,6 +19,7 @@ import com.into.websoso.core.designsystem.theme.Gray200
 import com.into.websoso.core.designsystem.theme.WebsosoTheme
 import com.into.websoso.core.designsystem.theme.White
 import com.into.websoso.feature.collection.component.CollectionAppBar
+import com.into.websoso.feature.collection.component.CollectionTabRow
 
 @Composable
 fun CollectionScreen(
@@ -32,6 +33,7 @@ fun CollectionScreen(
             .statusBarsPadding(),
     ) {
         CollectionAppBar(onNavigateBack = onNavigateBack)
+        CollectionTabRow()
         Box(
             modifier = Modifier
                 .fillMaxWidth()

--- a/feature/collection/src/main/java/com/into/websoso/feature/collection/CollectionScreen.kt
+++ b/feature/collection/src/main/java/com/into/websoso/feature/collection/CollectionScreen.kt
@@ -2,9 +2,12 @@ package com.into.websoso.feature.collection
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -15,29 +18,43 @@ import com.into.websoso.core.designsystem.theme.Black
 import com.into.websoso.core.designsystem.theme.Gray200
 import com.into.websoso.core.designsystem.theme.WebsosoTheme
 import com.into.websoso.core.designsystem.theme.White
+import com.into.websoso.feature.collection.component.CollectionAppBar
 
 @Composable
 fun CollectionScreen(
+    onNavigateBack: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Column(
         modifier = modifier
             .fillMaxSize()
             .background(White)
-            .padding(horizontal = 20.dp),
-        horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.Center,
+            .statusBarsPadding(),
     ) {
-        Text(
-            text = "컬렉션",
-            color = Black,
-            style = WebsosoTheme.typography.headline1,
-        )
-        Text(
-            text = "임시화면",
-            color = Gray200,
-            style = WebsosoTheme.typography.body2,
-        )
+        CollectionAppBar(onNavigateBack = onNavigateBack)
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .weight(1f)
+                .padding(horizontal = 20.dp),
+            contentAlignment = Alignment.Center,
+        ) {
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.Center,
+            ) {
+                Text(
+                    text = "컬렉션",
+                    color = Black,
+                    style = WebsosoTheme.typography.headline1,
+                )
+                Text(
+                    text = "임시화면",
+                    color = Gray200,
+                    style = WebsosoTheme.typography.body2,
+                )
+            }
+        }
     }
 }
 
@@ -45,6 +62,6 @@ fun CollectionScreen(
 @Composable
 private fun CollectionScreenPreview() {
     WebsosoTheme {
-        CollectionScreen()
+        CollectionScreen(onNavigateBack = {})
     }
 }

--- a/feature/collection/src/main/java/com/into/websoso/feature/collection/CollectionScreen.kt
+++ b/feature/collection/src/main/java/com/into/websoso/feature/collection/CollectionScreen.kt
@@ -1,25 +1,18 @@
 package com.into.websoso.feature.collection
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBarsPadding
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import com.into.websoso.core.designsystem.theme.Black
-import com.into.websoso.core.designsystem.theme.Gray200
 import com.into.websoso.core.designsystem.theme.WebsosoTheme
 import com.into.websoso.core.designsystem.theme.White
 import com.into.websoso.feature.collection.component.CollectionAppBar
@@ -51,29 +44,6 @@ fun CollectionScreen(
                 vertical = 16.dp,
             ),
         )
-        Box(
-            modifier = Modifier
-                .fillMaxWidth()
-                .weight(1f)
-                .padding(horizontal = 20.dp),
-            contentAlignment = Alignment.Center,
-        ) {
-            Column(
-                horizontalAlignment = Alignment.CenterHorizontally,
-                verticalArrangement = Arrangement.Center,
-            ) {
-                Text(
-                    text = "컬렉션",
-                    color = Black,
-                    style = WebsosoTheme.typography.headline1,
-                )
-                Text(
-                    text = "임시화면",
-                    color = Gray200,
-                    style = WebsosoTheme.typography.body2,
-                )
-            }
-        }
     }
 }
 

--- a/feature/collection/src/main/java/com/into/websoso/feature/collection/component/CollectionAppBar.kt
+++ b/feature/collection/src/main/java/com/into/websoso/feature/collection/component/CollectionAppBar.kt
@@ -1,0 +1,62 @@
+package com.into.websoso.feature.collection.component
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.into.websoso.core.designsystem.theme.Black
+import com.into.websoso.core.designsystem.theme.WebsosoTheme
+import com.into.websoso.core.designsystem.theme.White
+import com.into.websoso.core.resource.R.drawable.ic_navigate_left
+
+@Composable
+internal fun CollectionAppBar(
+    onNavigateBack: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        modifier = modifier
+            .fillMaxWidth()
+            .height(44.dp)
+            .background(White),
+        contentAlignment = Alignment.Center,
+    ) {
+        IconButton(
+            onClick = onNavigateBack,
+            modifier = Modifier
+                .align(Alignment.CenterStart)
+                .padding(start = 6.dp)
+                .size(44.dp),
+        ) {
+            Image(
+                painter = painterResource(id = ic_navigate_left),
+                contentDescription = null,
+                modifier = Modifier.size(24.dp),
+            )
+        }
+        Text(
+            text = "컬렉션",
+            color = Black,
+            style = WebsosoTheme.typography.title2,
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun CollectionAppBarPreview() {
+    WebsosoTheme {
+        CollectionAppBar(onNavigateBack = {})
+    }
+}

--- a/feature/collection/src/main/java/com/into/websoso/feature/collection/component/CollectionCreateButton.kt
+++ b/feature/collection/src/main/java/com/into/websoso/feature/collection/component/CollectionCreateButton.kt
@@ -17,15 +17,13 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.into.websoso.core.designsystem.theme.Gray20
-import com.into.websoso.core.designsystem.theme.Primary30
 import com.into.websoso.core.designsystem.theme.Primary100
+import com.into.websoso.core.designsystem.theme.Primary30
 import com.into.websoso.core.designsystem.theme.WebsosoTheme
 import com.into.websoso.core.resource.R.drawable.ic_collection_create
 
 @Composable
-internal fun CollectionCreateButton(
-    modifier: Modifier = Modifier,
-) {
+internal fun CollectionCreateButton(modifier: Modifier = Modifier) {
     val shape = RoundedCornerShape(12.dp)
 
     Row(
@@ -35,8 +33,7 @@ internal fun CollectionCreateButton(
             .background(
                 color = Gray20,
                 shape = shape,
-            )
-            .border(
+            ).border(
                 width = 1.dp,
                 color = Primary30,
                 shape = shape,

--- a/feature/collection/src/main/java/com/into/websoso/feature/collection/component/CollectionCreateButton.kt
+++ b/feature/collection/src/main/java/com/into/websoso/feature/collection/component/CollectionCreateButton.kt
@@ -1,0 +1,69 @@
+package com.into.websoso.feature.collection.component
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.into.websoso.core.designsystem.theme.Gray20
+import com.into.websoso.core.designsystem.theme.Primary30
+import com.into.websoso.core.designsystem.theme.Primary100
+import com.into.websoso.core.designsystem.theme.WebsosoTheme
+import com.into.websoso.core.resource.R.drawable.ic_collection_create
+
+@Composable
+internal fun CollectionCreateButton(
+    modifier: Modifier = Modifier,
+) {
+    val shape = RoundedCornerShape(12.dp)
+
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .height(46.dp)
+            .background(
+                color = Gray20,
+                shape = shape,
+            )
+            .border(
+                width = 1.dp,
+                color = Primary30,
+                shape = shape,
+            ),
+        horizontalArrangement = Arrangement.spacedBy(
+            space = 10.dp,
+            alignment = Alignment.CenterHorizontally,
+        ),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            text = "컬렉션 만들기",
+            color = Primary100,
+            style = WebsosoTheme.typography.title3,
+        )
+        Image(
+            painter = painterResource(id = ic_collection_create),
+            contentDescription = null,
+            modifier = Modifier.size(18.dp),
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun CollectionCreateButtonPreview() {
+    WebsosoTheme {
+        CollectionCreateButton()
+    }
+}

--- a/feature/collection/src/main/java/com/into/websoso/feature/collection/component/CollectionEntry.kt
+++ b/feature/collection/src/main/java/com/into/websoso/feature/collection/component/CollectionEntry.kt
@@ -1,4 +1,4 @@
-package com.into.websoso.feature.collection
+package com.into.websoso.feature.collection.component
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background

--- a/feature/collection/src/main/java/com/into/websoso/feature/collection/component/CollectionTabRow.kt
+++ b/feature/collection/src/main/java/com/into/websoso/feature/collection/component/CollectionTabRow.kt
@@ -1,0 +1,94 @@
+package com.into.websoso.feature.collection.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.into.websoso.core.designsystem.theme.Black
+import com.into.websoso.core.designsystem.theme.Gray100
+import com.into.websoso.core.designsystem.theme.Gray70New
+import com.into.websoso.core.designsystem.theme.WebsosoTheme
+import com.into.websoso.core.designsystem.theme.White
+
+@Composable
+internal fun CollectionTabRow(
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        modifier = modifier
+            .fillMaxWidth()
+            .height(47.dp)
+            .background(White),
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(46.dp),
+        ) {
+            CollectionTab(
+                title = "내 컬렉션",
+                isSelected = true,
+                modifier = Modifier.weight(1f),
+            )
+            CollectionTab(
+                title = "좋아요한 컬렉션",
+                isSelected = false,
+                modifier = Modifier.weight(1f),
+            )
+        }
+        Box(
+            modifier = Modifier
+                .align(Alignment.BottomCenter)
+                .fillMaxWidth()
+                .height(1.dp)
+                .background(Gray70New),
+        )
+    }
+}
+
+@Composable
+private fun CollectionTab(
+    title: String,
+    isSelected: Boolean,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier
+            .height(46.dp)
+            .padding(top = 12.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Text(
+            text = title,
+            color = if (isSelected) Black else Gray100,
+            style = WebsosoTheme.typography.title2,
+        )
+        Spacer(modifier = Modifier.weight(1f))
+        if (isSelected) {
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(2.dp)
+                    .background(Black),
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun CollectionTabRowPreview() {
+    WebsosoTheme {
+        CollectionTabRow()
+    }
+}

--- a/feature/collection/src/main/java/com/into/websoso/feature/collection/component/CollectionTabRow.kt
+++ b/feature/collection/src/main/java/com/into/websoso/feature/collection/component/CollectionTabRow.kt
@@ -8,10 +8,12 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.selection.selectable
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.into.websoso.core.designsystem.theme.Black
@@ -19,9 +21,12 @@ import com.into.websoso.core.designsystem.theme.Gray100
 import com.into.websoso.core.designsystem.theme.Gray70New
 import com.into.websoso.core.designsystem.theme.WebsosoTheme
 import com.into.websoso.core.designsystem.theme.White
+import com.into.websoso.feature.collection.model.CollectionTab
 
 @Composable
 internal fun CollectionTabRow(
+    selectedTab: CollectionTab,
+    onTabSelected: (CollectionTab) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Box(
@@ -35,16 +40,14 @@ internal fun CollectionTabRow(
                 .fillMaxWidth()
                 .height(46.dp),
         ) {
-            CollectionTab(
-                title = "내 컬렉션",
-                isSelected = true,
-                modifier = Modifier.weight(1f),
-            )
-            CollectionTab(
-                title = "좋아요한 컬렉션",
-                isSelected = false,
-                modifier = Modifier.weight(1f),
-            )
+            CollectionTab.entries.forEach { tab ->
+                CollectionTabItem(
+                    title = tab.title,
+                    isSelected = tab == selectedTab,
+                    onClick = { onTabSelected(tab) },
+                    modifier = Modifier.weight(1f),
+                )
+            }
         }
         Box(
             modifier = Modifier
@@ -57,14 +60,20 @@ internal fun CollectionTabRow(
 }
 
 @Composable
-private fun CollectionTab(
+private fun CollectionTabItem(
     title: String,
     isSelected: Boolean,
+    onClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Column(
         modifier = modifier
             .height(46.dp)
+            .selectable(
+                selected = isSelected,
+                onClick = onClick,
+                role = Role.Tab,
+            )
             .padding(top = 12.dp),
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
@@ -85,10 +94,19 @@ private fun CollectionTab(
     }
 }
 
+private val CollectionTab.title: String
+    get() = when (this) {
+        CollectionTab.MY_COLLECTION -> "내 컬렉션"
+        CollectionTab.LIKED_COLLECTION -> "좋아요한 컬렉션"
+    }
+
 @Preview(showBackground = true)
 @Composable
 private fun CollectionTabRowPreview() {
     WebsosoTheme {
-        CollectionTabRow()
+        CollectionTabRow(
+            selectedTab = CollectionTab.MY_COLLECTION,
+            onTabSelected = {},
+        )
     }
 }

--- a/feature/collection/src/main/java/com/into/websoso/feature/collection/component/CollectionTabRow.kt
+++ b/feature/collection/src/main/java/com/into/websoso/feature/collection/component/CollectionTabRow.kt
@@ -73,8 +73,7 @@ private fun CollectionTabItem(
                 selected = isSelected,
                 onClick = onClick,
                 role = Role.Tab,
-            )
-            .padding(top = 12.dp),
+            ).padding(top = 12.dp),
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
         Text(

--- a/feature/collection/src/main/java/com/into/websoso/feature/collection/component/CollectionTabRow.kt
+++ b/feature/collection/src/main/java/com/into/websoso/feature/collection/component/CollectionTabRow.kt
@@ -13,6 +13,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -42,7 +43,7 @@ internal fun CollectionTabRow(
         ) {
             CollectionTab.entries.forEach { tab ->
                 CollectionTabItem(
-                    title = tab.title,
+                    title = stringResource(tab.titleRes),
                     isSelected = tab == selectedTab,
                     onClick = { onTabSelected(tab) },
                     modifier = Modifier.weight(1f),
@@ -92,12 +93,6 @@ private fun CollectionTabItem(
         }
     }
 }
-
-private val CollectionTab.title: String
-    get() = when (this) {
-        CollectionTab.MY_COLLECTION -> "내 컬렉션"
-        CollectionTab.LIKED_COLLECTION -> "좋아요한 컬렉션"
-    }
 
 @Preview(showBackground = true)
 @Composable

--- a/feature/collection/src/main/java/com/into/websoso/feature/collection/model/CollectionTab.kt
+++ b/feature/collection/src/main/java/com/into/websoso/feature/collection/model/CollectionTab.kt
@@ -1,0 +1,6 @@
+package com.into.websoso.feature.collection.model
+
+internal enum class CollectionTab {
+    MY_COLLECTION,
+    LIKED_COLLECTION,
+}

--- a/feature/collection/src/main/java/com/into/websoso/feature/collection/model/CollectionTab.kt
+++ b/feature/collection/src/main/java/com/into/websoso/feature/collection/model/CollectionTab.kt
@@ -1,6 +1,12 @@
 package com.into.websoso.feature.collection.model
 
-internal enum class CollectionTab {
-    MY_COLLECTION,
-    LIKED_COLLECTION,
+import androidx.annotation.StringRes
+import com.into.websoso.core.resource.R.string.collection_liked
+import com.into.websoso.core.resource.R.string.collection_my
+
+internal enum class CollectionTab(
+    @get:StringRes val titleRes: Int,
+) {
+    MY_COLLECTION(collection_my),
+    LIKED_COLLECTION(collection_liked),
 }


### PR DESCRIPTION
## 📌𝘐𝘴𝘴𝘶𝘦𝘴
- closed #934

## 📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯

- 컬렉션 목록 화면의 상단 앱바와 뒤로가기 동작을 구현했습니다.
- `내 컬렉션`과 `좋아요한 컬렉션` 탭 UI 및 선택 상태를 구현했습니다.
- 컬렉션 만들기 버튼 UI를 추가했습니다.
- 기존 임시 화면을 제거하고 컬렉션 목록 화면 구조로 교체했습니다.
- 컬렉션 관련 UI를 `component` 패키지로 정리했습니다.
- 컬렉션 목록 API와 생성 화면 이동은 후속 PR에서 연결합니다.

### 검증

- `./gradlew :feature:collection:compileDebugKotlin ktlintCheck --console=plain`
- 컬렉션 모듈 Debug 컴파일 성공
- ktlint 성공
- push 전 전체 단위 테스트 및 앱 Debug 빌드 성공

## 📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵
<img width="360" height="780" alt="Screenshot_20260818_191329" src="https://github.com/user-attachments/assets/5ae4451e-b4f8-4a0d-bb71-38228746bf86" />
<img width="360" height="780" alt="Screenshot_20260818_191335" src="https://github.com/user-attachments/assets/83bbe6df-6e75-4088-bfca-f6773ab02a28" />


## 💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴

- 앱바, 탭, 컬렉션 만들기 버튼의 UI 구성을 확인 부탁드립니다.
- 탭 선택 상태는 화면 내부 `rememberSaveable` 상태로 관리합니다.
- 현재 목록 데이터와 컬렉션 만들기 버튼의 화면 이동은 포함하지 않습니다.
- Base: `feat/933`
- Head: `feat/934`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새 기능**
  - 컬렉션 화면에 상단 앱 바, 뒤로 가기, 탭 메뉴를 추가했습니다.
  - ‘내 컬렉션’과 ‘좋아요한 컬렉션’ 탭을 제공합니다.
  - ‘컬렉션 만들기’ 버튼과 관련 아이콘을 추가했습니다.
  - 컬렉션 화면에서 뒤로 가기 시 이전 화면으로 정상 이동합니다.
- **개선**
  - 선택한 탭 상태가 화면 재생성 후에도 유지됩니다.
  - 컬렉션 화면의 제목과 안내 문구를 리소스 기반으로 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->