### PR TITLE
feat : 컬렉션 생성 화면에 선택 작품 목록 연동

### DIFF
--- a/core/resource/src/main/res/values/strings.xml
+++ b/core/resource/src/main/res/values/strings.xml
@@ -459,6 +459,7 @@
     <string name="collection_create_description_hint">컬렉션에 관련한 설명을 간단하게 작성해주세요</string>
     <string name="collection_create_novel_list">작품 리스트</string>
     <string name="collection_create_add_novel">작품 추가</string>
+    <string name="collection_create_edit_novel">작품 수정</string>
     <string name="collection_create_add">추가</string>
     <string name="collection_create_delete">삭제</string>
     <string name="collection_create_added_novels">추가한 작품</string>

--- a/core/resource/src/main/res/values/strings.xml
+++ b/core/resource/src/main/res/values/strings.xml
@@ -460,6 +460,7 @@
     <string name="collection_create_novel_list">작품 리스트</string>
     <string name="collection_create_add_novel">작품 추가</string>
     <string name="collection_create_edit_novel">작품 수정</string>
+    <string name="collection_create_representative">대표</string>
     <string name="collection_create_add">추가</string>
     <string name="collection_create_delete">삭제</string>
     <string name="collection_create_added_novels">추가한 작품</string>

--- a/feature/collection/src/main/java/com/into/websoso/feature/collection/CollectionCreateScreen.kt
+++ b/feature/collection/src/main/java/com/into/websoso/feature/collection/CollectionCreateScreen.kt
@@ -46,6 +46,7 @@ internal fun CollectionCreateScreen(
         CollectionAppBar(
             actionLabel = "완료",
             onNavigateBack = onNavigateBack,
+            isActionEnabled = collectionName.isNotBlank() && selectedNovels.isNotEmpty(),
         )
         Column(
             modifier = Modifier

--- a/feature/collection/src/main/java/com/into/websoso/feature/collection/CollectionCreateScreen.kt
+++ b/feature/collection/src/main/java/com/into/websoso/feature/collection/CollectionCreateScreen.kt
@@ -5,6 +5,8 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -43,37 +45,44 @@ internal fun CollectionCreateScreen(
             actionLabel = "완료",
             onNavigateBack = onNavigateBack,
         )
-        CollectionPrivacySetting(
-            isPrivate = isPrivate,
-            onPrivateChange = { isPrivate = it },
-        )
-        CollectionNameInput(
-            value = collectionName,
-            onValueChange = { collectionName = it },
-            modifier = Modifier.padding(
-                start = 20.dp,
-                top = 20.dp,
-                end = 20.dp,
-            ),
-        )
-        CollectionDescriptionInput(
-            value = collectionDescription,
-            onValueChange = { collectionDescription = it },
-            modifier = Modifier.padding(
-                start = 20.dp,
-                top = 30.dp,
-                end = 20.dp,
-            ),
-        )
-        CollectionNovelSection(
-            novelCount = selectedNovels.size,
-            onAddNovelClick = onNavigateToNovelSearch,
-            modifier = Modifier.padding(
-                start = 20.dp,
-                top = 30.dp,
-                end = 20.dp,
-            ),
-        )
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .verticalScroll(rememberScrollState()),
+        ) {
+            CollectionPrivacySetting(
+                isPrivate = isPrivate,
+                onPrivateChange = { isPrivate = it },
+            )
+            CollectionNameInput(
+                value = collectionName,
+                onValueChange = { collectionName = it },
+                modifier = Modifier.padding(
+                    start = 20.dp,
+                    top = 20.dp,
+                    end = 20.dp,
+                ),
+            )
+            CollectionDescriptionInput(
+                value = collectionDescription,
+                onValueChange = { collectionDescription = it },
+                modifier = Modifier.padding(
+                    start = 20.dp,
+                    top = 30.dp,
+                    end = 20.dp,
+                ),
+            )
+            CollectionNovelSection(
+                selectedNovels = selectedNovels,
+                onAddNovelClick = onNavigateToNovelSearch,
+                modifier = Modifier.padding(
+                    start = 20.dp,
+                    top = 30.dp,
+                    end = 20.dp,
+                    bottom = 20.dp,
+                ),
+            )
+        }
     }
 }
 

--- a/feature/collection/src/main/java/com/into/websoso/feature/collection/CollectionCreateScreen.kt
+++ b/feature/collection/src/main/java/com/into/websoso/feature/collection/CollectionCreateScreen.kt
@@ -20,9 +20,11 @@ import com.into.websoso.feature.collection.component.CollectionDescriptionInput
 import com.into.websoso.feature.collection.component.CollectionNameInput
 import com.into.websoso.feature.collection.component.CollectionNovelSection
 import com.into.websoso.feature.collection.component.CollectionPrivacySetting
+import com.into.websoso.feature.collection.model.CollectionSelectedNovel
 
 @Composable
 internal fun CollectionCreateScreen(
+    selectedNovels: List<CollectionSelectedNovel>,
     onNavigateBack: () -> Unit,
     onNavigateToNovelSearch: () -> Unit,
     modifier: Modifier = Modifier,
@@ -79,6 +81,7 @@ internal fun CollectionCreateScreen(
 private fun CollectionCreateScreenPreview() {
     WebsosoTheme {
         CollectionCreateScreen(
+            selectedNovels = emptyList(),
             onNavigateBack = {},
             onNavigateToNovelSearch = {},
         )

--- a/feature/collection/src/main/java/com/into/websoso/feature/collection/CollectionCreateScreen.kt
+++ b/feature/collection/src/main/java/com/into/websoso/feature/collection/CollectionCreateScreen.kt
@@ -27,6 +27,8 @@ import com.into.websoso.feature.collection.model.CollectionSelectedNovel
 @Composable
 internal fun CollectionCreateScreen(
     selectedNovels: List<CollectionSelectedNovel>,
+    representativeNovelId: Long?,
+    onRepresentativeNovelClick: (Long) -> Unit,
     onNavigateBack: () -> Unit,
     onNavigateToNovelSearch: () -> Unit,
     modifier: Modifier = Modifier,
@@ -74,6 +76,8 @@ internal fun CollectionCreateScreen(
             )
             CollectionNovelSection(
                 selectedNovels = selectedNovels,
+                representativeNovelId = representativeNovelId,
+                onRepresentativeNovelClick = onRepresentativeNovelClick,
                 onAddNovelClick = onNavigateToNovelSearch,
                 modifier = Modifier.padding(
                     start = 20.dp,
@@ -92,6 +96,8 @@ private fun CollectionCreateScreenPreview() {
     WebsosoTheme {
         CollectionCreateScreen(
             selectedNovels = emptyList(),
+            representativeNovelId = null,
+            onRepresentativeNovelClick = {},
             onNavigateBack = {},
             onNavigateToNovelSearch = {},
         )

--- a/feature/collection/src/main/java/com/into/websoso/feature/collection/CollectionCreateScreen.kt
+++ b/feature/collection/src/main/java/com/into/websoso/feature/collection/CollectionCreateScreen.kt
@@ -66,6 +66,7 @@ internal fun CollectionCreateScreen(
             ),
         )
         CollectionNovelSection(
+            novelCount = selectedNovels.size,
             onAddNovelClick = onNavigateToNovelSearch,
             modifier = Modifier.padding(
                 start = 20.dp,

--- a/feature/collection/src/main/java/com/into/websoso/feature/collection/CollectionLibraryNovelSelectionViewModel.kt
+++ b/feature/collection/src/main/java/com/into/websoso/feature/collection/CollectionLibraryNovelSelectionViewModel.kt
@@ -39,7 +39,7 @@ internal class CollectionLibraryNovelSelectionViewModel
                 if (selectedNovels.any { it.novelId == novel.novelId }) {
                     selectedNovels.filterNot { it.novelId == novel.novelId }
                 } else {
-                    selectedNovels + novel.toSelectedNovel()
+                    listOf(novel.toSelectedNovel()) + selectedNovels
                 }
             }
         }

--- a/feature/collection/src/main/java/com/into/websoso/feature/collection/CollectionNavHost.kt
+++ b/feature/collection/src/main/java/com/into/websoso/feature/collection/CollectionNavHost.kt
@@ -39,9 +39,13 @@ fun CollectionNavHost(
         composable(route = COLLECTION_CREATE_ROUTE) { backStackEntry ->
             val novelSearchViewModel: CollectionNovelSearchViewModel = hiltViewModel(backStackEntry)
             val selectedNovels by novelSearchViewModel.selectedNovels.collectAsStateWithLifecycle()
+            val representativeNovelId by
+                novelSearchViewModel.representativeNovelId.collectAsStateWithLifecycle()
 
             CollectionCreateScreen(
                 selectedNovels = selectedNovels,
+                representativeNovelId = representativeNovelId,
+                onRepresentativeNovelClick = novelSearchViewModel::updateRepresentativeNovel,
                 onNavigateBack = navController::popBackStack,
                 onNavigateToNovelSearch = {
                     navController.navigate(COLLECTION_NOVEL_SEARCH_ROUTE)

--- a/feature/collection/src/main/java/com/into/websoso/feature/collection/CollectionNavHost.kt
+++ b/feature/collection/src/main/java/com/into/websoso/feature/collection/CollectionNavHost.kt
@@ -56,7 +56,8 @@ fun CollectionNavHost(
             val createBackStackEntry = remember(backStackEntry) {
                 navController.getBackStackEntry(COLLECTION_CREATE_ROUTE)
             }
-            val novelSearchViewModel: CollectionNovelSearchViewModel = hiltViewModel(createBackStackEntry)
+            val novelSearchViewModel: CollectionNovelSearchViewModel =
+                hiltViewModel(createBackStackEntry)
 
             CollectionNovelSearchRoute(
                 viewModel = novelSearchViewModel,
@@ -70,10 +71,12 @@ fun CollectionNavHost(
             val createBackStackEntry = remember(backStackEntry) {
                 navController.getBackStackEntry(COLLECTION_CREATE_ROUTE)
             }
-            val novelSearchViewModel: CollectionNovelSearchViewModel = hiltViewModel(createBackStackEntry)
+            val novelSearchViewModel: CollectionNovelSearchViewModel =
+                hiltViewModel(createBackStackEntry)
+            val selectedNovels by novelSearchViewModel.selectedNovels.collectAsStateWithLifecycle()
 
             CollectionLibraryNovelSelectionRoute(
-                initialSelectedNovels = novelSearchViewModel.selectedNovels.value,
+                initialSelectedNovels = selectedNovels,
                 onAddClick = { selectedNovels ->
                     novelSearchViewModel.updateSelectedNovels(selectedNovels)
                     navController.popBackStack()

--- a/feature/collection/src/main/java/com/into/websoso/feature/collection/CollectionNavHost.kt
+++ b/feature/collection/src/main/java/com/into/websoso/feature/collection/CollectionNavHost.kt
@@ -1,9 +1,11 @@
 package com.into.websoso.feature.collection
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
@@ -34,8 +36,12 @@ fun CollectionNavHost(
                 },
             )
         }
-        composable(route = COLLECTION_CREATE_ROUTE) {
+        composable(route = COLLECTION_CREATE_ROUTE) { backStackEntry ->
+            val novelSearchViewModel: CollectionNovelSearchViewModel = hiltViewModel(backStackEntry)
+            val selectedNovels by novelSearchViewModel.selectedNovels.collectAsStateWithLifecycle()
+
             CollectionCreateScreen(
+                selectedNovels = selectedNovels,
                 onNavigateBack = navController::popBackStack,
                 onNavigateToNovelSearch = {
                     navController.navigate(COLLECTION_NOVEL_SEARCH_ROUTE)

--- a/feature/collection/src/main/java/com/into/websoso/feature/collection/CollectionNovelSearchViewModel.kt
+++ b/feature/collection/src/main/java/com/into/websoso/feature/collection/CollectionNovelSearchViewModel.kt
@@ -15,7 +15,6 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
-import kotlinx.coroutines.flow.update
 import javax.inject.Inject
 
 @HiltViewModel
@@ -29,6 +28,9 @@ internal class CollectionNovelSearchViewModel
 
         private val _selectedNovels = MutableStateFlow<List<CollectionSelectedNovel>>(emptyList())
         val selectedNovels: StateFlow<List<CollectionSelectedNovel>> = _selectedNovels.asStateFlow()
+
+        private val _representativeNovelId = MutableStateFlow<Long?>(null)
+        val representativeNovelId: StateFlow<Long?> = _representativeNovelId.asStateFlow()
 
         @OptIn(ExperimentalCoroutinesApi::class)
         val searchResults: Flow<PagingData<NovelSearchEntity>> =
@@ -46,23 +48,37 @@ internal class CollectionNovelSearchViewModel
         }
 
         fun addNovel(novel: NovelSearchEntity) {
-            _selectedNovels.update { selectedNovels ->
-                if (selectedNovels.any { it.novelId == novel.novelId }) {
-                    selectedNovels
-                } else {
-                    selectedNovels + novel.toSelectedNovel()
-                }
-            }
+            if (_selectedNovels.value.any { it.novelId == novel.novelId }) return
+
+            _selectedNovels.value += novel.toSelectedNovel()
+            _representativeNovelId.value = novel.novelId
         }
 
         fun removeNovel(novelId: Long) {
-            _selectedNovels.update { selectedNovels ->
-                selectedNovels.filterNot { it.novelId == novelId }
+            val remainingNovels = _selectedNovels.value.filterNot { it.novelId == novelId }
+            _selectedNovels.value = remainingNovels
+
+            if (_representativeNovelId.value == novelId) {
+                _representativeNovelId.value = remainingNovels.lastOrNull()?.novelId
             }
         }
 
         fun updateSelectedNovels(novels: List<CollectionSelectedNovel>) {
+            val previousNovelIds = _selectedNovels.value.map(CollectionSelectedNovel::novelId)
+            val novelIds = novels.map(CollectionSelectedNovel::novelId)
+            val selectedNovelIds = novelIds.toSet()
+            val onlyRemovedNovels = novelIds == previousNovelIds.filter { it in selectedNovelIds }
             _selectedNovels.value = novels
+
+            if (!onlyRemovedNovels || _representativeNovelId.value !in selectedNovelIds) {
+                _representativeNovelId.value = novelIds.lastOrNull()
+            }
+        }
+
+        fun updateRepresentativeNovel(novelId: Long) {
+            if (_selectedNovels.value.any { it.novelId == novelId }) {
+                _representativeNovelId.value = novelId
+            }
         }
     }
 

--- a/feature/collection/src/main/java/com/into/websoso/feature/collection/CollectionNovelSearchViewModel.kt
+++ b/feature/collection/src/main/java/com/into/websoso/feature/collection/CollectionNovelSearchViewModel.kt
@@ -50,7 +50,7 @@ internal class CollectionNovelSearchViewModel
         fun addNovel(novel: NovelSearchEntity) {
             if (_selectedNovels.value.any { it.novelId == novel.novelId }) return
 
-            _selectedNovels.value += novel.toSelectedNovel()
+            _selectedNovels.value = listOf(novel.toSelectedNovel()) + _selectedNovels.value
             _representativeNovelId.value = novel.novelId
         }
 
@@ -59,7 +59,7 @@ internal class CollectionNovelSearchViewModel
             _selectedNovels.value = remainingNovels
 
             if (_representativeNovelId.value == novelId) {
-                _representativeNovelId.value = remainingNovels.lastOrNull()?.novelId
+                _representativeNovelId.value = remainingNovels.firstOrNull()?.novelId
             }
         }
 
@@ -71,7 +71,7 @@ internal class CollectionNovelSearchViewModel
             _selectedNovels.value = novels
 
             if (!onlyRemovedNovels || _representativeNovelId.value !in selectedNovelIds) {
-                _representativeNovelId.value = novelIds.lastOrNull()
+                _representativeNovelId.value = novelIds.firstOrNull()
             }
         }
 

--- a/feature/collection/src/main/java/com/into/websoso/feature/collection/component/CollectionNovelSection.kt
+++ b/feature/collection/src/main/java/com/into/websoso/feature/collection/component/CollectionNovelSection.kt
@@ -11,7 +11,9 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.requiredSize
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.selection.selectable
 import androidx.compose.foundation.selection.selectableGroup
@@ -94,7 +96,7 @@ internal fun CollectionNovelSection(
                 modifier = Modifier.selectableGroup(),
                 verticalArrangement = Arrangement.spacedBy(12.dp),
             ) {
-                (listOf<CollectionSelectedNovel?>(null) + selectedNovels.asReversed())
+                (listOf<CollectionSelectedNovel?>(null) + selectedNovels)
                     .chunked(3)
                     .forEach { rowItems ->
                         Row(
@@ -213,21 +215,34 @@ private fun CollectionNovelItem(
                 modifier = Modifier
                     .align(Alignment.TopEnd)
                     .padding(8.dp)
-                    .height(18.dp)
+                    .size(
+                        width = if (isRepresentative) 40.dp else 32.dp,
+                        height = 18.dp,
+                    )
                     .background(
                         color = if (isRepresentative) Primary100 else Gray100,
                         shape = RoundedCornerShape(4.dp),
-                    ).padding(horizontal = 6.dp),
-                horizontalArrangement = Arrangement.spacedBy(2.dp),
+                    ),
+                horizontalArrangement = Arrangement.spacedBy(
+                    space = 2.dp,
+                    alignment = Alignment.CenterHorizontally,
+                ),
                 verticalAlignment = Alignment.CenterVertically,
             ) {
                 if (isRepresentative) {
-                    Icon(
-                        painter = painterResource(id = ic_library_sort_check),
-                        contentDescription = null,
-                        tint = White,
-                        modifier = Modifier.size(10.dp),
-                    )
+                    Box(
+                        modifier = Modifier
+                            .size(width = 8.4.dp, height = 6.dp)
+                            .offset(y = (-0.5).dp),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        Icon(
+                            painter = painterResource(id = ic_library_sort_check),
+                            contentDescription = null,
+                            tint = White,
+                            modifier = Modifier.requiredSize(14.4.dp),
+                        )
+                    }
                 }
                 Text(
                     text = stringResource(collection_create_representative),

--- a/feature/collection/src/main/java/com/into/websoso/feature/collection/component/CollectionNovelSection.kt
+++ b/feature/collection/src/main/java/com/into/websoso/feature/collection/component/CollectionNovelSection.kt
@@ -5,6 +5,9 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -14,14 +17,17 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.into.websoso.core.designsystem.component.NetworkImage
 import com.into.websoso.core.designsystem.theme.Black
 import com.into.websoso.core.designsystem.theme.Gray200
 import com.into.websoso.core.designsystem.theme.Gray50
@@ -30,16 +36,18 @@ import com.into.websoso.core.designsystem.theme.WebsosoTheme
 import com.into.websoso.core.resource.R.drawable.ic_plus_novel
 import com.into.websoso.core.resource.R.string.collection_create_add_novel
 import com.into.websoso.core.resource.R.string.collection_create_count
+import com.into.websoso.core.resource.R.string.collection_create_edit_novel
 import com.into.websoso.core.resource.R.string.collection_create_novel_list
+import com.into.websoso.feature.collection.model.CollectionSelectedNovel
 
 @Composable
 internal fun CollectionNovelSection(
-    novelCount: Int,
+    selectedNovels: List<CollectionSelectedNovel>,
     onAddNovelClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val addCardShape = RoundedCornerShape(8.dp)
     val novelList = stringResource(collection_create_novel_list)
+
     Column(
         modifier = modifier,
         verticalArrangement = Arrangement.spacedBy(12.dp),
@@ -59,38 +67,115 @@ internal fun CollectionNovelSection(
                 style = WebsosoTheme.typography.title2,
             )
             Text(
-                text = stringResource(collection_create_count, novelCount, 100),
+                text = stringResource(collection_create_count, selectedNovels.size, 100),
                 color = Gray200,
                 style = WebsosoTheme.typography.body3,
             )
         }
-        Column(
-            modifier = Modifier
-                .size(width = 103.dp, height = 160.dp)
-                .clip(addCardShape)
-                .background(
-                    color = Gray50,
-                    shape = addCardShape,
-                ).clickable(
-                    onClick = onAddNovelClick,
-                    role = Role.Button,
-                ),
-            horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.Center,
-        ) {
-            Text(
-                text = stringResource(collection_create_add_novel),
-                color = Gray200,
-                style = WebsosoTheme.typography.title4,
-                modifier = Modifier.padding(bottom = 4.dp),
+        if (selectedNovels.isEmpty()) {
+            CollectionNovelEditCard(
+                label = stringResource(collection_create_add_novel),
+                onClick = onAddNovelClick,
+                modifier = Modifier.size(width = 103.dp, height = 160.dp),
             )
-            Icon(
-                painter = painterResource(id = ic_plus_novel),
-                contentDescription = null,
-                tint = Gray200,
-                modifier = Modifier.size(24.dp),
-            )
+        } else {
+            Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                (listOf<CollectionSelectedNovel?>(null) + selectedNovels)
+                    .chunked(3)
+                    .forEach { rowItems ->
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            horizontalArrangement = Arrangement.spacedBy(8.dp),
+                        ) {
+                            rowItems.forEach { novel ->
+                                if (novel == null) {
+                                    CollectionNovelEditCard(
+                                        label = stringResource(collection_create_edit_novel),
+                                        onClick = onAddNovelClick,
+                                        modifier = Modifier
+                                            .weight(1f)
+                                            .height(156.dp),
+                                    )
+                                } else {
+                                    CollectionNovelItem(
+                                        novel = novel,
+                                        modifier = Modifier.weight(1f),
+                                    )
+                                }
+                            }
+                            repeat(3 - rowItems.size) {
+                                Spacer(modifier = Modifier.weight(1f))
+                            }
+                        }
+                    }
+            }
         }
+    }
+}
+
+@Composable
+private fun CollectionNovelEditCard(
+    label: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val shape = RoundedCornerShape(8.dp)
+
+    Column(
+        modifier = modifier
+            .clip(shape)
+            .background(
+                color = Gray50,
+                shape = shape,
+            ).clickable(
+                onClick = onClick,
+                role = Role.Button,
+            ),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center,
+    ) {
+        Text(
+            text = label,
+            color = Gray200,
+            style = WebsosoTheme.typography.title4,
+            modifier = Modifier.padding(bottom = 4.dp),
+        )
+        Icon(
+            painter = painterResource(id = ic_plus_novel),
+            contentDescription = null,
+            tint = Gray200,
+            modifier = Modifier.size(24.dp),
+        )
+    }
+}
+
+@Composable
+private fun CollectionNovelItem(
+    novel: CollectionSelectedNovel,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier,
+        verticalArrangement = Arrangement.spacedBy(6.dp),
+    ) {
+        NetworkImage(
+            imageUrl = novel.imageUrl,
+            contentDescription = novel.title,
+            contentScale = ContentScale.Crop,
+            // TODO: 기획·디자인 확인 후 Alignment.Center 적용 여부 재검토
+            alignment = Alignment.BottomCenter,
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(156.dp)
+                .clip(RoundedCornerShape(8.dp)),
+        )
+        Text(
+            text = novel.title,
+            color = Black,
+            style = WebsosoTheme.typography.body4,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+        )
     }
 }
 
@@ -99,7 +184,7 @@ internal fun CollectionNovelSection(
 private fun CollectionNovelSectionPreview() {
     WebsosoTheme {
         CollectionNovelSection(
-            novelCount = 0,
+            selectedNovels = emptyList(),
             onAddNovelClick = {},
         )
     }

--- a/feature/collection/src/main/java/com/into/websoso/feature/collection/component/CollectionNovelSection.kt
+++ b/feature/collection/src/main/java/com/into/websoso/feature/collection/component/CollectionNovelSection.kt
@@ -34,6 +34,7 @@ import com.into.websoso.core.resource.R.string.collection_create_novel_list
 
 @Composable
 internal fun CollectionNovelSection(
+    novelCount: Int,
     onAddNovelClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -58,7 +59,7 @@ internal fun CollectionNovelSection(
                 style = WebsosoTheme.typography.title2,
             )
             Text(
-                text = stringResource(collection_create_count, 0, 100),
+                text = stringResource(collection_create_count, novelCount, 100),
                 color = Gray200,
                 style = WebsosoTheme.typography.body3,
             )
@@ -97,6 +98,9 @@ internal fun CollectionNovelSection(
 @Composable
 private fun CollectionNovelSectionPreview() {
     WebsosoTheme {
-        CollectionNovelSection(onAddNovelClick = {})
+        CollectionNovelSection(
+            novelCount = 0,
+            onAddNovelClick = {},
+        )
     }
 }

--- a/feature/collection/src/main/java/com/into/websoso/feature/collection/component/CollectionNovelSection.kt
+++ b/feature/collection/src/main/java/com/into/websoso/feature/collection/component/CollectionNovelSection.kt
@@ -1,15 +1,20 @@
 package com.into.websoso.feature.collection.component
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.selection.selectable
+import androidx.compose.foundation.selection.selectableGroup
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
@@ -29,20 +34,26 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.into.websoso.core.designsystem.component.NetworkImage
 import com.into.websoso.core.designsystem.theme.Black
+import com.into.websoso.core.designsystem.theme.Gray100
 import com.into.websoso.core.designsystem.theme.Gray200
 import com.into.websoso.core.designsystem.theme.Gray50
 import com.into.websoso.core.designsystem.theme.Primary100
 import com.into.websoso.core.designsystem.theme.WebsosoTheme
+import com.into.websoso.core.designsystem.theme.White
+import com.into.websoso.core.resource.R.drawable.ic_library_sort_check
 import com.into.websoso.core.resource.R.drawable.ic_plus_novel
 import com.into.websoso.core.resource.R.string.collection_create_add_novel
 import com.into.websoso.core.resource.R.string.collection_create_count
 import com.into.websoso.core.resource.R.string.collection_create_edit_novel
 import com.into.websoso.core.resource.R.string.collection_create_novel_list
+import com.into.websoso.core.resource.R.string.collection_create_representative
 import com.into.websoso.feature.collection.model.CollectionSelectedNovel
 
 @Composable
 internal fun CollectionNovelSection(
     selectedNovels: List<CollectionSelectedNovel>,
+    representativeNovelId: Long?,
+    onRepresentativeNovelClick: (Long) -> Unit,
     onAddNovelClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -79,8 +90,11 @@ internal fun CollectionNovelSection(
                 modifier = Modifier.size(width = 103.dp, height = 160.dp),
             )
         } else {
-            Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
-                (listOf<CollectionSelectedNovel?>(null) + selectedNovels)
+            Column(
+                modifier = Modifier.selectableGroup(),
+                verticalArrangement = Arrangement.spacedBy(12.dp),
+            ) {
+                (listOf<CollectionSelectedNovel?>(null) + selectedNovels.asReversed())
                     .chunked(3)
                     .forEach { rowItems ->
                         Row(
@@ -99,6 +113,10 @@ internal fun CollectionNovelSection(
                                 } else {
                                     CollectionNovelItem(
                                         novel = novel,
+                                        isRepresentative = novel.novelId == representativeNovelId,
+                                        onRepresentativeClick = {
+                                            onRepresentativeNovelClick(novel.novelId)
+                                        },
                                         modifier = Modifier.weight(1f),
                                     )
                                 }
@@ -152,23 +170,72 @@ private fun CollectionNovelEditCard(
 @Composable
 private fun CollectionNovelItem(
     novel: CollectionSelectedNovel,
+    isRepresentative: Boolean,
+    onRepresentativeClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    val thumbnailShape = RoundedCornerShape(8.dp)
+
     Column(
         modifier = modifier,
         verticalArrangement = Arrangement.spacedBy(6.dp),
     ) {
-        NetworkImage(
-            imageUrl = novel.imageUrl,
-            contentDescription = novel.title,
-            contentScale = ContentScale.Crop,
-            // TODO: 기획·디자인 확인 후 Alignment.Center 적용 여부 재검토
-            alignment = Alignment.BottomCenter,
+        Box(
             modifier = Modifier
                 .fillMaxWidth()
                 .height(156.dp)
-                .clip(RoundedCornerShape(8.dp)),
-        )
+                .clip(thumbnailShape)
+                .selectable(
+                    selected = isRepresentative,
+                    onClick = onRepresentativeClick,
+                    role = Role.RadioButton,
+                ).then(
+                    if (isRepresentative) {
+                        Modifier.border(
+                            width = 2.dp,
+                            color = Primary100,
+                            shape = thumbnailShape,
+                        )
+                    } else {
+                        Modifier
+                    },
+                ),
+        ) {
+            NetworkImage(
+                imageUrl = novel.imageUrl,
+                contentDescription = novel.title,
+                contentScale = ContentScale.Crop,
+                // TODO: 기획·디자인 확인 후 Alignment.Center 적용 여부 재검토
+                alignment = Alignment.BottomCenter,
+                modifier = Modifier.fillMaxSize(),
+            )
+            Row(
+                modifier = Modifier
+                    .align(Alignment.TopEnd)
+                    .padding(8.dp)
+                    .height(18.dp)
+                    .background(
+                        color = if (isRepresentative) Primary100 else Gray100,
+                        shape = RoundedCornerShape(4.dp),
+                    ).padding(horizontal = 6.dp),
+                horizontalArrangement = Arrangement.spacedBy(2.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                if (isRepresentative) {
+                    Icon(
+                        painter = painterResource(id = ic_library_sort_check),
+                        contentDescription = null,
+                        tint = White,
+                        modifier = Modifier.size(10.dp),
+                    )
+                }
+                Text(
+                    text = stringResource(collection_create_representative),
+                    color = White,
+                    style = WebsosoTheme.typography.label2,
+                )
+            }
+        }
         Text(
             text = novel.title,
             color = Black,
@@ -185,6 +252,8 @@ private fun CollectionNovelSectionPreview() {
     WebsosoTheme {
         CollectionNovelSection(
             selectedNovels = emptyList(),
+            representativeNovelId = null,
+            onRepresentativeNovelClick = {},
             onAddNovelClick = {},
         )
     }

--- a/feature/collection/src/main/java/com/into/websoso/feature/collection/component/CollectionNovelSection.kt
+++ b/feature/collection/src/main/java/com/into/websoso/feature/collection/component/CollectionNovelSection.kt
@@ -218,8 +218,7 @@ private fun CollectionNovelItem(
                     .size(
                         width = if (isRepresentative) 40.dp else 32.dp,
                         height = 18.dp,
-                    )
-                    .background(
+                    ).background(
                         color = if (isRepresentative) Primary100 else Gray100,
                         shape = RoundedCornerShape(4.dp),
                     ),


### PR DESCRIPTION
## 📌𝘐𝘴𝘴𝘶𝘦𝘴
- closed #940

## 📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯
- 작품 검색 및 서재에서 선택한 작품 목록을 컬렉션 생성 화면과 연동했습니다.
- 선택 작품 개수를 `(선택 개수/100)` 형식으로 표시했습니다.
- 선택 작품을 최근 추가 순서대로 3열 그리드에 표시하고, 작품 수정 진입 카드를 추가했습니다.
- 마지막으로 추가한 작품을 기본 대표 작품으로 설정하고, 대표 작품을 직접 변경할 수 있도록 구현했습니다.
- 대표 작품 변경 시 작품의 표시 순서는 유지되도록 처리했습니다.
- 컬렉션 이름이 입력되고 작품이 1개 이상 선택된 경우에만 완료 버튼이 활성화되도록 적용했습니다.

## 📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵

https://github.com/user-attachments/assets/f947fbc2-4063-4a5b-a583-f20cdc56be2c



## 💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴
- 해당 PR은 `feat/939`를 base로 하는 stacked PR입니다.
- 작품 썸네일은 현재 요구사항에 따라 `BottomCenter` 기준으로 크롭했습니다. 디자인 확인 결과에 따라 `Center`로 변경될 수 있습니다.
- 작품은 최근 추가한 순서대로 앞에 표시되며, 대표 작품을 변경해도 작품 순서는 변경되지 않습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 컬렉션 생성 화면을 추가했습니다.
  * 컬렉션 이름과 설명, 비공개 설정을 입력할 수 있습니다.
  * 서재 또는 검색을 통해 작품을 추가하고 삭제할 수 있습니다.
  * 대표 작품을 지정하고 선택한 작품 목록과 개수를 확인할 수 있습니다.
  * 작품 검색 및 서재 작품 선택 화면을 제공합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->