### PR TITLE
fix: 상세 탐색 키워드 검색창 터치 영역 및 아이콘 크기 시안 불일치

### DIFF
--- a/app/src/main/java/com/into/websoso/ui/detailExplore/component/DetailExploreKeywordTab.kt
+++ b/app/src/main/java/com/into/websoso/ui/detailExplore/component/DetailExploreKeywordTab.kt
@@ -1,5 +1,7 @@
 package com.into.websoso.ui.detailExplore.component
 
+import androidx.annotation.DrawableRes
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.horizontalScroll
@@ -16,7 +18,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.rememberScrollState
@@ -43,6 +44,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.into.websoso.core.common.ui.model.CategoriesModel.CategoryModel
 import com.into.websoso.core.common.ui.model.CategoriesModel.CategoryModel.KeywordModel
@@ -68,6 +70,10 @@ import com.into.websoso.core.resource.R.string.detail_explore_keyword_search_res
 import com.into.websoso.core.resource.R.string.detail_explore_search_hint
 import com.into.websoso.ui.detailExplore.DetailExploreViewModel
 import com.into.websoso.ui.detailExplore.keyword.model.DetailExploreKeywordUiState
+
+private val SEARCH_FIELD_BUTTON_SIZE = 36.dp
+private val CLEAR_ICON_SIZE = 18.dp
+private val SEARCH_ICON_SIZE = 25.dp
 
 @Composable
 fun DetailExploreKeywordTab(
@@ -148,10 +154,10 @@ private fun KeywordSearchField(
         modifier = Modifier
             .padding(horizontal = 20.dp, vertical = 12.dp)
             .fillMaxWidth()
-            .height(44.dp)
+            .height(42.dp)
             .clip(RoundedCornerShape(14.dp))
             .background(Gray50)
-            .padding(horizontal = 14.dp),
+            .padding(start = 16.dp, end = 10.dp),
         contentAlignment = Alignment.CenterStart,
     ) {
         Row(verticalAlignment = Alignment.CenterVertically) {
@@ -174,23 +180,38 @@ private fun KeywordSearchField(
                 }
             }
             if (value.text.isNotEmpty()) {
-                androidx.compose.foundation.Image(
-                    painter = painterResource(id = ic_common_search_clear),
-                    contentDescription = null,
-                    modifier = Modifier
-                        .size(18.dp)
-                        .clickableWithoutRipple(onClick = onClear),
+                KeywordSearchFieldButton(
+                    iconResId = ic_common_search_clear,
+                    iconSize = CLEAR_ICON_SIZE,
+                    onClick = onClear,
                 )
-                Spacer(modifier = Modifier.width(8.dp))
             }
-            androidx.compose.foundation.Image(
-                painter = painterResource(id = ic_common_search),
-                contentDescription = null,
-                modifier = Modifier
-                    .size(20.dp)
-                    .clickableWithoutRipple(onClick = onSearch),
+            KeywordSearchFieldButton(
+                iconResId = ic_common_search,
+                iconSize = SEARCH_ICON_SIZE,
+                onClick = onSearch,
             )
         }
+    }
+}
+
+@Composable
+private fun KeywordSearchFieldButton(
+    @DrawableRes iconResId: Int,
+    iconSize: Dp,
+    onClick: () -> Unit,
+) {
+    Box(
+        modifier = Modifier
+            .size(SEARCH_FIELD_BUTTON_SIZE)
+            .clickableWithoutRipple(onClick = onClick),
+        contentAlignment = Alignment.Center,
+    ) {
+        Image(
+            painter = painterResource(id = iconResId),
+            contentDescription = null,
+            modifier = Modifier.size(iconSize),
+        )
     }
 }
 


### PR DESCRIPTION
## 📌𝘐𝘴𝘴𝘶𝘦𝘴
- closed #955
https://discord.com/channels/1185753783020568648/1537808439965786192
## 📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯
디자인 QA로 접수된 키워드 검색창 이슈를 수정했습니다.

기존에는 아이콘에 `Modifier.size()`와 `clickableWithoutRipple`을 함께 걸어 **아이콘 크기가 곧 터치 영역**이었습니다. 시안 구조대로 아이콘을 36dp 버튼 안에 배치하도록 `KeywordSearchFieldButton`을 분리했습니다.

| 항목 | 시안 | 수정 전 | 수정 후 |
|---|---|---|---|
| 컨테이너 높이 | 42dp | 44dp | **42dp** |
| 좌우 패딩 | 16dp / 10dp | 14dp / 14dp | **16dp / 10dp** |
| X 아이콘 | 18dp | 18dp | 18dp |
| X 터치 영역 | 36×36dp | 18×18dp | **36dp 버튼** |
| 검색 아이콘 | 25dp | 20dp | **25dp** |
| 검색 터치 영역 | 36×36dp | 20×20dp | **36dp 버튼** |

## 📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵

| | 수정 전 | 수정 후 | 해석 |
|---|---|---|---|
| 좌측 | 102px | 108px | +2dp (start 패딩 14→16) |
| 상단 | 313px | 310px | −1dp (높이 44→42) |

**X 버튼 터치 영역** — 검색어 입력 상태에서 `x=1116..1224` = **36dp** 확인

**동작** — X 탭 시 입력이 지워지고 placeholder로 복귀하는 것까지 확인했습니다.

## 💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴

