### PR TITLE
fix: 서재·알림 화면 시안 반영

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -23,7 +23,7 @@ android {
         versionName = libs.versions.versionName.get()
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 
-        targetSdk = 35
+        targetSdk = 36
 
         buildConfigs(rootDir) {
             string(name = "S3_BASE_URL", key = "s3.url")

--- a/app/src/main/java/com/into/websoso/core/common/util/navigator/WebsosoNavigator.kt
+++ b/app/src/main/java/com/into/websoso/core/common/util/navigator/WebsosoNavigator.kt
@@ -6,6 +6,7 @@ import com.into.websoso.core.common.navigator.NavigatorProvider
 import com.into.websoso.ui.login.LoginActivity
 import com.into.websoso.ui.main.MainActivity
 import com.into.websoso.ui.normalExplore.NormalExploreActivity
+import com.into.websoso.ui.notificationSetting.NotificationSettingActivity
 import com.into.websoso.ui.novelDetail.NovelDetailActivity
 import com.into.websoso.ui.onboarding.OnboardingActivity
 import com.into.websoso.ui.userStorage.UserStorageActivity
@@ -64,6 +65,11 @@ internal class WebsosoNavigator
 
         override fun navigateToNormalExploreActivity(startActivity: (Intent) -> Unit) {
             val intent = NormalExploreActivity.getIntent(context)
+            startActivity(intent)
+        }
+
+        override fun navigateToNotificationSettingActivity(startActivity: (Intent) -> Unit) {
+            val intent = NotificationSettingActivity.getIntent(context)
             startActivity(intent)
         }
     }

--- a/app/src/main/java/com/into/websoso/ui/main/library/LibraryFragment.kt
+++ b/app/src/main/java/com/into/websoso/ui/main/library/LibraryFragment.kt
@@ -42,6 +42,9 @@ class LibraryFragment : Fragment() {
                         navigateToNovelDetailActivity = { novelId ->
                             websosoNavigator.navigateToNovelDetailActivity(novelId, ::startActivity)
                         },
+                        navigateToNotificationSettingActivity = {
+                            websosoNavigator.navigateToNotificationSettingActivity(::startActivity)
+                        },
                     )
                 }
             }

--- a/app/src/main/java/com/into/websoso/ui/novelNotification/component/NovelNotificationEmptyView.kt
+++ b/app/src/main/java/com/into/websoso/ui/novelNotification/component/NovelNotificationEmptyView.kt
@@ -37,7 +37,7 @@ fun NovelNotificationEmptyView(
         modifier = modifier.fillMaxSize(),
         horizontalAlignment = CenterHorizontally,
     ) {
-        Spacer(modifier = Modifier.weight(1f))
+        Spacer(modifier = Modifier.weight(2f))
         Image(
             imageVector = ImageVector.vectorResource(id = ic_storage_null),
             contentDescription = null,
@@ -64,7 +64,7 @@ fun NovelNotificationEmptyView(
                 color = Primary100,
             )
         }
-        Spacer(modifier = Modifier.weight(2f))
+        Spacer(modifier = Modifier.weight(3f))
     }
 }
 

--- a/app/src/main/java/com/into/websoso/ui/novelNotification/component/NovelNotificationListAppBar.kt
+++ b/app/src/main/java/com/into/websoso/ui/novelNotification/component/NovelNotificationListAppBar.kt
@@ -2,19 +2,23 @@ package com.into.websoso.ui.novelNotification.component
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment.Companion.CenterVertically
+import androidx.compose.ui.Alignment.Companion.Center as CenterAlignment
+import androidx.compose.ui.Alignment.Companion.CenterEnd
+import androidx.compose.ui.Alignment.Companion.CenterStart
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale.Companion.FillHeight
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign.Companion.Center
+import androidx.compose.ui.text.style.TextOverflow.Companion.Ellipsis
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.into.websoso.core.common.util.clickableWithoutRipple
@@ -31,6 +35,9 @@ import com.into.websoso.domain.model.NovelNotificationType.COMPLETION
 import com.into.websoso.domain.model.NovelNotificationType.HIATUS_RETURN
 import com.into.websoso.ui.novelNotification.novelNotificationTitleRes
 
+// 뒤로가기(6 + 44)와 액션 영역을 침범하지 않도록 제목이 쓸 수 있는 좌우 여백
+private val TITLE_HORIZONTAL_MARGIN = 70.dp
+
 @Composable
 fun NovelNotificationListAppBar(
     notificationType: NovelNotificationType,
@@ -42,30 +49,33 @@ fun NovelNotificationListAppBar(
     onDeleteButtonClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    Row(
+    Box(
         modifier = modifier
             .background(White)
             .fillMaxWidth()
-            .padding(start = 6.dp, end = 20.dp)
             .height(44.dp),
-        verticalAlignment = CenterVertically,
     ) {
         Image(
             painter = painterResource(id = ic_notification_back),
             contentDescription = null,
             contentScale = FillHeight,
             modifier = Modifier
+                .align(CenterStart)
+                .padding(start = 6.dp)
                 .size(44.dp)
                 .clickableWithoutRipple { onBackButtonClick() },
         )
+        // 뒤로가기/액션 유무와 무관하게 제목이 화면 정중앙에 오도록 Box 위에 겹쳐 배치한다
         Text(
             text = stringResource(notificationType.novelNotificationTitleRes()),
             style = WebsosoTheme.typography.title2,
             color = Black,
             textAlign = Center,
+            maxLines = 1,
+            overflow = Ellipsis,
             modifier = Modifier
-                .weight(1f)
-                .padding(start = 24.dp),
+                .align(CenterAlignment)
+                .padding(horizontal = TITLE_HORIZONTAL_MARGIN),
         )
         if (isActionVisible) {
             NovelNotificationListAppBarAction(
@@ -73,24 +83,28 @@ fun NovelNotificationListAppBar(
                 isDeletable = isDeletable,
                 onEditButtonClick = onEditButtonClick,
                 onDeleteButtonClick = onDeleteButtonClick,
+                modifier = Modifier
+                    .align(CenterEnd)
+                    .padding(end = 20.dp),
             )
         }
     }
 }
 
 @Composable
-private fun NovelNotificationListAppBarAction(
+private fun BoxScope.NovelNotificationListAppBarAction(
     isEditing: Boolean,
     isDeletable: Boolean,
     onEditButtonClick: () -> Unit,
     onDeleteButtonClick: () -> Unit,
+    modifier: Modifier = Modifier,
 ) {
     when (isEditing) {
         true -> Text(
             text = stringResource(novel_notification_delete),
             style = WebsosoTheme.typography.title2,
             color = if (isDeletable) Gray300 else Gray200,
-            modifier = Modifier.clickableWithoutRipple {
+            modifier = modifier.clickableWithoutRipple {
                 if (isDeletable) onDeleteButtonClick()
             },
         )
@@ -99,7 +113,7 @@ private fun NovelNotificationListAppBarAction(
             text = stringResource(novel_notification_edit),
             style = WebsosoTheme.typography.title2,
             color = Gray300,
-            modifier = Modifier.clickableWithoutRipple { onEditButtonClick() },
+            modifier = modifier.clickableWithoutRipple { onEditButtonClick() },
         )
     }
 }

--- a/app/src/main/java/com/into/websoso/ui/novelNotification/component/NovelNotificationListAppBar.kt
+++ b/app/src/main/java/com/into/websoso/ui/novelNotification/component/NovelNotificationListAppBar.kt
@@ -10,7 +10,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment.Companion.Center as CenterAlignment
 import androidx.compose.ui.Alignment.Companion.CenterEnd
 import androidx.compose.ui.Alignment.Companion.CenterStart
 import androidx.compose.ui.Modifier
@@ -34,6 +33,7 @@ import com.into.websoso.domain.model.NovelNotificationType
 import com.into.websoso.domain.model.NovelNotificationType.COMPLETION
 import com.into.websoso.domain.model.NovelNotificationType.HIATUS_RETURN
 import com.into.websoso.ui.novelNotification.novelNotificationTitleRes
+import androidx.compose.ui.Alignment.Companion.Center as CenterAlignment
 
 // 뒤로가기(6 + 44)와 액션 영역을 침범하지 않도록 제목이 쓸 수 있는 좌우 여백
 private val TITLE_HORIZONTAL_MARGIN = 70.dp

--- a/app/src/main/res/layout/activity_notification_setting.xml
+++ b/app/src/main/res/layout/activity_notification_setting.xml
@@ -31,7 +31,6 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginStart="6dp"
-            android:layout_marginTop="2dp"
             android:contentDescription="@null"
             android:padding="10dp"
             android:src="@drawable/btn_setting_back"
@@ -42,8 +41,8 @@
         <TextView
             android:id="@+id/tv_notification_setting_title"
             android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:paddingVertical="20dp"
+            android:layout_height="44dp"
+            android:gravity="center"
             android:text="@string/setting_notification"
             android:textAppearance="@style/title2"
             android:textColor="@color/black"

--- a/build-logic/src/main/kotlin/websoso.android.kotlin.gradle.kts
+++ b/build-logic/src/main/kotlin/websoso.android.kotlin.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 androidExtension.apply {
-    compileSdk = 35
+    compileSdk = 36
 
     defaultConfig {
         minSdk = 30

--- a/core/common/src/main/java/com/into/websoso/core/common/navigator/NavigatorProvider.kt
+++ b/core/common/src/main/java/com/into/websoso/core/common/navigator/NavigatorProvider.kt
@@ -26,6 +26,8 @@ interface NavigatorProvider {
     )
 
     fun navigateToNormalExploreActivity(startActivity: (Intent) -> Unit)
+
+    fun navigateToNotificationSettingActivity(startActivity: (Intent) -> Unit)
 }
 
 @EntryPoint

--- a/core/resource/build.gradle.kts
+++ b/core/resource/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 
 android {
     namespace = "com.into.websoso.core.resource"
-    compileSdk = 35
+    compileSdk = 36
 
     defaultConfig {
         minSdk = 30

--- a/core/resource/src/main/res/drawable/ic_library_notification.xml
+++ b/core/resource/src/main/res/drawable/ic_library_notification.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="12dp"
+    android:height="15dp"
+    android:viewportWidth="12"
+    android:viewportHeight="15">
+  <path
+      android:pathData="M6.75,0.75C6.75,0.336 6.414,0 6,0C5.586,0 5.25,0.336 5.25,0.75V0.803C2.706,1.167 0.75,3.355 0.75,6V10.5C0.336,10.5 0,10.836 0,11.25C0,11.664 0.336,12 0.75,12H1.5H2.25H3C3,13.657 4.343,15 6,15C7.657,15 9,13.657 9,12H9.75H10.5H11.25C11.664,12 12,11.664 12,11.25C12,10.836 11.664,10.5 11.25,10.5V6C11.25,3.355 9.294,1.167 6.75,0.803V0.75ZM6,2.25C3.929,2.25 2.25,3.929 2.25,6V10.5H9.75V6C9.75,3.929 8.071,2.25 6,2.25ZM6,13.5C5.172,13.5 4.5,12.828 4.5,12H7.5C7.5,12.828 6.828,13.5 6,13.5Z"
+      android:fillColor="#C7C7D0"
+      android:fillType="evenOdd"/>
+</vector>

--- a/core/resource/src/main/res/values/strings.xml
+++ b/core/resource/src/main/res/values/strings.xml
@@ -298,8 +298,8 @@
     <string name="notification_setting_description">댓글, 좋아요 등 알림</string>
     <string name="notification_setting_completion_title">완결 알림</string>
     <string name="notification_setting_completion_description">작품이 완결나면 알림을 드려요</string>
-    <string name="notification_setting_hiatus_return_title">휴재 복귀, 외전 알림</string>
-    <string name="notification_setting_hiatus_return_description">휴재가 끝나거나 새로운 회차가 생기면 알림을 드려요</string>
+    <string name="notification_setting_hiatus_return_title">휴재 복귀 알림</string>
+    <string name="notification_setting_hiatus_return_description">새로운 회차가 생기면 알림을 드려요</string>
 
     <!-- 작품 알림 뷰 -->
     <string name="novel_detail_notification_content_description">작품 알림 설정</string>

--- a/feature/library/src/main/java/com/into/websoso/feature/library/LibraryScreen.kt
+++ b/feature/library/src/main/java/com/into/websoso/feature/library/LibraryScreen.kt
@@ -57,6 +57,7 @@ fun LibraryScreen(
     navigateToNormalExploreActivity: () -> Unit,
     navigateToNovelDetailActivity: (novelId: Long) -> Unit,
     libraryViewModel: LibraryViewModel,
+    navigateToNotificationSettingActivity: (() -> Unit)? = null,
 ) {
     val scope = rememberCoroutineScope()
     val uiState by libraryViewModel.uiState.collectAsStateWithLifecycle()
@@ -134,6 +135,7 @@ fun LibraryScreen(
         onItemClick = { navigateToNovelDetailActivity(it.novelId) },
         onSearchClick = navigateToNormalExploreActivity,
         onExploreClick = navigateToNormalExploreActivity,
+        onNotificationManageClick = navigateToNotificationSettingActivity,
         onInterestClick = libraryViewModel::updateInterestedNovels,
         onAttractivePointClick = libraryViewModel::updateAttractivePoints,
         onReadStatusClick = libraryViewModel::updateReadStatus,
@@ -182,6 +184,7 @@ private fun LibraryScreen(
     onKeywordClick: (String) -> Unit,
     onResetClick: () -> Unit,
     onFilterSearchClick: () -> Unit,
+    onNotificationManageClick: (() -> Unit)?,
 ) {
     Column(
         modifier = Modifier
@@ -192,8 +195,6 @@ private fun LibraryScreen(
 
         LibraryTopBar(onSearchClick = onSearchClick)
 
-        Spacer(modifier = Modifier.height(9.dp))
-
         LibraryFilterTopBar(
             libraryFilterUiModel = uiState.libraryFilterUiModel,
             totalCount = uiState.novelTotalCount,
@@ -202,6 +203,7 @@ private fun LibraryScreen(
             onSortClick = onSortClick,
             onToggleViewType = onToggleViewType,
             onInterestClick = onInterestClick,
+            onNotificationManageClick = onNotificationManageClick,
         )
 
         PullToRefreshBox(

--- a/feature/library/src/main/java/com/into/websoso/feature/library/LibraryScreen.kt
+++ b/feature/library/src/main/java/com/into/websoso/feature/library/LibraryScreen.kt
@@ -1,11 +1,14 @@
 package com.into.websoso.feature.library
 
+import android.view.HapticFeedbackConstants
 import android.widget.Toast
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.grid.LazyGridState
 import androidx.compose.foundation.lazy.grid.rememberLazyGridState
@@ -23,6 +26,7 @@ import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.paging.LoadState.Loading
@@ -150,6 +154,19 @@ fun LibraryScreen(
     )
 }
 
+// 당겨서 새로고침은 중첩 스크롤로 동작해 스크롤 가능한 자식이 없으면 제스처가 전달되지 않는다.
+// 빈 화면은 스크롤할 내용이 없으므로 화면 높이만큼 차지하는 항목 하나로 감싸 제스처만 살린다.
+@Composable
+private fun RefreshableContainer(content: @Composable () -> Unit) {
+    LazyColumn(modifier = Modifier.fillMaxSize()) {
+        item {
+            Box(modifier = Modifier.fillParentMaxSize()) {
+                content()
+            }
+        }
+    }
+}
+
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun LibraryScreen(
@@ -186,6 +203,8 @@ private fun LibraryScreen(
     onFilterSearchClick: () -> Unit,
     onNotificationManageClick: (() -> Unit)?,
 ) {
+    val view = LocalView.current
+
     Column(
         modifier = Modifier
             .fillMaxSize()
@@ -208,15 +227,20 @@ private fun LibraryScreen(
 
         PullToRefreshBox(
             isRefreshing = isNovelsRefreshing,
-            onRefresh = novels::refresh,
+            onRefresh = {
+                view.performHapticFeedback(HapticFeedbackConstants.CONFIRM)
+                novels.refresh()
+            },
         ) {
             when {
                 novels.itemCount == 0 &&
                     novels.loadState.refresh !is Loading -> {
-                    if (uiState.libraryFilterUiModel.isFilterApplied) {
-                        LibraryFilterEmptyView()
-                    } else {
-                        LibraryEmptyView(onExploreClick = onExploreClick)
+                    RefreshableContainer {
+                        if (uiState.libraryFilterUiModel.isFilterApplied) {
+                            LibraryFilterEmptyView()
+                        } else {
+                            LibraryEmptyView(onExploreClick = onExploreClick)
+                        }
                     }
                 }
 

--- a/feature/library/src/main/java/com/into/websoso/feature/library/component/LibraryGridList.kt
+++ b/feature/library/src/main/java/com/into/websoso/feature/library/component/LibraryGridList.kt
@@ -27,7 +27,7 @@ internal fun LibraryGridList(
         columns = GridCells.Fixed(3),
         state = gridState,
         modifier = modifier.fillMaxSize(),
-        contentPadding = PaddingValues(horizontal = 20.dp),
+        contentPadding = PaddingValues(start = 20.dp, top = 16.dp, end = 20.dp, bottom = 20.dp),
         horizontalArrangement = Arrangement.spacedBy(6.dp),
         verticalArrangement = Arrangement.spacedBy(18.dp),
     ) {

--- a/feature/library/src/main/java/com/into/websoso/feature/library/component/LibraryGridListItem.kt
+++ b/feature/library/src/main/java/com/into/websoso/feature/library/component/LibraryGridListItem.kt
@@ -67,24 +67,29 @@ internal fun NovelGridListItem(
             size = itemSize,
         )
 
-        Text(
-            text = item.title,
-            style = WebsosoTheme.typography.body4,
-            color = Black,
-            maxLines = 2,
-            overflow = TextOverflow.Ellipsis,
-        )
-
-        if (item.ratingStars.isNotEmpty()) {
-            NovelRatingStar(stars = item.ratingStars)
-        }
-
-        item.formattedDateRange?.let {
+        Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
             Text(
-                text = it,
-                style = WebsosoTheme.typography.label2,
-                color = Gray200,
+                text = item.title,
+                style = WebsosoTheme.typography.body4,
+                color = Black,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis,
             )
+
+            if (item.ratingStars.isNotEmpty()) {
+                NovelRatingStar(
+                    stars = item.ratingStars,
+                    modifier = Modifier.padding(bottom = 4.dp),
+                )
+            }
+
+            item.formattedDateRange?.let {
+                Text(
+                    text = it,
+                    style = WebsosoTheme.typography.label2,
+                    color = Gray200,
+                )
+            }
         }
     }
 }
@@ -120,9 +125,9 @@ private fun NovelGridThumbnail(
                 imageVector = ImageVector.vectorResource(id = ic_library_interesting),
                 contentDescription = null,
                 modifier = Modifier
-                    .size(30.dp)
                     .align(Alignment.BottomEnd)
-                    .padding(6.dp),
+                    .padding(10.dp)
+                    .size(13.dp),
             )
         }
     }
@@ -181,7 +186,7 @@ internal fun NovelRatingStar(
             Image(
                 imageVector = ratingStarIcon(starType),
                 contentDescription = null,
-                modifier = Modifier.size(14.dp),
+                modifier = Modifier.size(9.dp),
             )
         }
     }

--- a/feature/library/src/main/java/com/into/websoso/feature/library/component/LibraryList.kt
+++ b/feature/library/src/main/java/com/into/websoso/feature/library/component/LibraryList.kt
@@ -21,7 +21,7 @@ internal fun LibraryList(
     LazyColumn(
         modifier = modifier.fillMaxSize(),
         state = listState,
-        contentPadding = PaddingValues(start = 20.dp, bottom = 20.dp),
+        contentPadding = PaddingValues(start = 20.dp, top = 16.dp, bottom = 20.dp),
         verticalArrangement = Arrangement.spacedBy(28.dp),
     ) {
         items(novels.itemCount) { index ->

--- a/feature/library/src/main/java/com/into/websoso/feature/library/component/LibraryListItem.kt
+++ b/feature/library/src/main/java/com/into/websoso/feature/library/component/LibraryListItem.kt
@@ -7,7 +7,6 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -16,6 +15,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
@@ -63,6 +63,8 @@ import com.into.websoso.feature.library.model.ReadStatusUiModel
 private const val THUMBNAIL_WIDTH_RATIO = 60f / 360f
 private const val THUMBNAIL_HEIGHT_RATIO = 80f / 360f
 private const val FEED_CARD_WIDTH_RATIO = 0.8611f
+private val CONTENT_SPACING = 16.dp
+private val ATTRACTIVE_POINT_ROW_HEIGHT = 23.dp
 
 @Composable
 internal fun LibraryListItem(
@@ -74,19 +76,25 @@ internal fun LibraryListItem(
         modifier = modifier
             .fillMaxWidth()
             .debouncedClickable { onClick() },
-        verticalArrangement = Arrangement.spacedBy(8.dp),
+        verticalArrangement = Arrangement.spacedBy(6.dp),
     ) {
+        NovelStatusHeader(
+            readStatus = item.readStatus,
+            formattedDateRange = item.formattedDateRange,
+        )
+
         Row(
-            horizontalArrangement = Arrangement.spacedBy(16.dp),
+            horizontalArrangement = Arrangement.spacedBy(CONTENT_SPACING),
+            verticalAlignment = Alignment.CenterVertically,
         ) {
             NovelThumbnail(
                 thumbnailUrl = item.novelImage,
-                readStatus = item.readStatus,
                 isInteresting = item.isInterest,
             )
 
             NovelInfo(
                 item = item,
+                modifier = Modifier.weight(1f),
             )
         }
 
@@ -102,7 +110,7 @@ internal fun LibraryListItem(
             }
 
         HorizontalDivider(
-            modifier = Modifier.padding(top = 16.dp),
+            modifier = Modifier.padding(top = 10.dp),
             thickness = 1.dp,
             color = Gray50,
         )
@@ -110,43 +118,61 @@ internal fun LibraryListItem(
 }
 
 @Composable
-private fun NovelThumbnail(
-    thumbnailUrl: String,
+private fun NovelStatusHeader(
     readStatus: ReadStatusUiModel?,
-    isInteresting: Boolean,
+    formattedDateRange: String?,
 ) {
+    if (readStatus == null && formattedDateRange == null) return
+
     val size = calculateThumbnailSize()
 
-    Column(modifier = Modifier.width(size.width)) {
+    Row(
+        horizontalArrangement = Arrangement.spacedBy(CONTENT_SPACING),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
         ReadStatusBadge(
             readStatusUiModel = readStatus,
             width = size.width,
         )
 
-        Spacer(modifier = Modifier.height(6.dp))
-
-        Box(
-            modifier = Modifier
-                .size(width = size.width, height = size.height)
-                .clip(RoundedCornerShape(8.dp)),
-        ) {
-            AsyncImage(
-                model = thumbnailUrl,
-                contentDescription = null,
-                contentScale = ContentScale.Crop,
-                modifier = Modifier.fillMaxSize(),
+        formattedDateRange?.let {
+            Text(
+                text = it,
+                style = WebsosoTheme.typography.body5,
+                color = Gray300,
             )
+        }
+    }
+}
 
-            if (isInteresting) {
-                Image(
-                    imageVector = ImageVector.vectorResource(id = ic_library_interesting),
-                    contentDescription = null,
-                    modifier = Modifier
-                        .align(Alignment.BottomEnd)
-                        .padding(4.dp)
-                        .size(16.dp),
-                )
-            }
+@Composable
+private fun NovelThumbnail(
+    thumbnailUrl: String,
+    isInteresting: Boolean,
+) {
+    val size = calculateThumbnailSize()
+
+    Box(
+        modifier = Modifier
+            .size(width = size.width, height = size.height)
+            .clip(RoundedCornerShape(8.dp)),
+    ) {
+        AsyncImage(
+            model = thumbnailUrl,
+            contentDescription = null,
+            contentScale = ContentScale.Crop,
+            modifier = Modifier.fillMaxSize(),
+        )
+
+        if (isInteresting) {
+            Image(
+                imageVector = ImageVector.vectorResource(id = ic_library_interesting),
+                contentDescription = null,
+                modifier = Modifier
+                    .align(Alignment.BottomEnd)
+                    .padding(10.dp)
+                    .size(13.dp),
+            )
         }
     }
 }
@@ -156,24 +182,26 @@ private fun ReadStatusBadge(
     readStatusUiModel: ReadStatusUiModel?,
     width: Dp,
 ) {
-    readStatusUiModel?.let {
-        Box(
-            modifier = Modifier
-                .width(width)
-                .background(
-                    color = it.backgroundColor,
-                    shape = RoundedCornerShape(8.dp),
-                ).padding(vertical = 4.dp),
-            contentAlignment = Alignment.Center,
-        ) {
-            Text(
-                text = it.readStatus.label,
-                color = White,
-                style = WebsosoTheme.typography.label2,
-                softWrap = false,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
-            )
+    Box(modifier = Modifier.width(width)) {
+        readStatusUiModel?.let {
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .background(
+                        color = it.backgroundColor,
+                        shape = RoundedCornerShape(8.dp),
+                    ).padding(horizontal = 6.dp, vertical = 4.dp),
+                contentAlignment = Alignment.Center,
+            ) {
+                Text(
+                    text = it.readStatus.label,
+                    color = White,
+                    style = WebsosoTheme.typography.label2,
+                    softWrap = false,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
         }
     }
 }
@@ -188,68 +216,30 @@ private fun calculateThumbnailSize(): ThumbnailUiSize {
 }
 
 @Composable
-private fun NovelInfo(item: NovelUiModel) {
-    Column {
-        Spacer(modifier = Modifier.height(2.dp))
-        NovelInfoDate(item = item)
-        Spacer(modifier = Modifier.height(4.dp))
-        NovelInfoContent(
-            title = item.title,
-            myRating = item.userNovelRating,
-            totalRating = item.novelRating,
-            attractivePoints = item.attractivePoints,
-        )
-    }
-}
-
-@Composable
-private fun NovelInfoDate(item: NovelUiModel) {
-    Box(modifier = Modifier.height(18.dp)) {
-        item.formattedDateRange?.let {
+private fun NovelInfo(
+    item: NovelUiModel,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier,
+        verticalArrangement = Arrangement.spacedBy(6.dp),
+    ) {
+        Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
             Text(
-                text = it,
-                style = WebsosoTheme.typography.body5,
-                color = Gray300,
+                text = item.title,
+                style = WebsosoTheme.typography.title2,
+                color = Black,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+
+            NovelRatings(
+                myRating = item.userNovelRating,
+                totalRating = item.novelRating,
             )
         }
-    }
-}
 
-@Composable
-private fun NovelInfoContent(
-    title: String,
-    myRating: NovelRating?,
-    totalRating: Float,
-    attractivePoints: AttractivePoints,
-) {
-    val size = calculateThumbnailSize()
-
-    Column(
-        modifier = Modifier.height(size.height),
-        verticalArrangement = Arrangement.Center,
-    ) {
-        Text(
-            text = title,
-            style = WebsosoTheme.typography.title2,
-            color = Black,
-            maxLines = 1,
-            overflow = TextOverflow.Ellipsis,
-        )
-
-        Spacer(modifier = Modifier.height(4.dp))
-
-        NovelRatings(
-            myRating = myRating,
-            totalRating = totalRating,
-        )
-
-        Spacer(modifier = Modifier.height(10.dp))
-
-        if (attractivePoints.value.isNotEmpty()) {
-            AttractivePointTags(attractivePoints = attractivePoints)
-        } else {
-            Box(modifier = Modifier.height(18.dp))
-        }
+        AttractivePointTags(attractivePoints = item.attractivePoints)
     }
 }
 
@@ -258,74 +248,102 @@ private fun NovelRatings(
     myRating: NovelRating?,
     totalRating: Float,
 ) {
-    Row(verticalAlignment = Alignment.CenterVertically) {
-        myRating?.let {
-            MyRatingSection(rating = it.rating.value)
-            Spacer(modifier = Modifier.width(10.dp))
-        }
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(7.dp),
+    ) {
+        myRating?.let { MyRatingSection(rating = it.rating.value) }
+
         TotalRatingSection(rating = totalRating)
     }
 }
 
 @Composable
 private fun MyRatingSection(rating: Float) {
-    Image(
-        imageVector = ImageVector.vectorResource(id = ic_storage_star),
-        contentDescription = null,
-        modifier = Modifier.size(10.dp),
-    )
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(5.dp),
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(2.dp),
+        ) {
+            Box(
+                modifier = Modifier.size(12.dp),
+                contentAlignment = Alignment.Center,
+            ) {
+                Image(
+                    imageVector = ImageVector.vectorResource(id = ic_storage_star),
+                    contentDescription = null,
+                    modifier = Modifier.size(9.dp),
+                )
+            }
 
-    Spacer(modifier = Modifier.width(2.dp))
+            Text(
+                text = "$rating",
+                style = WebsosoTheme.typography.body5Secondary,
+                color = Secondary100,
+            )
+        }
 
-    Text(
-        text = "$rating",
-        style = WebsosoTheme.typography.body5Secondary,
-        color = Secondary100,
-    )
-
-    Spacer(modifier = Modifier.width(4.dp))
-
-    Text(
-        text = "내 별점",
-        style = WebsosoTheme.typography.body5,
-        color = Gray300,
-    )
+        Text(
+            text = "내 별점",
+            style = WebsosoTheme.typography.body5,
+            color = Gray300,
+        )
+    }
 }
 
 @Composable
 private fun TotalRatingSection(rating: Float) {
-    Icon(
-        imageVector = ImageVector.vectorResource(id = ic_storage_star),
-        contentDescription = null,
-        modifier = Modifier.size(10.dp),
-        tint = Gray200,
-    )
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(5.dp),
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(4.dp),
+        ) {
+            Icon(
+                imageVector = ImageVector.vectorResource(id = ic_storage_star),
+                contentDescription = null,
+                modifier = Modifier.size(12.dp),
+                tint = Gray200,
+            )
 
-    Spacer(modifier = Modifier.width(2.dp))
+            Text(
+                text = "$rating",
+                style = WebsosoTheme.typography.body5,
+                color = Gray200,
+            )
+        }
 
-    Text(
-        text = "$rating 전체 별점",
-        style = WebsosoTheme.typography.body5,
-        color = Gray200,
-    )
+        Text(
+            text = "전체 별점",
+            style = WebsosoTheme.typography.body5,
+            color = Gray200,
+        )
+    }
 }
 
 @Composable
 private fun AttractivePointTags(attractivePoints: AttractivePoints) {
-    Row(verticalAlignment = Alignment.CenterVertically) {
-        attractivePoints.selectedAttractivePoints.forEachIndexed { index, attractivePoint ->
+    val selectedAttractivePoints = attractivePoints.selectedAttractivePoints
+
+    Row(
+        modifier = Modifier.height(ATTRACTIVE_POINT_ROW_HEIGHT),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        selectedAttractivePoints.forEachIndexed { index, attractivePoint ->
             AttractivePointItem(attractivePoint)
 
-            if (index < attractivePoints.selectedAttractivePoints.lastIndex) {
-                Spacer(modifier = Modifier.width(6.dp))
-
-                Text(
-                    text = "•",
-                    style = WebsosoTheme.typography.body4,
-                    color = Primary100,
+            if (index < selectedAttractivePoints.lastIndex) {
+                Box(
+                    modifier = Modifier
+                        .size(2.dp)
+                        .background(color = Primary100, shape = CircleShape),
                 )
-
-                Spacer(modifier = Modifier.width(6.dp))
             }
         }
     }
@@ -333,18 +351,19 @@ private fun AttractivePointTags(attractivePoints: AttractivePoints) {
 
 @Composable
 private fun AttractivePointItem(attractivePoint: AttractivePoint) {
-    Row(verticalAlignment = Alignment.CenterVertically) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(3.dp),
+    ) {
         Image(
             imageVector = attractivePointIcon(attractivePoint),
             contentDescription = attractivePoint.label,
-            modifier = Modifier.size(16.dp),
+            modifier = Modifier.size(12.dp),
         )
-
-        Spacer(modifier = Modifier.width(4.dp))
 
         Text(
             text = attractivePoint.label,
-            style = WebsosoTheme.typography.body4,
+            style = WebsosoTheme.typography.body5,
             color = Gray300,
         )
     }
@@ -382,8 +401,8 @@ private fun NovelKeywordChip(keyword: String) {
         style = WebsosoTheme.typography.body5,
         color = Gray200,
         modifier = Modifier
-            .background(color = Primary20, shape = RoundedCornerShape(6.dp))
-            .padding(horizontal = 8.dp, vertical = 3.dp),
+            .background(color = Primary20, shape = RoundedCornerShape(20.dp))
+            .padding(horizontal = 8.dp, vertical = 6.dp),
     )
 }
 

--- a/feature/library/src/main/java/com/into/websoso/feature/library/component/LibrayFilterTopBar.kt
+++ b/feature/library/src/main/java/com/into/websoso/feature/library/component/LibrayFilterTopBar.kt
@@ -152,11 +152,15 @@ private fun RowScope.LibraryViewTypeToggleButton(
     onClick: () -> Unit,
 ) {
     val selectedModifier = when (isSelected) {
-        true -> Modifier
-            .shadow(elevation = 2.dp, shape = VIEW_TYPE_TOGGLE_BUTTON_SHAPE)
-            .background(color = White, shape = VIEW_TYPE_TOGGLE_BUTTON_SHAPE)
+        true -> {
+            Modifier
+                .shadow(elevation = 2.dp, shape = VIEW_TYPE_TOGGLE_BUTTON_SHAPE)
+                .background(color = White, shape = VIEW_TYPE_TOGGLE_BUTTON_SHAPE)
+        }
 
-        false -> Modifier
+        false -> {
+            Modifier
+        }
     }
 
     Box(

--- a/feature/library/src/main/java/com/into/websoso/feature/library/component/LibrayFilterTopBar.kt
+++ b/feature/library/src/main/java/com/into/websoso/feature/library/component/LibrayFilterTopBar.kt
@@ -1,16 +1,19 @@
 package com.into.websoso.feature.library.component
 
+import androidx.annotation.DrawableRes
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.defaultMinSize
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -18,31 +21,41 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.IconButton
+import androidx.compose.material3.Icon
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.into.websoso.core.common.extensions.debouncedClickable
+import com.into.websoso.core.common.extensions.debouncedSelectable
 import com.into.websoso.core.designsystem.theme.Black
+import com.into.websoso.core.designsystem.theme.Gray100
+import com.into.websoso.core.designsystem.theme.Gray20
 import com.into.websoso.core.designsystem.theme.Gray200
 import com.into.websoso.core.designsystem.theme.Gray300
 import com.into.websoso.core.designsystem.theme.Gray50
-import com.into.websoso.core.designsystem.theme.Gray70
+import com.into.websoso.core.designsystem.theme.Gray70New
+import com.into.websoso.core.designsystem.theme.Gray80
 import com.into.websoso.core.designsystem.theme.WebsosoTheme
 import com.into.websoso.core.designsystem.theme.White
 import com.into.websoso.core.resource.R.drawable.ic_library_drop_down_fill
 import com.into.websoso.core.resource.R.drawable.ic_library_grid
 import com.into.websoso.core.resource.R.drawable.ic_library_list
+import com.into.websoso.core.resource.R.drawable.ic_library_notification
 import com.into.websoso.core.resource.R.drawable.ic_library_sort
 import com.into.websoso.domain.library.model.SortCriteria
 import com.into.websoso.feature.library.filter.LibraryFilterTab
 import com.into.websoso.feature.library.model.LibraryFilterUiModel
+
+private val VIEW_TYPE_TOGGLE_SHAPE = RoundedCornerShape(16.dp)
+private val VIEW_TYPE_TOGGLE_BUTTON_SHAPE = RoundedCornerShape(13.dp)
 
 @Composable
 internal fun LibraryFilterTopBar(
@@ -54,33 +67,42 @@ internal fun LibraryFilterTopBar(
     onToggleViewType: () -> Unit,
     onInterestClick: () -> Unit,
     modifier: Modifier = Modifier,
+    onNotificationManageClick: (() -> Unit)? = null,
 ) {
     Column(
         modifier = modifier.fillMaxWidth(),
     ) {
-        Column(
+        Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(start = 20.dp),
+                .padding(start = 20.dp)
+                .padding(vertical = 9.dp),
+            verticalAlignment = Alignment.CenterVertically,
         ) {
+            LibraryViewTypeToggle(
+                isGrid = isGrid,
+                onToggleViewType = onToggleViewType,
+            )
+
+            Spacer(modifier = Modifier.width(12.dp))
+
+            VerticalDivider(height = 29.dp)
+
+            Spacer(modifier = Modifier.width(10.dp))
+
             NovelFilterChipSection(
                 libraryFilterUiModel = libraryFilterUiModel,
                 onFilterClick = onFilterClick,
                 onInterestClick = onInterestClick,
             )
-
-            Spacer(modifier = Modifier.height(10.dp))
-
-            NovelFilterStatusBar(
-                totalCount = totalCount,
-                sortCriteria = libraryFilterUiModel.sortCriteria,
-                isGrid = isGrid,
-                onSortClick = onSortClick,
-                onToggleViewType = onToggleViewType,
-            )
         }
 
-        Spacer(modifier = Modifier.height(10.dp))
+        NovelFilterStatusBar(
+            totalCount = totalCount,
+            sortCriteria = libraryFilterUiModel.sortCriteria,
+            onSortClick = onSortClick,
+            onNotificationManageClick = onNotificationManageClick,
+        )
 
         Box(
             modifier = Modifier
@@ -89,6 +111,83 @@ internal fun LibraryFilterTopBar(
                 .background(color = Gray50),
         )
     }
+}
+
+@Composable
+private fun LibraryViewTypeToggle(
+    isGrid: Boolean,
+    onToggleViewType: () -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .width(70.dp)
+            .height(33.dp)
+            .background(color = Gray20, shape = VIEW_TYPE_TOGGLE_SHAPE)
+            .border(width = 1.dp, color = Gray70New, shape = VIEW_TYPE_TOGGLE_SHAPE)
+            .padding(3.dp),
+        horizontalArrangement = Arrangement.spacedBy(2.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        LibraryViewTypeToggleButton(
+            iconRes = ic_library_grid,
+            iconSize = 12.dp,
+            isSelected = isGrid,
+            onClick = { if (!isGrid) onToggleViewType() },
+        )
+
+        LibraryViewTypeToggleButton(
+            iconRes = ic_library_list,
+            iconSize = 13.dp,
+            isSelected = isGrid.not(),
+            onClick = { if (isGrid) onToggleViewType() },
+        )
+    }
+}
+
+@Composable
+private fun RowScope.LibraryViewTypeToggleButton(
+    @DrawableRes iconRes: Int,
+    iconSize: Dp,
+    isSelected: Boolean,
+    onClick: () -> Unit,
+) {
+    val selectedModifier = when (isSelected) {
+        true -> Modifier
+            .shadow(elevation = 2.dp, shape = VIEW_TYPE_TOGGLE_BUTTON_SHAPE)
+            .background(color = White, shape = VIEW_TYPE_TOGGLE_BUTTON_SHAPE)
+
+        false -> Modifier
+    }
+
+    Box(
+        modifier = Modifier
+            .weight(1f)
+            .fillMaxHeight()
+            .then(selectedModifier)
+            .clip(VIEW_TYPE_TOGGLE_BUTTON_SHAPE)
+            .debouncedSelectable(selected = isSelected, onClick = onClick),
+        contentAlignment = Alignment.Center,
+    ) {
+        Icon(
+            imageVector = ImageVector.vectorResource(id = iconRes),
+            contentDescription = null,
+            tint = if (isSelected) Black else Gray100,
+            modifier = Modifier.size(iconSize),
+        )
+    }
+}
+
+@Composable
+private fun VerticalDivider(
+    height: Dp,
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        modifier = modifier
+            .width(1.dp)
+            .height(height)
+            .background(color = Gray80),
+    )
 }
 
 @Composable
@@ -101,21 +200,13 @@ private fun NovelFilterChipSection(
         modifier = Modifier
             .horizontalScroll(rememberScrollState())
             .padding(end = 20.dp),
-        horizontalArrangement = Arrangement.spacedBy(6.dp),
+        horizontalArrangement = Arrangement.spacedBy(2.dp),
     ) {
         NovelFilterChip(
             text = "관심",
             isSelected = libraryFilterUiModel.isInterested,
             onClick = onInterestClick,
             showDropdownIcon = false,
-        )
-
-        Box(
-            modifier = Modifier
-                .padding(horizontal = 4.dp)
-                .width(1.dp)
-                .height(32.dp)
-                .background(color = Gray70),
         )
 
         NovelFilterChip(
@@ -168,15 +259,15 @@ private fun NovelFilterChip(
 
     Surface(
         color = backgroundColor,
-        shape = RoundedCornerShape(20.dp),
+        shape = RoundedCornerShape(18.dp),
         modifier = Modifier
-            .defaultMinSize(minHeight = 32.dp)
+            .defaultMinSize(minHeight = 33.dp)
             .debouncedClickable(onClick = onClick),
-        border = if (!isSelected) BorderStroke(1.dp, Gray70) else null,
+        border = if (!isSelected) BorderStroke(1.dp, Gray80) else null,
     ) {
         Row(
             verticalAlignment = Alignment.CenterVertically,
-            modifier = Modifier.padding(horizontal = 9.5.dp, vertical = 6.5.dp),
+            modifier = Modifier.padding(horizontal = 10.dp, vertical = 7.dp),
         ) {
             Text(
                 text = text,
@@ -188,8 +279,8 @@ private fun NovelFilterChip(
                     imageVector = ImageVector.vectorResource(id = ic_library_drop_down_fill),
                     contentDescription = null,
                     modifier = Modifier
-                        .padding(start = 4.dp)
-                        .size(12.dp),
+                        .padding(start = 2.dp)
+                        .size(14.dp),
                 )
             }
         }
@@ -200,14 +291,14 @@ private fun NovelFilterChip(
 private fun NovelFilterStatusBar(
     totalCount: Long,
     sortCriteria: SortCriteria,
-    isGrid: Boolean,
     onSortClick: () -> Unit,
-    onToggleViewType: () -> Unit,
+    onNotificationManageClick: (() -> Unit)?,
 ) {
     Row(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(end = 8.dp),
+            .padding(horizontal = 20.dp)
+            .padding(vertical = 4.dp),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.SpaceBetween,
     ) {
@@ -217,57 +308,55 @@ private fun NovelFilterStatusBar(
             color = Gray200,
         )
 
-        Row(verticalAlignment = Alignment.CenterVertically) {
-            SortTypeSelector(
-                sortCriteria = sortCriteria,
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(10.dp),
+        ) {
+            onNotificationManageClick?.let { onClick ->
+                StatusBarAction(
+                    iconRes = ic_library_notification,
+                    iconSize = 12.dp,
+                    text = "알림 관리",
+                    onClick = onClick,
+                )
+
+                VerticalDivider(height = 8.dp)
+            }
+
+            StatusBarAction(
+                iconRes = ic_library_sort,
+                iconSize = 16.dp,
+                text = sortCriteria.label,
                 onClick = onSortClick,
             )
-
-            Box(
-                modifier = Modifier
-                    .height(12.dp)
-                    .width(1.dp)
-                    .background(color = Gray70),
-            )
-
-            IconButton(onClick = onToggleViewType) {
-                Image(
-                    imageVector = ImageVector.vectorResource(
-                        id = if (isGrid) ic_library_grid else ic_library_list,
-                    ),
-                    contentDescription = null,
-                    modifier = Modifier.size(18.dp),
-                )
-            }
         }
     }
 }
 
 @Composable
-private fun SortTypeSelector(
-    sortCriteria: SortCriteria,
+private fun StatusBarAction(
+    @DrawableRes iconRes: Int,
+    iconSize: Dp,
+    text: String,
     onClick: () -> Unit,
-    modifier: Modifier = Modifier,
 ) {
-    TextButton(
-        onClick = onClick,
-        modifier = modifier,
-        contentPadding = PaddingValues(horizontal = 8.dp, vertical = 4.dp),
+    Row(
+        modifier = Modifier
+            .debouncedClickable(onClick = onClick)
+            .padding(vertical = 6.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(4.dp),
     ) {
-        Row(verticalAlignment = Alignment.CenterVertically) {
-            Image(
-                imageVector = ImageVector.vectorResource(id = ic_library_sort),
-                contentDescription = null,
-                modifier = Modifier.size(16.dp),
-            )
+        Image(
+            imageVector = ImageVector.vectorResource(id = iconRes),
+            contentDescription = null,
+            modifier = Modifier.size(iconSize),
+        )
 
-            Spacer(modifier = Modifier.width(4.dp))
-
-            Text(
-                text = sortCriteria.label,
-                style = WebsosoTheme.typography.body4,
-                color = Gray300,
-            )
-        }
+        Text(
+            text = text,
+            style = WebsosoTheme.typography.body3,
+            color = Gray300,
+        )
     }
 }


### PR DESCRIPTION
## 📌𝘐𝘴𝘴𝘶𝘦𝘴
- closed #964

## 📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯

**서재 상단 필터 바**
- 보기 방식 토글을 개수 줄 오른쪽에서 필터 칩 줄 맨 왼쪽으로 이동. 현재 모드 아이콘 하나만 보여주던 버튼을 그리드/리스트가 항상 보이는 세그먼트 컨트롤로 교체
- 개수 줄에 `알림 관리` 진입점 추가. 설정 > 알림 설정으로 이동
- 구분선을 `관심`과 `읽기상태` 사이에서 토글과 `관심` 사이로 이동
- 칩 간격·모서리·테두리 색, 개수 줄 타이포를 시안 값으로 정정

**서재 목록/그리드 아이템**
- 리스트 아이템의 읽기상태 배지와 날짜를 하나의 헤더 줄로 묶고, 둘 다 없는 작품은 줄 자체를 감춤. 기존에는 날짜 자리에 높이 18의 빈 박스가 항상 남아 있었음
- 별점·매력포인트 아이콘 크기와 각 영역 간격을 시안 값으로 정정
- 매력포인트 구분자를 텍스트 가운뎃점에서 2dp 원형 점으로 교체
- 키워드 칩 모서리와 세로 여백 정정
- 그리드 아이템은 표지와 정보 블록 사이만 간격 6을 유지하고 내부는 2로 조정
- 구분선과 첫 작품 줄 사이에 빠져 있던 여백 16 추가

**서재 당겨서 새로고침**
- 새로고침 시작 시 `CONFIRM` 햅틱 추가. 피드와 같은 방식
- 빈 화면에서도 당겨서 새로고침이 되도록 수정. 당겨서 새로고침은 중첩 스크롤로 동작해 스크롤 가능한 자식이 없으면 제스처가 전달되지 않는데, 빈 화면은 스크롤할 내용이 없어 반응하지 않았음. 화면 높이만큼 차지하는 항목 하나짜리 목록으로 감싸 기존 배치를 유지한 채 제스처만 살림

**알림 설정**
- `휴재 복귀, 외전 알림` → `휴재 복귀 알림`
- `휴재가 끝나거나 새로운 회차가 생기면 알림을 드려요` → `새로운 회차가 생기면 알림을 드려요`
- 상단바 높이를 시안의 44로 맞춤 (기존 62). 제목의 세로 여백 20을 걷어내고 높이를 고정

**완결/휴재 복귀 알림 목록**
- 상단바 제목이 화면 중앙에서 벗어나던 문제 수정. 뒤로가기와 편집 버튼을 제외한 공간 안에서 정렬하고 시작 여백 24까지 더해져 편집 버튼이 없을 때 약 27, 있을 때 약 11만큼 오른쪽으로 밀려 있었고 편집 모드 전환 시 제목이 좌우로 움직였음. 겹침 배치로 바꿔 버튼 유무와 무관하게 중앙 고정
- 빈 화면 블록의 상하 여백 비율을 시안에 맞춤

**빌드**
- `targetSdk` 35 -> 36. targetSdk는 compileSdk보다 높을 수 없어 `compileSdk`도 함께 36으로 상향했습니다. compileSdk는 공통 컨벤션 플러그인과 `core:resource` 두 곳에 선언돼 있어 둘 다 수정했습니다

## 📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵

**서재 상단 필터 바 · 목록/그리드 아이템**

| 그리드 | 리스트 |
|:-:|:-:|
| <img width="270" alt="01_library_grid" src="https://github.com/user-attachments/assets/6fa9cbd9-fe74-4539-a828-a016da5f5c6d" /> | <img width="270" alt="02_library_list" src="https://github.com/user-attachments/assets/0dc225bc-d0a7-4d3a-b982-565e1449d30a" /> |

**서재 당겨서 새로고침**

| 빈 화면 | 빈 화면에서 당겨서 새로고침 |
|:-:|:-:|
| <img width="270" alt="03_library_empty" src="https://github.com/user-attachments/assets/789eba06-3391-45b1-871d-061e7962cc8d" /> | <img width="270" alt="04_library_empty_refresh" src="https://github.com/user-attachments/assets/09fb4482-3229-4c60-94b2-51a9345dfb0e" /> |

**알림 설정**

| 알림 설정 |
|:-:|
| <img width="270" alt="05_notification_setting" src="https://github.com/user-attachments/assets/81129a86-ac48-4885-a13f-0024b9702fc8" /> |

**완결/휴재 복귀 알림 목록**

| 완결 알림 빈 화면 | 휴재 복귀 알림 빈 화면 |
|:-:|:-:|
| <img width="270" alt="06_notification_list" src="https://github.com/user-attachments/assets/0921fcb4-72a0-495e-bc41-8607705eb4ed" /> | <img width="270" alt="07_hiatus_list" src="https://github.com/user-attachments/assets/6a214684-4344-47e4-9b38-67fe1791e3bc" /> |

| 목록 (편집 버튼 있음) | 편집 모드 |
|:-:|:-:|
| <img width="270" alt="08_notification_list_items" src="https://github.com/user-attachments/assets/fea13683-889a-48b6-915a-8d875a669890" /> | <img width="270" alt="09_notification_list_edit" src="https://github.com/user-attachments/assets/db12c930-cf1f-4701-b8a9-f00a2bcb34fa" /> |

## 💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴

확인 부탁드리고 싶은 점이 세 가지 있습니다.

1. 보기 방식 토글의 트랙 배경(`#F7F7F9`), 테두리(`#ECECF1`), 선택 아이콘(`#26262B`)이 시안에서 디자인 토큰이 아닌 생 hex로 잡혀 있습니다. 기존 디자인 시스템 색상은 건드리지 않고 컴포넌트에 시안 hex 값을 그대로 넣었는데, 토큰으로 정리가 필요한지 확인 부탁드립니다.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 서재에서 알림 설정 화면으로 이동할 수 있습니다.
  * 서재 상단에 목록 보기 전환과 알림 관리 기능이 제공됩니다.
  * 서재 새로고침 시 햅틱 피드백이 지원됩니다.

* **개선 사항**
  * 서재 목록과 카드의 간격, 아이콘, 평점 및 상태 표시가 개선되었습니다.
  * 빈 화면에서 당겨서 새로고침 동작이 더 자연스럽게 작동합니다.
  * 알림 목록 제목이 화면 중앙에 표시되고 긴 제목은 말줄임 처리됩니다.
  * 알림 설정 안내 문구가 새 회차 알림 중심으로 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->