### PR TITLE
fix: CI Full Build 메모리 부족 문제 개선

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,8 @@
 # http://www.gradle.org/docs/current/userguide/build_environment.html
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
-org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx4g -XX:MaxMetaspaceSize=1g -Dfile.encoding=UTF-8
+kotlin.daemon.jvmargs=-Xmx2g
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects


### PR DESCRIPTION
## 📌𝘐𝘴𝘴𝘶𝘦𝘴
- closed #959

## 📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯
- Gradle Daemon의 최대 힙 크기를 2GB에서 4GB로 조정했습니다.
- Gradle Metaspace의 최대 크기를 1GB로 제한했습니다.
- Kotlin Daemon의 최대 힙 크기를 2GB로 설정했습니다.
- Push CI의 Full Build와 Gradle 병렬 빌드 설정은 유지했습니다.

## 📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵

## 💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴

Push CI에서는 머지 후 전체 검증을 위해 `./gradlew build --scan`을 실행하고 있습니다. 이 과정에서 debug lint, release lint, R8 축소 작업 등이 병렬로 수행될 때 기존 Gradle Daemon의 2GB 힙을 초과하여 `Java heap space` 오류가 발생했습니다.

PR CI의 작업 범위를 줄이거나 Push CI의 병렬 빌드를 비활성화하지 않고, Full Build의 검증 범위와 실행 방식을 유지하기 위해 JVM 메모리 설정을 조정했습니다.

```
org.gradle.jvmargs=-Xmx4g -XX:MaxMetaspaceSize=1g -Dfile.encoding=UTF-8
kotlin.daemon.jvmargs=-Xmx2g
```

각 값은 프로세스가 즉시 점유하는 메모리가 아니라 사용할 수 있는 최대 한도입니다. Gradle Daemon은 최대 4GB 힙과 1GB Metaspace를 사용하고, 별도 프로세스인 Kotlin Daemon은 최대 2GB 힙을 사용하도록 제한했습니다.

### 검증 결과

로컬에서 Push CI와 동일한 명령을 실행했습니다.

```
./gradlew build --scan
```

- BUILD SUCCESSFUL (17m 24s)
- 1,775개 태스크 처리
- 기존 실패 구간인 `lintAnalyzeDebug`, `lintVitalAnalyzeRelease`, `minifyReleaseWithR8` 통과
- Git hook의 `ktlintCheck`, `testDebugUnitTest`, `:app:assembleDebug` 통과

Build Scan은 Gradle Terms of Use 미동의로 게시되지 않았지만, 빌드 자체는 정상 완료되었습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **개선 사항**
  - 대규모 프로젝트 빌드 작업에서 사용할 수 있는 메모리 용량을 조정해 빌드 안정성과 처리 성능을 개선했습니다.
  - Kotlin 관련 빌드 작업의 메모리 사용량도 함께 최적화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->