### PR TITLE
feat : 서재에서 컬렉션 작품을 선택하는 기능 구현

### DIFF
--- a/core/resource/src/main/res/values/strings.xml
+++ b/core/resource/src/main/res/values/strings.xml
@@ -460,4 +460,7 @@
     <string name="collection_create_novel_list">작품 리스트</string>
     <string name="collection_create_add_novel">작품 추가</string>
     <string name="collection_create_count">(%1$d/%2$d)</string>
+    <string name="collection_read_status_watching">보는 중</string>
+    <string name="collection_read_status_watched">봤어요</string>
+    <string name="collection_read_status_quit">하차</string>
 </resources>

--- a/data/library/src/main/java/com/into/websoso/data/library/LibraryRepository.kt
+++ b/data/library/src/main/java/com/into/websoso/data/library/LibraryRepository.kt
@@ -10,6 +10,8 @@ interface LibraryRepository {
 
     fun getLibraryFlow(): Flow<PagingData<NovelEntity>>
 
+    fun getUnfilteredLibraryFlow(): Flow<PagingData<NovelEntity>>
+
     suspend fun getRegisteredKeywords(): List<LibraryKeywordEntity>
 
     companion object {

--- a/data/library/src/main/java/com/into/websoso/data/library/repository/MyLibraryRepository.kt
+++ b/data/library/src/main/java/com/into/websoso/data/library/repository/MyLibraryRepository.kt
@@ -39,25 +39,10 @@ class MyLibraryRepository
         @OptIn(ExperimentalCoroutinesApi::class)
         override fun getLibraryFlow(): Flow<PagingData<NovelEntity>> =
             filterRepository.filterFlow
-                .flatMapLatest { currentFilter ->
-                    Pager(
-                        config = PagingConfig(
-                            pageSize = PAGE_SIZE,
-                            enablePlaceholders = false,
-                        ),
-                        pagingSourceFactory = {
-                            LibraryPagingSource(
-                                getNovels = { cursor ->
-                                    getUserNovels(cursor, currentFilter).also { result ->
-                                        _novelTotalCount.update {
-                                            result.getOrNull()?.userNovelCount ?: 0
-                                        }
-                                    }
-                                },
-                            )
-                        },
-                    ).flow
-                }
+                .flatMapLatest(::createLibraryFlow)
+
+        override fun getUnfilteredLibraryFlow(): Flow<PagingData<NovelEntity>> =
+            createLibraryFlow(LibraryFilter())
 
         override suspend fun getRegisteredKeywords(): List<LibraryKeywordEntity> {
             val userId = accountRepository.userIdFlow.first { it != 0L }
@@ -86,6 +71,25 @@ class MyLibraryRepository
                 keywords = libraryFilter.keywords.ifEmpty { null },
             )
         }
+
+        private fun createLibraryFlow(libraryFilter: LibraryFilter): Flow<PagingData<NovelEntity>> =
+            Pager(
+                config = PagingConfig(
+                    pageSize = PAGE_SIZE,
+                    enablePlaceholders = false,
+                ),
+                pagingSourceFactory = {
+                    LibraryPagingSource(
+                        getNovels = { cursor ->
+                            getUserNovels(cursor, libraryFilter).also { result ->
+                                _novelTotalCount.update {
+                                    result.getOrNull()?.userNovelCount ?: 0
+                                }
+                            }
+                        },
+                    )
+                },
+            ).flow
 
         private fun LibraryFilter.toRatingRangeParams(): Pair<Float?, Float?> =
             when {

--- a/data/library/src/main/java/com/into/websoso/data/library/repository/MyLibraryRepository.kt
+++ b/data/library/src/main/java/com/into/websoso/data/library/repository/MyLibraryRepository.kt
@@ -41,8 +41,7 @@ class MyLibraryRepository
             filterRepository.filterFlow
                 .flatMapLatest(::createLibraryFlow)
 
-        override fun getUnfilteredLibraryFlow(): Flow<PagingData<NovelEntity>> =
-            createLibraryFlow(LibraryFilter())
+        override fun getUnfilteredLibraryFlow(): Flow<PagingData<NovelEntity>> = createLibraryFlow(LibraryFilter())
 
         override suspend fun getRegisteredKeywords(): List<LibraryKeywordEntity> {
             val userId = accountRepository.userIdFlow.first { it != 0L }

--- a/data/library/src/main/java/com/into/websoso/data/library/repository/UserLibraryRepository.kt
+++ b/data/library/src/main/java/com/into/websoso/data/library/repository/UserLibraryRepository.kt
@@ -45,8 +45,7 @@ internal class UserLibraryRepository
             filterRepository.filterFlow
                 .flatMapLatest(::createLibraryFlow)
 
-        override fun getUnfilteredLibraryFlow(): Flow<PagingData<NovelEntity>> =
-            createLibraryFlow(LibraryFilter())
+        override fun getUnfilteredLibraryFlow(): Flow<PagingData<NovelEntity>> = createLibraryFlow(LibraryFilter())
 
         override suspend fun getRegisteredKeywords() = libraryRemoteDataSource.getUserNovelKeywords(userId = userId)
 

--- a/data/library/src/main/java/com/into/websoso/data/library/repository/UserLibraryRepository.kt
+++ b/data/library/src/main/java/com/into/websoso/data/library/repository/UserLibraryRepository.kt
@@ -43,25 +43,10 @@ internal class UserLibraryRepository
         @OptIn(ExperimentalCoroutinesApi::class)
         override fun getLibraryFlow(): Flow<PagingData<NovelEntity>> =
             filterRepository.filterFlow
-                .flatMapLatest { currentFilter ->
-                    Pager(
-                        config = PagingConfig(
-                            pageSize = PAGE_SIZE,
-                            enablePlaceholders = false,
-                        ),
-                        pagingSourceFactory = {
-                            LibraryPagingSource(
-                                getNovels = { cursor ->
-                                    getUserNovels(cursor, currentFilter).also { result ->
-                                        _novelTotalCount.update {
-                                            result.getOrNull()?.userNovelCount ?: 0
-                                        }
-                                    }
-                                },
-                            )
-                        },
-                    ).flow
-                }
+                .flatMapLatest(::createLibraryFlow)
+
+        override fun getUnfilteredLibraryFlow(): Flow<PagingData<NovelEntity>> =
+            createLibraryFlow(LibraryFilter())
 
         override suspend fun getRegisteredKeywords() = libraryRemoteDataSource.getUserNovelKeywords(userId = userId)
 
@@ -87,6 +72,25 @@ internal class UserLibraryRepository
                 keywords = libraryFilter.keywords.ifEmpty { null },
             )
         }
+
+        private fun createLibraryFlow(libraryFilter: LibraryFilter): Flow<PagingData<NovelEntity>> =
+            Pager(
+                config = PagingConfig(
+                    pageSize = PAGE_SIZE,
+                    enablePlaceholders = false,
+                ),
+                pagingSourceFactory = {
+                    LibraryPagingSource(
+                        getNovels = { cursor ->
+                            getUserNovels(cursor, libraryFilter).also { result ->
+                                _novelTotalCount.update {
+                                    result.getOrNull()?.userNovelCount ?: 0
+                                }
+                            }
+                        },
+                    )
+                },
+            ).flow
 
         private fun LibraryFilter.toRatingRangeParams(): Pair<Float?, Float?> =
             when {

--- a/feature/collection/build.gradle.kts
+++ b/feature/collection/build.gradle.kts
@@ -10,5 +10,7 @@ android {
 
 dependencies {
     implementation(projects.data.library)
+
     implementation(libs.navigation.compose)
+    implementation(libs.paging.compose)
 }

--- a/feature/collection/build.gradle.kts
+++ b/feature/collection/build.gradle.kts
@@ -9,5 +9,6 @@ android {
 }
 
 dependencies {
+    implementation(projects.data.library)
     implementation(libs.navigation.compose)
 }

--- a/feature/collection/src/main/java/com/into/websoso/feature/collection/CollectionLibraryNovelSelectionScreen.kt
+++ b/feature/collection/src/main/java/com/into/websoso/feature/collection/CollectionLibraryNovelSelectionScreen.kt
@@ -1,23 +1,34 @@
 package com.into.websoso.feature.collection
 
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.GridItemSpan
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
@@ -26,8 +37,15 @@ import androidx.paging.LoadState
 import androidx.paging.PagingData
 import androidx.paging.compose.LazyPagingItems
 import androidx.paging.compose.collectAsLazyPagingItems
+import com.into.websoso.core.designsystem.theme.Black
+import com.into.websoso.core.designsystem.theme.Gray300
+import com.into.websoso.core.designsystem.theme.Primary100
 import com.into.websoso.core.designsystem.theme.WebsosoTheme
 import com.into.websoso.core.designsystem.theme.White
+import com.into.websoso.core.resource.R.drawable.img_load_fail
+import com.into.websoso.core.resource.R.string.load_fail_description
+import com.into.websoso.core.resource.R.string.load_fail_reload
+import com.into.websoso.core.resource.R.string.load_fail_title
 import com.into.websoso.feature.collection.component.CollectionAppBar
 import com.into.websoso.feature.collection.component.CollectionLibraryNovelItem
 import com.into.websoso.feature.collection.model.CollectionLibraryNovelUiModel
@@ -83,36 +101,81 @@ internal fun CollectionLibraryNovelSelectionScreen(
                 .fillMaxWidth()
                 .weight(1f),
         ) {
-            if (novels.itemCount == 0 && novels.loadState.refresh is LoadState.Loading) {
-                CircularProgressIndicator(modifier = Modifier.align(Alignment.Center))
-            } else {
-                LazyVerticalGrid(
-                    columns = GridCells.Fixed(3),
-                    modifier = Modifier.fillMaxSize(),
-                    contentPadding = PaddingValues(
-                        start = 20.dp,
-                        top = 11.dp,
-                        end = 20.dp,
-                    ),
-                    horizontalArrangement = Arrangement.spacedBy(6.dp),
-                    verticalArrangement = Arrangement.spacedBy(18.dp),
-                ) {
-                    items(novels.itemCount) { index ->
-                        novels[index]?.let { novel ->
-                            CollectionLibraryNovelItem(
-                                novel = novel,
-                                isSelected = novel.novelId in selectedNovelIds,
-                                onSelectionChange = { onNovelSelectionChange(novel.novelId) },
+            when (novels.itemCount) {
+                0 if novels.loadState.refresh is LoadState.Loading -> {
+                    CircularProgressIndicator(modifier = Modifier.align(Alignment.Center))
+                }
+
+                0 if novels.loadState.refresh is LoadState.Error -> {
+                    Column(
+                        modifier = Modifier.align(Alignment.Center),
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                    ) {
+                        Image(
+                            painter = painterResource(img_load_fail),
+                            contentDescription = null,
+                            modifier = Modifier.size(width = 166.dp, height = 160.dp),
+                        )
+                        Spacer(modifier = Modifier.height(40.dp))
+                        Text(
+                            text = stringResource(load_fail_title),
+                            color = Black,
+                            style = WebsosoTheme.typography.title1,
+                            textAlign = TextAlign.Center,
+                        )
+                        Spacer(modifier = Modifier.height(10.dp))
+                        Text(
+                            text = stringResource(load_fail_description),
+                            color = Gray300,
+                            style = WebsosoTheme.typography.body2,
+                            textAlign = TextAlign.Center,
+                        )
+                        Spacer(modifier = Modifier.height(40.dp))
+                        Button(
+                            onClick = novels::retry,
+                            shape = RoundedCornerShape(8.dp),
+                            colors = ButtonDefaults.buttonColors(containerColor = Primary100),
+                            contentPadding = PaddingValues(horizontal = 38.dp, vertical = 14.dp),
+                            elevation = null,
+                        ) {
+                            Text(
+                                text = stringResource(load_fail_reload),
+                                color = White,
+                                style = WebsosoTheme.typography.label1,
                             )
                         }
                     }
-                    if (novels.loadState.append is LoadState.Loading) {
-                        item(span = { GridItemSpan(maxLineSpan) }) {
-                            Box(
-                                modifier = Modifier.fillMaxWidth(),
-                                contentAlignment = Alignment.Center,
-                            ) {
-                                CircularProgressIndicator(modifier = Modifier.padding(16.dp))
+                }
+
+                else -> {
+                    LazyVerticalGrid(
+                        columns = GridCells.Fixed(3),
+                        modifier = Modifier.fillMaxSize(),
+                        contentPadding = PaddingValues(
+                            start = 20.dp,
+                            top = 11.dp,
+                            end = 20.dp,
+                        ),
+                        horizontalArrangement = Arrangement.spacedBy(6.dp),
+                        verticalArrangement = Arrangement.spacedBy(18.dp),
+                    ) {
+                        items(novels.itemCount) { index ->
+                            novels[index]?.let { novel ->
+                                CollectionLibraryNovelItem(
+                                    novel = novel,
+                                    isSelected = novel.novelId in selectedNovelIds,
+                                    onSelectionChange = { onNovelSelectionChange(novel.novelId) },
+                                )
+                            }
+                        }
+                        if (novels.loadState.append is LoadState.Loading) {
+                            item(span = { GridItemSpan(maxLineSpan) }) {
+                                Box(
+                                    modifier = Modifier.fillMaxWidth(),
+                                    contentAlignment = Alignment.Center,
+                                ) {
+                                    CircularProgressIndicator(modifier = Modifier.padding(16.dp))
+                                }
                             }
                         }
                     }

--- a/feature/collection/src/main/java/com/into/websoso/feature/collection/CollectionLibraryNovelSelectionScreen.kt
+++ b/feature/collection/src/main/java/com/into/websoso/feature/collection/CollectionLibraryNovelSelectionScreen.kt
@@ -101,12 +101,13 @@ internal fun CollectionLibraryNovelSelectionScreen(
                 .fillMaxWidth()
                 .weight(1f),
         ) {
-            when (novels.itemCount) {
-                0 if novels.loadState.refresh is LoadState.Loading -> {
+            when {
+                novels.itemCount == 0 && novels.loadState.refresh is LoadState.Loading -> {
                     CircularProgressIndicator(modifier = Modifier.align(Alignment.Center))
                 }
 
-                0 if novels.loadState.refresh is LoadState.Error -> {
+                (novels.itemCount == 0 && novels.loadState.refresh is LoadState.Error) ||
+                    novels.loadState.append is LoadState.Error -> {
                     Column(
                         modifier = Modifier.align(Alignment.Center),
                         horizontalAlignment = Alignment.CenterHorizontally,

--- a/feature/collection/src/main/java/com/into/websoso/feature/collection/CollectionLibraryNovelSelectionScreen.kt
+++ b/feature/collection/src/main/java/com/into/websoso/feature/collection/CollectionLibraryNovelSelectionScreen.kt
@@ -2,20 +2,25 @@ package com.into.websoso.feature.collection
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.paging.LoadState
 import androidx.paging.PagingData
 import androidx.paging.compose.LazyPagingItems
 import androidx.paging.compose.collectAsLazyPagingItems
@@ -71,26 +76,34 @@ internal fun CollectionLibraryNovelSelectionScreen(
             onActionClick = onAddClick,
             isActionEnabled = selectedNovelIds.isNotEmpty(),
         )
-        LazyVerticalGrid(
-            columns = GridCells.Fixed(3),
+        Box(
             modifier = Modifier
-                .fillMaxSize()
+                .fillMaxWidth()
                 .weight(1f),
-            contentPadding = PaddingValues(
-                start = 20.dp,
-                top = 11.dp,
-                end = 20.dp,
-            ),
-            horizontalArrangement = Arrangement.spacedBy(6.dp),
-            verticalArrangement = Arrangement.spacedBy(18.dp),
         ) {
-            items(novels.itemCount) { index ->
-                novels[index]?.let { novel ->
-                    CollectionLibraryNovelItem(
-                        novel = novel,
-                        isSelected = novel.novelId in selectedNovelIds,
-                        onSelectionChange = { onNovelSelectionChange(novel.novelId) },
-                    )
+            if (novels.itemCount == 0 && novels.loadState.refresh is LoadState.Loading) {
+                CircularProgressIndicator(modifier = Modifier.align(Alignment.Center))
+            } else {
+                LazyVerticalGrid(
+                    columns = GridCells.Fixed(3),
+                    modifier = Modifier.fillMaxSize(),
+                    contentPadding = PaddingValues(
+                        start = 20.dp,
+                        top = 11.dp,
+                        end = 20.dp,
+                    ),
+                    horizontalArrangement = Arrangement.spacedBy(6.dp),
+                    verticalArrangement = Arrangement.spacedBy(18.dp),
+                ) {
+                    items(novels.itemCount) { index ->
+                        novels[index]?.let { novel ->
+                            CollectionLibraryNovelItem(
+                                novel = novel,
+                                isSelected = novel.novelId in selectedNovelIds,
+                                onSelectionChange = { onNovelSelectionChange(novel.novelId) },
+                            )
+                        }
+                    }
                 }
             }
         }

--- a/feature/collection/src/main/java/com/into/websoso/feature/collection/CollectionLibraryNovelSelectionScreen.kt
+++ b/feature/collection/src/main/java/com/into/websoso/feature/collection/CollectionLibraryNovelSelectionScreen.kt
@@ -1,0 +1,57 @@
+package com.into.websoso.feature.collection
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import com.into.websoso.core.designsystem.theme.Gray200
+import com.into.websoso.core.designsystem.theme.WebsosoTheme
+import com.into.websoso.core.designsystem.theme.White
+import com.into.websoso.feature.collection.component.CollectionAppBar
+
+@Composable
+internal fun CollectionLibraryNovelSelectionScreen(
+    onNavigateBack: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .background(White)
+            .statusBarsPadding(),
+    ) {
+        CollectionAppBar(
+            title = "서재",
+            actionLabel = "추가",
+            onNavigateBack = onNavigateBack,
+            isActionEnabled = false,
+        )
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .weight(1f),
+            contentAlignment = Alignment.Center,
+        ) {
+            Text(
+                text = "서재에서 작품 추가",
+                color = Gray200,
+                style = WebsosoTheme.typography.body2,
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun CollectionLibraryNovelSelectionScreenPreview() {
+    WebsosoTheme {
+        CollectionLibraryNovelSelectionScreen(onNavigateBack = {})
+    }
+}

--- a/feature/collection/src/main/java/com/into/websoso/feature/collection/CollectionLibraryNovelSelectionScreen.kt
+++ b/feature/collection/src/main/java/com/into/websoso/feature/collection/CollectionLibraryNovelSelectionScreen.kt
@@ -7,8 +7,10 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.GridItemSpan
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.runtime.Composable
@@ -102,6 +104,16 @@ internal fun CollectionLibraryNovelSelectionScreen(
                                 isSelected = novel.novelId in selectedNovelIds,
                                 onSelectionChange = { onNovelSelectionChange(novel.novelId) },
                             )
+                        }
+                    }
+                    if (novels.loadState.append is LoadState.Loading) {
+                        item(span = { GridItemSpan(maxLineSpan) }) {
+                            Box(
+                                modifier = Modifier.fillMaxWidth(),
+                                contentAlignment = Alignment.Center,
+                            ) {
+                                CircularProgressIndicator(modifier = Modifier.padding(16.dp))
+                            }
                         }
                     }
                 }

--- a/feature/collection/src/main/java/com/into/websoso/feature/collection/CollectionLibraryNovelSelectionScreen.kt
+++ b/feature/collection/src/main/java/com/into/websoso/feature/collection/CollectionLibraryNovelSelectionScreen.kt
@@ -1,23 +1,60 @@
 package com.into.websoso.feature.collection
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.statusBarsPadding
-import androidx.compose.material3.Text
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
-import com.into.websoso.core.designsystem.theme.Gray200
+import androidx.compose.ui.unit.dp
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.paging.PagingData
+import androidx.paging.compose.LazyPagingItems
+import androidx.paging.compose.collectAsLazyPagingItems
 import com.into.websoso.core.designsystem.theme.WebsosoTheme
 import com.into.websoso.core.designsystem.theme.White
 import com.into.websoso.feature.collection.component.CollectionAppBar
+import com.into.websoso.feature.collection.component.CollectionLibraryNovelItem
+import com.into.websoso.feature.collection.model.CollectionLibraryNovelUiModel
+import kotlinx.coroutines.flow.flowOf
+
+@Composable
+internal fun CollectionLibraryNovelSelectionRoute(
+    initialSelectedNovelIds: Set<Long>,
+    onAddClick: (Set<Long>) -> Unit,
+    onNavigateBack: () -> Unit,
+    viewModel: CollectionLibraryNovelSelectionViewModel = hiltViewModel(),
+) {
+    val novels = viewModel.novels.collectAsLazyPagingItems()
+    val selectedNovelIds by viewModel.selectedNovelIds.collectAsStateWithLifecycle()
+
+    LaunchedEffect(initialSelectedNovelIds) {
+        viewModel.setSelectedNovelIds(initialSelectedNovelIds)
+    }
+
+    CollectionLibraryNovelSelectionScreen(
+        novels = novels,
+        selectedNovelIds = selectedNovelIds,
+        onNovelSelectionChange = viewModel::toggleNovelSelection,
+        onAddClick = { onAddClick(selectedNovelIds) },
+        onNavigateBack = onNavigateBack,
+    )
+}
 
 @Composable
 internal fun CollectionLibraryNovelSelectionScreen(
+    novels: LazyPagingItems<CollectionLibraryNovelUiModel>,
+    selectedNovelIds: Set<Long>,
+    onNovelSelectionChange: (Long) -> Unit,
+    onAddClick: () -> Unit,
     onNavigateBack: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -31,19 +68,31 @@ internal fun CollectionLibraryNovelSelectionScreen(
             title = "서재",
             actionLabel = "추가",
             onNavigateBack = onNavigateBack,
-            isActionEnabled = false,
+            onActionClick = onAddClick,
+            isActionEnabled = selectedNovelIds.isNotEmpty(),
         )
-        Box(
+        LazyVerticalGrid(
+            columns = GridCells.Fixed(3),
             modifier = Modifier
-                .fillMaxWidth()
+                .fillMaxSize()
                 .weight(1f),
-            contentAlignment = Alignment.Center,
+            contentPadding = PaddingValues(
+                start = 20.dp,
+                top = 11.dp,
+                end = 20.dp,
+            ),
+            horizontalArrangement = Arrangement.spacedBy(6.dp),
+            verticalArrangement = Arrangement.spacedBy(18.dp),
         ) {
-            Text(
-                text = "서재에서 작품 추가",
-                color = Gray200,
-                style = WebsosoTheme.typography.body2,
-            )
+            items(novels.itemCount) { index ->
+                novels[index]?.let { novel ->
+                    CollectionLibraryNovelItem(
+                        novel = novel,
+                        isSelected = novel.novelId in selectedNovelIds,
+                        onSelectionChange = { onNovelSelectionChange(novel.novelId) },
+                    )
+                }
+            }
         }
     }
 }
@@ -52,6 +101,13 @@ internal fun CollectionLibraryNovelSelectionScreen(
 @Composable
 private fun CollectionLibraryNovelSelectionScreenPreview() {
     WebsosoTheme {
-        CollectionLibraryNovelSelectionScreen(onNavigateBack = {})
+        CollectionLibraryNovelSelectionScreen(
+            novels = flowOf(PagingData.empty<CollectionLibraryNovelUiModel>())
+                .collectAsLazyPagingItems(),
+            selectedNovelIds = emptySet(),
+            onNovelSelectionChange = {},
+            onAddClick = {},
+            onNavigateBack = {},
+        )
     }
 }

--- a/feature/collection/src/main/java/com/into/websoso/feature/collection/CollectionLibraryNovelSelectionViewModel.kt
+++ b/feature/collection/src/main/java/com/into/websoso/feature/collection/CollectionLibraryNovelSelectionViewModel.kt
@@ -1,0 +1,49 @@
+package com.into.websoso.feature.collection
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import androidx.paging.PagingData
+import androidx.paging.cachedIn
+import androidx.paging.map
+import com.into.websoso.data.library.LibraryRepository
+import com.into.websoso.data.library.model.NovelEntity
+import com.into.websoso.feature.collection.mapper.toUiModel
+import com.into.websoso.feature.collection.model.CollectionLibraryNovelUiModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.update
+import javax.inject.Inject
+
+@HiltViewModel
+internal class CollectionLibraryNovelSelectionViewModel
+    @Inject
+    constructor(
+        libraryRepository: LibraryRepository,
+    ) : ViewModel() {
+        private val _selectedNovelIds = MutableStateFlow<Set<Long>>(emptySet())
+        val selectedNovelIds: StateFlow<Set<Long>> = _selectedNovelIds.asStateFlow()
+
+        val novels: Flow<PagingData<CollectionLibraryNovelUiModel>> =
+            libraryRepository
+                .getUnfilteredLibraryFlow()
+                .map { pagingData -> pagingData.map(NovelEntity::toUiModel) }
+                .cachedIn(viewModelScope)
+
+        fun toggleNovelSelection(novelId: Long) {
+            _selectedNovelIds.update { selectedNovelIds ->
+                if (novelId in selectedNovelIds) {
+                    selectedNovelIds - novelId
+                } else {
+                    selectedNovelIds + novelId
+                }
+            }
+        }
+
+        fun setSelectedNovelIds(novelIds: Set<Long>) {
+            _selectedNovelIds.value = novelIds
+        }
+    }

--- a/feature/collection/src/main/java/com/into/websoso/feature/collection/CollectionNavHost.kt
+++ b/feature/collection/src/main/java/com/into/websoso/feature/collection/CollectionNavHost.kt
@@ -1,7 +1,9 @@
 package com.into.websoso.feature.collection
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
@@ -11,6 +13,7 @@ private const val COLLECTION_CREATE_ROUTE = "collection/create"
 private const val COLLECTION_NOVEL_SEARCH_ROUTE = "collection/create/novel-search"
 private const val COLLECTION_LIBRARY_NOVEL_SELECTION_ROUTE =
     "collection/create/novel-search/library"
+private const val SELECTED_NOVEL_IDS_KEY = "selectedNovelIds"
 
 @Composable
 fun CollectionNavHost(
@@ -40,8 +43,13 @@ fun CollectionNavHost(
                 },
             )
         }
-        composable(route = COLLECTION_NOVEL_SEARCH_ROUTE) {
+        composable(route = COLLECTION_NOVEL_SEARCH_ROUTE) { backStackEntry ->
+            val selectedNovelIds by backStackEntry.savedStateHandle
+                .getStateFlow(SELECTED_NOVEL_IDS_KEY, longArrayOf())
+                .collectAsStateWithLifecycle()
+
             CollectionNovelSearchScreen(
+                addedNovelCount = selectedNovelIds.size,
                 onNavigateBack = navController::popBackStack,
                 onNavigateToLibraryNovelSelection = {
                     navController.navigate(COLLECTION_LIBRARY_NOVEL_SELECTION_ROUTE)
@@ -49,7 +57,20 @@ fun CollectionNavHost(
             )
         }
         composable(route = COLLECTION_LIBRARY_NOVEL_SELECTION_ROUTE) {
-            CollectionLibraryNovelSelectionScreen(
+            val initialSelectedNovelIds = navController.previousBackStackEntry
+                ?.savedStateHandle
+                ?.get<LongArray>(SELECTED_NOVEL_IDS_KEY)
+                ?.toSet()
+                .orEmpty()
+
+            CollectionLibraryNovelSelectionRoute(
+                initialSelectedNovelIds = initialSelectedNovelIds,
+                onAddClick = { selectedNovelIds ->
+                    navController.previousBackStackEntry
+                        ?.savedStateHandle
+                        ?.set(SELECTED_NOVEL_IDS_KEY, selectedNovelIds.toLongArray())
+                    navController.popBackStack()
+                },
                 onNavigateBack = navController::popBackStack,
             )
         }

--- a/feature/collection/src/main/java/com/into/websoso/feature/collection/CollectionNavHost.kt
+++ b/feature/collection/src/main/java/com/into/websoso/feature/collection/CollectionNavHost.kt
@@ -9,6 +9,8 @@ import androidx.navigation.compose.rememberNavController
 private const val COLLECTION_ROUTE = "collection"
 private const val COLLECTION_CREATE_ROUTE = "collection/create"
 private const val COLLECTION_NOVEL_SEARCH_ROUTE = "collection/create/novel-search"
+private const val COLLECTION_LIBRARY_NOVEL_SELECTION_ROUTE =
+    "collection/create/novel-search/library"
 
 @Composable
 fun CollectionNavHost(
@@ -40,6 +42,14 @@ fun CollectionNavHost(
         }
         composable(route = COLLECTION_NOVEL_SEARCH_ROUTE) {
             CollectionNovelSearchScreen(
+                onNavigateBack = navController::popBackStack,
+                onNavigateToLibraryNovelSelection = {
+                    navController.navigate(COLLECTION_LIBRARY_NOVEL_SELECTION_ROUTE)
+                },
+            )
+        }
+        composable(route = COLLECTION_LIBRARY_NOVEL_SELECTION_ROUTE) {
+            CollectionLibraryNovelSelectionScreen(
                 onNavigateBack = navController::popBackStack,
             )
         }

--- a/feature/collection/src/main/java/com/into/websoso/feature/collection/CollectionNovelSearchScreen.kt
+++ b/feature/collection/src/main/java/com/into/websoso/feature/collection/CollectionNovelSearchScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
@@ -22,15 +23,18 @@ import com.into.websoso.core.designsystem.theme.WebsosoTheme
 import com.into.websoso.core.designsystem.theme.White
 import com.into.websoso.feature.collection.component.CollectionAppBar
 import com.into.websoso.feature.collection.component.CollectionNovelSearchField
+import com.into.websoso.feature.collection.component.CollectionNovelSelectionInfo
 
 @Composable
 internal fun CollectionNovelSearchScreen(
     onNavigateBack: () -> Unit,
+    onNavigateToLibraryNovelSelection: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     var searchQuery by rememberSaveable(stateSaver = TextFieldValue.Saver) {
         mutableStateOf(TextFieldValue())
     }
+    var addedNovelCount by rememberSaveable { mutableIntStateOf(0) }
     val searchFocusRequester = remember { FocusRequester() }
     val keyboardController = LocalSoftwareKeyboardController.current
 
@@ -49,7 +53,7 @@ internal fun CollectionNovelSearchScreen(
             title = "작품 리스트",
             actionLabel = "완료",
             onNavigateBack = onNavigateBack,
-            isActionEnabled = false,
+            isActionEnabled = addedNovelCount > 0,
         )
         CollectionNovelSearchField(
             value = searchQuery,
@@ -62,6 +66,11 @@ internal fun CollectionNovelSearchScreen(
                 end = 20.dp,
             ),
         )
+        CollectionNovelSelectionInfo(
+            addedNovelCount = addedNovelCount,
+            onAddFromLibraryClick = onNavigateToLibraryNovelSelection,
+            modifier = Modifier.padding(top = 16.dp),
+        )
     }
 }
 
@@ -69,6 +78,9 @@ internal fun CollectionNovelSearchScreen(
 @Composable
 private fun CollectionNovelSearchScreenPreview() {
     WebsosoTheme {
-        CollectionNovelSearchScreen(onNavigateBack = {})
+        CollectionNovelSearchScreen(
+            onNavigateBack = {},
+            onNavigateToLibraryNovelSelection = {},
+        )
     }
 }

--- a/feature/collection/src/main/java/com/into/websoso/feature/collection/CollectionNovelSearchScreen.kt
+++ b/feature/collection/src/main/java/com/into/websoso/feature/collection/CollectionNovelSearchScreen.kt
@@ -8,7 +8,6 @@ import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
@@ -27,6 +26,7 @@ import com.into.websoso.feature.collection.component.CollectionNovelSelectionInf
 
 @Composable
 internal fun CollectionNovelSearchScreen(
+    addedNovelCount: Int,
     onNavigateBack: () -> Unit,
     onNavigateToLibraryNovelSelection: () -> Unit,
     modifier: Modifier = Modifier,
@@ -34,7 +34,6 @@ internal fun CollectionNovelSearchScreen(
     var searchQuery by rememberSaveable(stateSaver = TextFieldValue.Saver) {
         mutableStateOf(TextFieldValue())
     }
-    var addedNovelCount by rememberSaveable { mutableIntStateOf(0) }
     val searchFocusRequester = remember { FocusRequester() }
     val keyboardController = LocalSoftwareKeyboardController.current
 
@@ -79,6 +78,7 @@ internal fun CollectionNovelSearchScreen(
 private fun CollectionNovelSearchScreenPreview() {
     WebsosoTheme {
         CollectionNovelSearchScreen(
+            addedNovelCount = 0,
             onNavigateBack = {},
             onNavigateToLibraryNovelSelection = {},
         )

--- a/feature/collection/src/main/java/com/into/websoso/feature/collection/component/CollectionAppBar.kt
+++ b/feature/collection/src/main/java/com/into/websoso/feature/collection/component/CollectionAppBar.kt
@@ -2,7 +2,9 @@ package com.into.websoso.feature.collection.component
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -27,6 +29,7 @@ internal fun CollectionAppBar(
     title: String? = null,
     actionLabel: String? = null,
     onNavigateBack: () -> Unit,
+    onActionClick: () -> Unit = {},
     isActionEnabled: Boolean = false,
     modifier: Modifier = Modifier,
 ) {
@@ -58,14 +61,22 @@ internal fun CollectionAppBar(
             )
         }
         actionLabel?.let {
-            Text(
-                text = it,
-                color = if (isActionEnabled) Primary100 else Gray100,
-                style = WebsosoTheme.typography.title2,
+            Box(
                 modifier = Modifier
                     .align(Alignment.CenterEnd)
-                    .padding(horizontal = 20.dp),
-            )
+                    .fillMaxHeight()
+                    .clickable(
+                        enabled = isActionEnabled,
+                        onClick = onActionClick,
+                    ).padding(horizontal = 20.dp),
+                contentAlignment = Alignment.Center,
+            ) {
+                Text(
+                    text = it,
+                    color = if (isActionEnabled) Primary100 else Gray100,
+                    style = WebsosoTheme.typography.title2,
+                )
+            }
         }
     }
 }

--- a/feature/collection/src/main/java/com/into/websoso/feature/collection/component/CollectionLibraryNovelItem.kt
+++ b/feature/collection/src/main/java/com/into/websoso/feature/collection/component/CollectionLibraryNovelItem.kt
@@ -1,0 +1,193 @@
+package com.into.websoso.feature.collection.component
+
+import androidx.annotation.DrawableRes
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.selection.toggleable
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.into.websoso.core.designsystem.component.NetworkImage
+import com.into.websoso.core.designsystem.theme.Black
+import com.into.websoso.core.designsystem.theme.Gray200
+import com.into.websoso.core.designsystem.theme.Primary100
+import com.into.websoso.core.designsystem.theme.WebsosoTheme
+import com.into.websoso.core.designsystem.theme.White
+import com.into.websoso.core.resource.R.drawable.ic_library_half_star
+import com.into.websoso.core.resource.R.drawable.ic_library_interesting
+import com.into.websoso.core.resource.R.drawable.ic_library_null_star
+import com.into.websoso.core.resource.R.drawable.ic_novel_detail_check
+import com.into.websoso.core.resource.R.drawable.ic_novel_unselected
+import com.into.websoso.core.resource.R.drawable.ic_storage_star
+import com.into.websoso.feature.collection.model.CollectionLibraryNovelUiModel
+import com.into.websoso.feature.collection.model.CollectionLibraryRatingStar
+import com.into.websoso.feature.collection.model.CollectionLibraryReadStatus
+
+@Composable
+internal fun CollectionLibraryNovelItem(
+    novel: CollectionLibraryNovelUiModel,
+    isSelected: Boolean,
+    onSelectionChange: (Boolean) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier.toggleable(
+            value = isSelected,
+            role = Role.Checkbox,
+            onValueChange = onSelectionChange,
+        ),
+        verticalArrangement = Arrangement.spacedBy(6.dp),
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(160.dp)
+                .clip(RoundedCornerShape(8.dp)),
+        ) {
+            NetworkImage(
+                imageUrl = novel.imageUrl,
+                contentDescription = novel.title,
+                contentScale = ContentScale.Crop,
+                modifier = Modifier.fillMaxSize(),
+            )
+            novel.readStatus?.let { readStatus ->
+                Text(
+                    text = readStatus.label,
+                    color = White,
+                    style = WebsosoTheme.typography.label2,
+                    modifier = Modifier
+                        .align(Alignment.BottomStart)
+                        .padding(6.dp)
+                        .background(
+                            color = readStatus.backgroundColor,
+                            shape = RoundedCornerShape(4.dp),
+                        ).padding(
+                            horizontal = 6.dp,
+                            vertical = 4.dp,
+                        ),
+                )
+            }
+            if (novel.isInterested) {
+                Box(
+                    modifier = Modifier
+                        .align(Alignment.BottomEnd)
+                        .size(32.dp),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Image(
+                        imageVector = ImageVector.vectorResource(ic_library_interesting),
+                        contentDescription = null,
+                        modifier = Modifier.size(13.dp),
+                    )
+                }
+            }
+            Image(
+                imageVector = ImageVector.vectorResource(
+                    if (isSelected) ic_novel_detail_check else ic_novel_unselected,
+                ),
+                contentDescription = null,
+                modifier = Modifier
+                    .align(Alignment.TopEnd)
+                    .padding(
+                        top = 8.dp,
+                        end = 8.dp,
+                    ).size(24.dp),
+            )
+        }
+        Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
+            Text(
+                text = novel.title,
+                color = Black,
+                style = WebsosoTheme.typography.body4,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis,
+            )
+            if (novel.ratingStars.isNotEmpty()) {
+                Row(
+                    modifier = Modifier.padding(bottom = 4.dp),
+                    horizontalArrangement = Arrangement.spacedBy(2.dp),
+                ) {
+                    novel.ratingStars.forEach { star ->
+                        Image(
+                            imageVector = ImageVector.vectorResource(star.iconRes),
+                            contentDescription = null,
+                            modifier = Modifier.size(9.dp),
+                        )
+                    }
+                }
+            }
+            novel.dateText?.let {
+                Text(
+                    text = it,
+                    color = Gray200,
+                    style = WebsosoTheme.typography.label2,
+                )
+            }
+        }
+    }
+}
+
+private val CollectionLibraryReadStatus.label: String
+    get() = when (this) {
+        CollectionLibraryReadStatus.WATCHING -> "보는 중"
+        CollectionLibraryReadStatus.WATCHED -> "봤어요"
+        CollectionLibraryReadStatus.QUIT -> "하차"
+    }
+
+private val CollectionLibraryReadStatus.backgroundColor: Color
+    get() = when (this) {
+        CollectionLibraryReadStatus.WATCHING -> Primary100
+        CollectionLibraryReadStatus.WATCHED -> Black
+        CollectionLibraryReadStatus.QUIT -> Gray200
+    }
+
+@get:DrawableRes
+private val CollectionLibraryRatingStar.iconRes: Int
+    get() = when (this) {
+        CollectionLibraryRatingStar.FULL -> ic_storage_star
+        CollectionLibraryRatingStar.HALF -> ic_library_half_star
+        CollectionLibraryRatingStar.EMPTY -> ic_library_null_star
+    }
+
+@Preview(showBackground = true)
+@Composable
+private fun CollectionLibraryNovelItemPreview() {
+    WebsosoTheme {
+        CollectionLibraryNovelItem(
+            novel = CollectionLibraryNovelUiModel(
+                novelId = 1L,
+                title = "당신의 이해를 돕기 위하여",
+                imageUrl = "",
+                readStatus = CollectionLibraryReadStatus.WATCHING,
+                isInterested = true,
+                ratingStars = List(5) { CollectionLibraryRatingStar.FULL },
+                dateText = "24.01.03 ~ 25.03.08",
+            ),
+            isSelected = false,
+            onSelectionChange = {},
+            modifier = Modifier
+                .padding(20.dp)
+                .size(width = 103.dp, height = 240.dp),
+        )
+    }
+}

--- a/feature/collection/src/main/java/com/into/websoso/feature/collection/component/CollectionLibraryNovelItem.kt
+++ b/feature/collection/src/main/java/com/into/websoso/feature/collection/component/CollectionLibraryNovelItem.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.style.TextOverflow
@@ -87,7 +88,7 @@ internal fun CollectionLibraryNovelItem(
                     contentAlignment = Alignment.Center,
                 ) {
                     Text(
-                        text = readStatus.label,
+                        text = stringResource(readStatus.labelRes),
                         color = White,
                         style = WebsosoTheme.typography.label2,
                     )
@@ -152,13 +153,6 @@ internal fun CollectionLibraryNovelItem(
         }
     }
 }
-
-private val CollectionLibraryReadStatus.label: String
-    get() = when (this) {
-        CollectionLibraryReadStatus.WATCHING -> "보는 중"
-        CollectionLibraryReadStatus.WATCHED -> "봤어요"
-        CollectionLibraryReadStatus.QUIT -> "하차"
-    }
 
 private val CollectionLibraryReadStatus.backgroundColor: Color
     get() = when (this) {

--- a/feature/collection/src/main/java/com/into/websoso/feature/collection/component/CollectionLibraryNovelItem.kt
+++ b/feature/collection/src/main/java/com/into/websoso/feature/collection/component/CollectionLibraryNovelItem.kt
@@ -7,9 +7,9 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.selection.toggleable
@@ -61,7 +61,7 @@ internal fun CollectionLibraryNovelItem(
         Box(
             modifier = Modifier
                 .fillMaxWidth()
-                .height(160.dp)
+                .aspectRatio(102.67f / 160f)
                 .clip(RoundedCornerShape(8.dp)),
         ) {
             NetworkImage(
@@ -71,21 +71,27 @@ internal fun CollectionLibraryNovelItem(
                 modifier = Modifier.fillMaxSize(),
             )
             novel.readStatus?.let { readStatus ->
-                Text(
-                    text = readStatus.label,
-                    color = White,
-                    style = WebsosoTheme.typography.label2,
+                Box(
                     modifier = Modifier
                         .align(Alignment.BottomStart)
-                        .padding(6.dp)
-                        .background(
+                        .padding(
+                            start = 6.dp,
+                            bottom = 7.dp,
+                        ).size(
+                            width = 48.dp,
+                            height = 18.dp,
+                        ).background(
                             color = readStatus.backgroundColor,
                             shape = RoundedCornerShape(4.dp),
-                        ).padding(
-                            horizontal = 6.dp,
-                            vertical = 4.dp,
                         ),
-                )
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Text(
+                        text = readStatus.label,
+                        color = White,
+                        style = WebsosoTheme.typography.label2,
+                    )
+                }
             }
             if (novel.isInterested) {
                 Box(

--- a/feature/collection/src/main/java/com/into/websoso/feature/collection/component/CollectionNovelSelectionInfo.kt
+++ b/feature/collection/src/main/java/com/into/websoso/feature/collection/component/CollectionNovelSelectionInfo.kt
@@ -1,0 +1,68 @@
+package com.into.websoso.feature.collection.component
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.into.websoso.core.designsystem.theme.Gray200
+import com.into.websoso.core.designsystem.theme.Primary100
+import com.into.websoso.core.designsystem.theme.WebsosoTheme
+
+@Composable
+internal fun CollectionNovelSelectionInfo(
+    addedNovelCount: Int,
+    onAddFromLibraryClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = 20.dp),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Row(horizontalArrangement = Arrangement.spacedBy(2.dp)) {
+            Text(
+                text = "추가한 작품",
+                color = Gray200,
+                style = WebsosoTheme.typography.body4,
+            )
+            Text(
+                text = "${addedNovelCount}개",
+                color = Primary100,
+                style = WebsosoTheme.typography.body4,
+            )
+        }
+        Text(
+            text = "서재에서 추가",
+            color = Gray200,
+            style = WebsosoTheme.typography.body4.copy(
+                textDecoration = TextDecoration.Underline,
+            ),
+            modifier = Modifier.clickable(
+                onClick = onAddFromLibraryClick,
+                role = Role.Button,
+            ),
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun CollectionNovelSelectionInfoPreview() {
+    WebsosoTheme {
+        CollectionNovelSelectionInfo(
+            addedNovelCount = 0,
+            onAddFromLibraryClick = {},
+        )
+    }
+}

--- a/feature/collection/src/main/java/com/into/websoso/feature/collection/mapper/CollectionLibraryNovelMapper.kt
+++ b/feature/collection/src/main/java/com/into/websoso/feature/collection/mapper/CollectionLibraryNovelMapper.kt
@@ -1,0 +1,32 @@
+package com.into.websoso.feature.collection.mapper
+
+import com.into.websoso.core.common.extensions.formatDateRange
+import com.into.websoso.data.library.model.NovelEntity
+import com.into.websoso.feature.collection.model.CollectionLibraryNovelUiModel
+import com.into.websoso.feature.collection.model.CollectionLibraryRatingStar
+import com.into.websoso.feature.collection.model.CollectionLibraryReadStatus
+
+internal fun NovelEntity.toUiModel(): CollectionLibraryNovelUiModel =
+    CollectionLibraryNovelUiModel(
+        novelId = novelId,
+        title = title,
+        imageUrl = novelImage,
+        readStatus = CollectionLibraryReadStatus.entries.find { it.name == readStatus },
+        isInterested = isInterest,
+        ratingStars = userNovelRating.toRatingStars(),
+        dateText = formatDateRange(startDate, endDate),
+    )
+
+private fun Float.toRatingStars(): List<CollectionLibraryRatingStar> {
+    if (this !in 0.5f..5f) return emptyList()
+
+    val fullStarCount = toInt()
+    val hasHalfStar = this - fullStarCount >= 0.5f
+    val emptyStarCount = 5 - fullStarCount - if (hasHalfStar) 1 else 0
+
+    return buildList {
+        repeat(fullStarCount) { add(CollectionLibraryRatingStar.FULL) }
+        if (hasHalfStar) add(CollectionLibraryRatingStar.HALF)
+        repeat(emptyStarCount) { add(CollectionLibraryRatingStar.EMPTY) }
+    }
+}

--- a/feature/collection/src/main/java/com/into/websoso/feature/collection/model/CollectionLibraryNovelUiModel.kt
+++ b/feature/collection/src/main/java/com/into/websoso/feature/collection/model/CollectionLibraryNovelUiModel.kt
@@ -1,5 +1,10 @@
 package com.into.websoso.feature.collection.model
 
+import androidx.annotation.StringRes
+import com.into.websoso.core.resource.R.string.collection_read_status_quit
+import com.into.websoso.core.resource.R.string.collection_read_status_watched
+import com.into.websoso.core.resource.R.string.collection_read_status_watching
+
 internal data class CollectionLibraryNovelUiModel(
     val novelId: Long,
     val title: String,
@@ -10,10 +15,12 @@ internal data class CollectionLibraryNovelUiModel(
     val dateText: String?,
 )
 
-internal enum class CollectionLibraryReadStatus {
-    WATCHING,
-    WATCHED,
-    QUIT,
+internal enum class CollectionLibraryReadStatus(
+    @get:StringRes val labelRes: Int,
+) {
+    WATCHING(collection_read_status_watching),
+    WATCHED(collection_read_status_watched),
+    QUIT(collection_read_status_quit),
 }
 
 internal enum class CollectionLibraryRatingStar {

--- a/feature/collection/src/main/java/com/into/websoso/feature/collection/model/CollectionLibraryNovelUiModel.kt
+++ b/feature/collection/src/main/java/com/into/websoso/feature/collection/model/CollectionLibraryNovelUiModel.kt
@@ -1,0 +1,23 @@
+package com.into.websoso.feature.collection.model
+
+internal data class CollectionLibraryNovelUiModel(
+    val novelId: Long,
+    val title: String,
+    val imageUrl: String,
+    val readStatus: CollectionLibraryReadStatus?,
+    val isInterested: Boolean,
+    val ratingStars: List<CollectionLibraryRatingStar>,
+    val dateText: String?,
+)
+
+internal enum class CollectionLibraryReadStatus {
+    WATCHING,
+    WATCHED,
+    QUIT,
+}
+
+internal enum class CollectionLibraryRatingStar {
+    FULL,
+    HALF,
+    EMPTY,
+}


### PR DESCRIPTION
## 📌𝘐𝘴𝘴𝘶𝘦𝘴
- closed #937

## 📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯

- 작품 검색 화면에 추가한 작품 개수와 `서재에서 추가` 진입 영역을 구현했습니다.
- 기존 서재 필터 상태와 무관하게 전체 작품을 조회하는 Paging 흐름을 추가했습니다.
- 서재 작품을 컬렉션 전용 UI 모델로 변환해 3열 목록으로 표시했습니다.
- 작품 썸네일, 제목, 별점, 읽기 상태와 날짜 정보를 표시했습니다.
- 작품 선택·해제와 선택 여부 체크 표시를 구현했습니다.
- 선택 작품이 있을 때 상단 `추가` 버튼을 활성화했습니다.
- 선택한 작품 ID를 작품 검색 화면으로 전달하고 추가한 작품 개수에 반영했습니다.
- 다시 서재 화면에 진입할 때 기존 선택 상태를 복원하도록 구현했습니다.
- 최초 로딩과 다음 페이지 로딩 인디케이터를 적용했습니다.
- 서재 조회 실패 시 공통 네트워크 오류 화면을 표시하고 `novels.retry()`로 재시도하도록 연결했습니다.
- 컬렉션 모듈에 Navigation Compose와 Paging Compose 의존성을 추가했습니다.

### 검증

- `./gradlew :feature:collection:compileDebugKotlin ktlintCheck --console=plain`
- 컬렉션 모듈 Debug 컴파일 성공
- ktlint 성공
- push 전 전체 단위 테스트 및 앱 Debug 빌드 성공

## 📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵

https://github.com/user-attachments/assets/b7382a5d-018b-4fd9-ae05-2a3e058901b6



## 💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴

- 필터가 적용되지 않은 서재 작품 조회와 Paging 동작을 확인 부탁드립니다.
- 작품 선택·해제, 선택 상태 복원 및 검색 화면의 작품 개수 반영 흐름을 확인 부탁드립니다.
- 실제 작품 검색 API와 검색 결과 선택 기능은 포함하지 않습니다.
- 서재가 비어 있을 때의 전용 화면 정책은 추후 확정 예정입니다.
- Base: `feat/936`
- Head: `feat/937`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 컬렉션 생성 과정에서 서재의 소설을 검색하고 여러 작품을 선택해 추가할 수 있습니다.
  * 3열 그리드에서 표지, 제목, 읽기 상태, 관심 표시, 별점 및 날짜를 확인할 수 있습니다.
  * 선택한 작품 수를 확인하고 선택 상태를 유지한 채 화면을 이동할 수 있습니다.
  * 소설 목록을 페이지 단위로 불러오며 초기 로딩과 추가 로딩 오류 시 재시도할 수 있습니다.
  * 선택된 작품이 있을 때만 완료 작업을 실행할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->