### PR TITLE
fix: 타 유저 활동기록 더보기 목록이 조회되지 않음

### DIFF
--- a/app/src/main/java/com/into/websoso/ui/activityDetail/ActivityDetailActivity.kt
+++ b/app/src/main/java/com/into/websoso/ui/activityDetail/ActivityDetailActivity.kt
@@ -106,6 +106,10 @@ class ActivityDetailActivity : BaseActivity<ActivityActivityDetailBinding>(activ
     private fun setupUserIDAndSource() {
         activityDetailViewModel.userId = userId
         activityDetailViewModel.updateUserActivities(userId)
+
+        if (activityDetailViewModel.source == SOURCE_OTHER_USER_ACTIVITY) {
+            otherUserPageViewModel.updateUserId(userId)
+        }
     }
 
     private fun setActivityTitle() {


### PR DESCRIPTION
## 📌𝘐𝘴𝘴𝘶𝘦𝘴
- closed #951
https://discord.com/channels/1185753783020568648/1537825273863479326
## 📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯
- 타 유저 페이지 > 활동 > 활동기록 더보기 진입 시 목록이 표시되지 않는 문제를 수정했습니다.
- `ActivityDetailActivity`에서 타 유저 프로필을 직접 조회하도록 `updateUserId()` 호출을 추가했습니다.

**원인**

`ActivityDetailActivity`의 `otherUserPageViewModel`은 `by viewModels()`로 이 액티비티에 새로 생성되는 인스턴스라 `OtherUserPageActivity`의 것과 공유되지 않습니다. `OtherUserPageViewModel`은 `updateUserId()`를 호출해야 프로필을 조회하는데 이 화면에서는 호출되지 않아 `otherUserProfile`이 계속 `null`이었습니다.

```kotlin
if (activities != null && userProfile != null) { ... }
else { activityDetailAdapter.submitList(emptyList()) }   // 프로필이 null이라 항상 여기로 빠짐
```

피드 조회 자체는 성공하지만 어댑터에 빈 리스트가 전달되어 화면에만 아무것도 그려지지 않았습니다.

내 활동은 `MyPageViewModel`이 `init`에서 프로필을 조회하므로 영향이 없습니다.

## 📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵

| 수정 전 | 수정 후 |
|:---:|:---:|
| 목록 항목 0개 (제목만 표시) | 활동 목록 정상 표시 |

**수정 전**
```
GET /users/10032/feeds?lastFeedId=0&size=100  ->  200
{"feeds":[{"feedId":4553,"feedContent":"아아", ...}]}
화면 표시 텍스트: "활동"
```

**수정 후**
```
GET /users/10032/feeds?lastFeedId=0&size=100  ->  200
GET /users/profile/10032                      ->  추가됨
화면 표시 텍스트: "활동" / "test" / "4월 13일" / "아아" ...
```

## 💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 다른 사용자의 활동에서 상세 화면을 열었을 때 해당 사용자 정보가 올바르게 전달되도록 개선했습니다.
  * 활동 상세 정보와 사용자 정보가 더욱 일관되게 갱신됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->