### PR TITLE
fix: 작품 상세 읽기 상태 막대 그래프가 비율대로 표시되지 않음

### DIFF
--- a/app/src/main/java/com/into/websoso/ui/novelInfo/NovelInfoFragment.kt
+++ b/app/src/main/java/com/into/websoso/ui/novelInfo/NovelInfoFragment.kt
@@ -166,42 +166,37 @@ class NovelInfoFragment : BaseFragment<FragmentNovelInfoBinding>(fragment_novel_
     }
 
     private fun updateGraphUi(unifiedReviewCountModel: UnifiedReviewCountModel) {
+        updateGraphHeight(
+            binding.viewNovelInfoReadStatusWatching,
+            unifiedReviewCountModel.watchingCount.graphHeight,
+        )
+        updateGraphHeight(
+            binding.viewNovelInfoReadStatusWatched,
+            unifiedReviewCountModel.watchedCount.graphHeight,
+        )
+        updateGraphHeight(
+            binding.viewNovelInfoReadStatusQuit,
+            unifiedReviewCountModel.quitCount.graphHeight,
+        )
+
         when (unifiedReviewCountModel.maxCountReadStatus()) {
-            WATCHING -> {
-                updateGraphHeight(
-                    binding.viewNovelInfoReadStatusWatching,
-                    unifiedReviewCountModel.watchingCount.graphHeight,
-                )
-                updateGraphSelection(
-                    binding.viewNovelInfoReadStatusWatching,
-                    binding.tvNovelInfoReadStatusWatchingCount,
-                    binding.tvNovelInfoReadStatusWatching,
-                )
-            }
+            WATCHING -> updateGraphSelection(
+                binding.viewNovelInfoReadStatusWatching,
+                binding.tvNovelInfoReadStatusWatchingCount,
+                binding.tvNovelInfoReadStatusWatching,
+            )
 
-            WATCHED -> {
-                updateGraphHeight(
-                    binding.viewNovelInfoReadStatusWatched,
-                    unifiedReviewCountModel.watchedCount.graphHeight,
-                )
-                updateGraphSelection(
-                    binding.viewNovelInfoReadStatusWatched,
-                    binding.tvNovelInfoReadStatusWatchedCount,
-                    binding.tvNovelInfoReadStatusWatched,
-                )
-            }
+            WATCHED -> updateGraphSelection(
+                binding.viewNovelInfoReadStatusWatched,
+                binding.tvNovelInfoReadStatusWatchedCount,
+                binding.tvNovelInfoReadStatusWatched,
+            )
 
-            QUIT -> {
-                updateGraphHeight(
-                    binding.viewNovelInfoReadStatusQuit,
-                    unifiedReviewCountModel.quitCount.graphHeight,
-                )
-                updateGraphSelection(
-                    binding.viewNovelInfoReadStatusQuit,
-                    binding.tvNovelInfoReadStatusQuitCount,
-                    binding.tvNovelInfoReadStatusQuit,
-                )
-            }
+            QUIT -> updateGraphSelection(
+                binding.viewNovelInfoReadStatusQuit,
+                binding.tvNovelInfoReadStatusQuitCount,
+                binding.tvNovelInfoReadStatusQuit,
+            )
 
             else -> Unit
         }

--- a/app/src/main/res/color/bg_novel_info_read_status_graph_selector.xml
+++ b/app/src/main/res/color/bg_novel_info_read_status_graph_selector.xml
@@ -2,5 +2,5 @@
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
 
     <item android:color="@color/primary_100_6A5DFD" android:state_selected="true" />
-    <item android:color="@color/gray_70_DFDFE3" android:state_selected="false" />
+    <item android:color="@color/gray_70_EEEEF2" android:state_selected="false" />
 </selector>

--- a/app/src/main/res/layout/fragment_novel_info.xml
+++ b/app/src/main/res/layout/fragment_novel_info.xml
@@ -246,7 +246,7 @@
                             <View
                                 android:id="@+id/view_novel_info_read_status_watching"
                                 android:layout_width="match_parent"
-                                android:layout_height="80dp"
+                                android:layout_height="100dp"
                                 android:layout_gravity="bottom"
                                 android:background="@color/bg_novel_info_read_status_graph_selector"
                                 tools:layout_height="100dp" />

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -12,6 +12,7 @@
     <color name="gray_20_FAFAFA">#FAFAFA</color>
     <color name="gray_50_F4F5F8">#F4F5F8</color>
     <color name="gray_70_DFDFE3">#DFDFE3</color>
+    <color name="gray_70_EEEEF2">#EEEEF2</color>
     <color name="gray_80_DDDDE3">#DDDDE3</color>
     <color name="gray_100_CBCBD1">#CBCBD1</color>
     <color name="gray_200_949399">#949399</color>


### PR DESCRIPTION
## 📌𝘐𝘴𝘴𝘶𝘦𝘴
- closed #953
https://discord.com/channels/1185753783020568648/1537808439965786192
## 📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯
디자인 QA로 접수된 막대 그래프 이슈를 수정했습니다.

**1. 채움 높이를 세 컬럼 모두에 적용**

막대는 바깥 트랙(`CardView`)과 안쪽 채움(`View`) 2겹 구조이고, 안쪽 채움 높이로 비율을 표현합니다. 그런데 `updateGraphUi()`가 `when (maxCountReadStatus())`로 **최댓값 컬럼 하나만** 높이를 적용해, 나머지 두 컬럼은 XML 기본 높이가 그대로 남아 트랙을 꽉 채운 상태였습니다.

높이 계산(`formattedHeight = viewHeight * count / maxCount`)과 `formattedUnifiedReviewCount()`는 이미 세 컬럼을 모두 계산하고 있어, 적용 지점만 넓히고 강조(선택) 처리만 최댓값에 남겼습니다.

**2. 미선택 채움 색상 `#DFDFE3` → `#EEEEF2`**

디자인의 `UI/gray.70`은 `#EEEEF2`인데 `colors.xml`에는 해당 색이 없었습니다. Compose 토큰에는 `Gray70New = #EEEEF2`로 이미 존재합니다.

**3. `보는 중` 막대 기본 높이 `80dp` → `100dp`**

세 컬럼 중 `보는 중`만 기본 높이가 달랐습니다.

## 📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵

작품 `황후가 되고 싶은 여자` (보는 중 1 / 봤어요 3 / 하차 0) 기준 실측입니다.

| 항목 | 값 | 기대 채움 | 수정 전 | 수정 후 |
|---|---|---|---|---|
| 보는 중 | 1 | 100px (1/3) | 240px | **100px** |
| 봤어요 | 3 | 300px | 300px | 300px |

수정 후에는 밝은 트랙 안에 아래쪽 1/3만 진한 회색으로 채워져 시안과 일치합니다.

## 💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 소설 정보 화면의 독서 상태 그래프 높이를 일관되게 조정했습니다.
  * ‘보고 있어요’ 상태 막대가 다른 상태 막대와 동일한 높이로 표시됩니다.
  * 독서 상태에 따른 그래프 표시가 더욱 안정적으로 갱신됩니다.

* **스타일**
  * 선택되지 않은 독서 상태 그래프의 배경 색상을 보다 자연스러운 밝은 회색으로 변경했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->