### PR TITLE
feat : 작품 검색 연결 및 Paging 데이터 계층 구현

### DIFF
--- a/data/novel/build.gradle.kts
+++ b/data/novel/build.gradle.kts
@@ -1,0 +1,20 @@
+import com.into.websoso.setNamespace
+
+plugins {
+    id("websoso.android.library")
+    alias(libs.plugins.kotlin.serialization)
+}
+
+android {
+    setNamespace("data.novel")
+}
+
+dependencies {
+    implementation(projects.core.network)
+
+    implementation(libs.paging.runtime)
+    implementation(libs.retrofit)
+    implementation(libs.serialization.json)
+
+    testImplementation(libs.junit)
+}

--- a/data/novel/src/main/AndroidManifest.xml
+++ b/data/novel/src/main/AndroidManifest.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest />

--- a/data/novel/src/main/java/com/into/websoso/data/novel/NovelSearchApi.kt
+++ b/data/novel/src/main/java/com/into/websoso/data/novel/NovelSearchApi.kt
@@ -1,0 +1,13 @@
+package com.into.websoso.data.novel
+
+import retrofit2.http.GET
+import retrofit2.http.Query
+
+internal interface NovelSearchApi {
+    @GET("novels")
+    suspend fun getNovels(
+        @Query("query") query: String,
+        @Query("page") page: Int,
+        @Query("size") size: Int,
+    ): NovelSearchResponseDto
+}

--- a/data/novel/src/main/java/com/into/websoso/data/novel/NovelSearchApiModule.kt
+++ b/data/novel/src/main/java/com/into/websoso/data/novel/NovelSearchApiModule.kt
@@ -1,0 +1,16 @@
+package com.into.websoso.data.novel
+
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import retrofit2.Retrofit
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+internal object NovelSearchApiModule {
+    @Provides
+    @Singleton
+    fun provideNovelSearchApi(retrofit: Retrofit): NovelSearchApi = retrofit.create(NovelSearchApi::class.java)
+}

--- a/data/novel/src/main/java/com/into/websoso/data/novel/NovelSearchPagingSource.kt
+++ b/data/novel/src/main/java/com/into/websoso/data/novel/NovelSearchPagingSource.kt
@@ -3,13 +3,14 @@ package com.into.websoso.data.novel
 import androidx.paging.PagingSource
 import androidx.paging.PagingState
 import com.into.websoso.data.novel.model.NovelSearchEntity
+import kotlin.coroutines.cancellation.CancellationException
 
 internal class NovelSearchPagingSource(
     private val query: String,
     private val api: NovelSearchApi,
 ) : PagingSource<Int, NovelSearchEntity>() {
     override suspend fun load(params: LoadParams<Int>): LoadResult<Int, NovelSearchEntity> =
-        runCatching {
+        try {
             val page = params.key ?: INITIAL_PAGE
             val response = api.getNovels(
                 query = query,
@@ -22,7 +23,11 @@ internal class NovelSearchPagingSource(
                 prevKey = page.takeIf { it > INITIAL_PAGE }?.minus(1),
                 nextKey = (page + 1).takeIf { response.isLoadable },
             )
-        }.getOrElse(LoadResult<Int, NovelSearchEntity>::Error)
+        } catch (exception: CancellationException) {
+            throw exception
+        } catch (exception: Exception) {
+            LoadResult.Error(exception)
+        }
 
     override fun getRefreshKey(state: PagingState<Int, NovelSearchEntity>): Int? =
         state.anchorPosition?.let { anchorPosition ->

--- a/data/novel/src/main/java/com/into/websoso/data/novel/NovelSearchPagingSource.kt
+++ b/data/novel/src/main/java/com/into/websoso/data/novel/NovelSearchPagingSource.kt
@@ -8,16 +8,20 @@ internal class NovelSearchPagingSource(
     private val query: String,
     private val api: NovelSearchApi,
 ) : PagingSource<Int, NovelSearchEntity>() {
-    override suspend fun load(params: LoadParams<Int>): LoadResult<Int, NovelSearchEntity> =
-        LoadResult.Page(
-            data = api.getNovels(
+    override suspend fun load(params: LoadParams<Int>): LoadResult<Int, NovelSearchEntity> {
+        val page = params.key ?: INITIAL_PAGE
+        val response = api.getNovels(
                 query = query,
-                page = params.key ?: INITIAL_PAGE,
+                page = page,
                 size = params.loadSize,
-            ).novels.map(NovelSearchResponseDto.NovelDto::toData),
-            prevKey = null,
-            nextKey = null,
+            )
+
+        return LoadResult.Page(
+            data = response.novels.map(NovelSearchResponseDto.NovelDto::toData),
+            prevKey = page.takeIf { it > INITIAL_PAGE }?.minus(1),
+            nextKey = (page + 1).takeIf { response.isLoadable },
         )
+    }
 
     override fun getRefreshKey(state: PagingState<Int, NovelSearchEntity>): Int? =
         state.anchorPosition?.let { anchorPosition ->

--- a/data/novel/src/main/java/com/into/websoso/data/novel/NovelSearchPagingSource.kt
+++ b/data/novel/src/main/java/com/into/websoso/data/novel/NovelSearchPagingSource.kt
@@ -1,0 +1,32 @@
+package com.into.websoso.data.novel
+
+import androidx.paging.PagingSource
+import androidx.paging.PagingState
+import com.into.websoso.data.novel.model.NovelSearchEntity
+
+internal class NovelSearchPagingSource(
+    private val query: String,
+    private val api: NovelSearchApi,
+) : PagingSource<Int, NovelSearchEntity>() {
+    override suspend fun load(params: LoadParams<Int>): LoadResult<Int, NovelSearchEntity> =
+        LoadResult.Page(
+            data = api.getNovels(
+                query = query,
+                page = params.key ?: INITIAL_PAGE,
+                size = params.loadSize,
+            ).novels.map(NovelSearchResponseDto.NovelDto::toData),
+            prevKey = null,
+            nextKey = null,
+        )
+
+    override fun getRefreshKey(state: PagingState<Int, NovelSearchEntity>): Int? =
+        state.anchorPosition?.let { anchorPosition ->
+            state.closestPageToPosition(anchorPosition)?.let { page ->
+                page.prevKey?.plus(1) ?: page.nextKey?.minus(1)
+            }
+        }
+
+    private companion object {
+        const val INITIAL_PAGE = 0
+    }
+}

--- a/data/novel/src/main/java/com/into/websoso/data/novel/NovelSearchPagingSource.kt
+++ b/data/novel/src/main/java/com/into/websoso/data/novel/NovelSearchPagingSource.kt
@@ -8,20 +8,21 @@ internal class NovelSearchPagingSource(
     private val query: String,
     private val api: NovelSearchApi,
 ) : PagingSource<Int, NovelSearchEntity>() {
-    override suspend fun load(params: LoadParams<Int>): LoadResult<Int, NovelSearchEntity> {
-        val page = params.key ?: INITIAL_PAGE
-        val response = api.getNovels(
+    override suspend fun load(params: LoadParams<Int>): LoadResult<Int, NovelSearchEntity> =
+        runCatching {
+            val page = params.key ?: INITIAL_PAGE
+            val response = api.getNovels(
                 query = query,
                 page = page,
                 size = params.loadSize,
             )
 
-        return LoadResult.Page(
-            data = response.novels.map(NovelSearchResponseDto.NovelDto::toData),
-            prevKey = page.takeIf { it > INITIAL_PAGE }?.minus(1),
-            nextKey = (page + 1).takeIf { response.isLoadable },
-        )
-    }
+            LoadResult.Page(
+                data = response.novels.map(NovelSearchResponseDto.NovelDto::toData),
+                prevKey = page.takeIf { it > INITIAL_PAGE }?.minus(1),
+                nextKey = (page + 1).takeIf { response.isLoadable },
+            )
+        }.getOrElse(LoadResult<Int, NovelSearchEntity>::Error)
 
     override fun getRefreshKey(state: PagingState<Int, NovelSearchEntity>): Int? =
         state.anchorPosition?.let { anchorPosition ->

--- a/data/novel/src/main/java/com/into/websoso/data/novel/NovelSearchResponseDto.kt
+++ b/data/novel/src/main/java/com/into/websoso/data/novel/NovelSearchResponseDto.kt
@@ -1,0 +1,33 @@
+package com.into.websoso.data.novel
+
+import com.into.websoso.data.novel.model.NovelSearchEntity
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+internal data class NovelSearchResponseDto(
+    @SerialName("isLoadable")
+    val isLoadable: Boolean,
+    @SerialName("novels")
+    val novels: List<NovelDto>,
+) {
+    @Serializable
+    data class NovelDto(
+        @SerialName("novelId")
+        val novelId: Long,
+        @SerialName("title")
+        val title: String,
+        @SerialName("author")
+        val author: String,
+        @SerialName("novelImage")
+        val imageUrl: String,
+    ) {
+        fun toData(): NovelSearchEntity =
+            NovelSearchEntity(
+                novelId = novelId,
+                title = title,
+                author = author,
+                imageUrl = imageUrl,
+            )
+    }
+}

--- a/data/novel/src/main/java/com/into/websoso/data/novel/model/NovelSearchEntity.kt
+++ b/data/novel/src/main/java/com/into/websoso/data/novel/model/NovelSearchEntity.kt
@@ -1,0 +1,8 @@
+package com.into.websoso.data.novel.model
+
+data class NovelSearchEntity(
+    val novelId: Long,
+    val title: String,
+    val author: String,
+    val imageUrl: String,
+)

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -33,6 +33,7 @@ include(
 include(
     ":data:account",
     ":data:library",
+    ":data:novel",
     ":data:feed",
 )
 


### PR DESCRIPTION
## 📌𝘐𝘴𝘴𝘶𝘦𝘴
- closed #938 

## 📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯

- 작품 검색 데이터 계층을 담당하는 `data:novel` 모듈을 추가했습니다.
- `GET /novels` 작품 검색 API를 정의하고 `query`, `page`, `size` 파라미터를 전달하도록 구현했습니다.
- Retrofit을 통해 작품 검색 API를 제공하는 Hilt 모듈을 추가했습니다.
- 작품 검색 응답 DTO와 컬렉션에서 사용할 검색 엔티티를 구현했습니다.
- 검색 결과의 작품 ID, 제목, 작가 및 이미지 URL을 엔티티로 변환하도록 연결했습니다.
- 작품 검색 요청을 수행하는 `NovelSearchPagingSource`를 구현했습니다.
- 최초 페이지를 0으로 설정하고 이전·다음 페이지 키를 계산하도록 구현했습니다.
- 서버의 `isLoadable` 값을 기준으로 다음 페이지 요청 여부를 결정합니다.
- API 요청 중 발생한 오류를 Paging의 `LoadResult.Error`로 전달하도록 구현했습니다.
- 프로젝트 설정에 `data:novel` 모듈을 등록하고 Network, Paging, Retrofit 및 Serialization 의존성을 연결했습니다.

### 검증

- `./gradlew :data:novel:compileDebugKotlin ktlintCheck --console=plain`
- `data:novel` 모듈 Debug 컴파일 성공
- ktlint 성공
- push 전 전체 단위 테스트 및 앱 Debug 빌드 성공

## 📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵


## 💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴

- `GET /novels`의 요청 파라미터와 응답 모델 매핑을 확인 부탁드립니다.
- `isLoadable`을 기준으로 다음 페이지 키를 결정하는 Paging 로직을 확인 부탁드립니다.
- `PagingSource`는 `params.loadSize`를 API의 `size`로 전달하며, 구체적인 Pager 설정과 화면 연결은 다음 PR에 포함됩니다.
- 실제 검색 화면과 검색 결과 UI는 포함하지 않습니다.
- Base: `feat/937`
- Head: `feat/938`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 소설 검색 결과를 불러오는 기능이 추가되었습니다.
  * 검색 결과를 페이지 단위로 제공해 더 원활하게 탐색할 수 있습니다.
  * 각 결과에서 소설 제목, 작가명, 대표 이미지와 식별 정보를 확인할 수 있습니다.

* **개선 사항**
  * 검색 결과를 안정적으로 처리하며, 네트워크 오류 발생 시 오류 상태를 반환합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->